### PR TITLE
To modify the "1" matched in the regular expression to match all inte…

### DIFF
--- a/packages/postcss/src/plugins/post.ts
+++ b/packages/postcss/src/plugins/post.ts
@@ -49,7 +49,7 @@ const postcssWeappTailwindcssPostPlugin: PostcssWeappTailwindcssRenamePlugin = (
        * @description 移除 calc(infinity * 1px)
        * https://github.com/tailwindlabs/tailwindcss/blob/77b3cb5318840925d8a75a11cc90552a93507ddc/packages/tailwindcss/src/utilities.ts#L2128
        */
-      else if (/calc\(\s*infinity\s*\*\s*1r?px/.test(decl.value)) {
+      else if (/calc\(\s*infinity\s*\*\s*(\d+\.?\d*|\.\d+)r?px/.test(decl.value)) {
         decl.value = '9999px'
       }
     }


### PR DESCRIPTION
To modify the "1" matched in the regular expression to match all integers and decimals in Infinite issue #695 

The original regex is designed to match patterns like calc(infinity * 1px) or calc(infinity * 1rpx). 

When using a custom design width (e.g., 390 design units), Taro automatically calculates the ratio relative to the standard mini-program design width of 750. This results in formats like calc(infinite * 1.91rpx). However, the original regular expression can only handle scenarios with the 750 design width, causing the rounded-full replacement to fail. 

It is now proposed to modify the regex to match all numeric cases, thereby expanding the range of applicable scenarios.
* `(\d+\.?\d*|\.\d+)` is used to match integers or decimals:
* `\d+\.?\d*` : Matches integers with one or more digits, which can be followed by a decimal point and zero or more decimal digits (e.g., 1, 1., 1.2).
* `|\.\d+` : Alternatively, matches pure decimals starting with a decimal point (e.g., .5).

This regular expression can match the following formats:
* `calc(infinity * 5px)`
* `calc(infinity * 3.14rpx)`
* `calc(infinity * .6px)`
* `calc(infinity * 100.px)`

## Sourcery 摘要

增强：
- 更新正则表达式以使用 (\d+\.?\d*|\.\d+) 来匹配 calc(infinity * …px/rpx) 中的所有整数和十进制值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update regex to use (\d+\.?\d*|\.\d+) for matching all integer and decimal values in calc(infinity * …px/rpx).

</details>