### PR TITLE
fix(tailwindcss-v4 compat): 修复空变量回退的空格处理逻辑 Fixes #909

### DIFF
--- a/packages/postcss/src/compat/tailwindcss-v4.ts
+++ b/packages/postcss/src/compat/tailwindcss-v4.ts
@@ -204,15 +204,28 @@ function normalizeTailwindcssV4EmptyVarFallback(value: string) {
     if (
       firstArg?.type !== 'word'
       || !firstArg.value.startsWith('--tw-')
-      || lastArg?.type !== 'div'
-      || lastArg.value !== ','
-      || node.after === ' '
     ) {
       return
     }
 
-    node.after = ' '
-    changed = true
+    // 检查是否有逗号作为最后一个参数（空默认值）
+    if (
+      lastArg?.type === 'div'
+      && lastArg.value === ','
+    ) {
+      // 在逗号后添加空格
+      const spaceNode = {
+        type: 'space',
+        value: ' ',
+      }
+      node.nodes.push(spaceNode)
+      changed = true
+    }
+    // 确保 var() 函数后有空格（如果后面还有内容）
+    if (node.after !== ' ') {
+      node.after = ' '
+      changed = true
+    }
   })
 
   return changed ? parsed.toString() : value

--- a/packages/postcss/test/compat.test.ts
+++ b/packages/postcss/test/compat.test.ts
@@ -1,6 +1,68 @@
 import { createStyleHandler } from '@/index'
+import { normalizeTailwindcssV4EmptyVarFallback } from '@/compat/tailwindcss-v4'
 
 describe('compat', () => {
+  describe('normalizeTailwindcssV4EmptyVarFallback', () => {
+    it('should not modify strings without var(--tw-)', () => {
+      const input = 'color: red; margin: var(--custom-var);'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe(input)
+    })
+
+    it('should add space after comma in var(--tw-) with empty fallback', () => {
+      const input = 'color: var(--tw-text-color,);'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe('color: var(--tw-text-color, );')
+    })
+
+    it('should add space after var() function if there is content after without space', () => {
+      const input = 'margin: var(--tw-margin)0px;'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe('margin: var(--tw-margin) 0px;')
+    })
+
+    it('should not add extra space after var() function if there is already space', () => {
+      const input = 'margin: var(--tw-margin) 0px;'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe(input)
+    })
+
+    it('should handle transform property with multiple empty var fallbacks (Issues#625)', () => {
+      const input = 'transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe('transform: var(--tw-rotate-x, ) var(--tw-rotate-y, ) var(--tw-rotate-z, ) var(--tw-skew-x, ) var(--tw-skew-y, );')
+    })
+
+    it('should handle multiple var() functions in one line', () => {
+      const input = 'padding: var(--tw-padding-x,) var(--tw-padding-y,);'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe('padding: var(--tw-padding-x, ) var(--tw-padding-y, );')
+    })
+
+    it('should handle complex expressions with nested functions', () => {
+      const input = 'background: linear-gradient(var(--tw-gradient-stops,),var(--tw-gradient-from) var(--tw-gradient-position,),var(--tw-gradient-to,));'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe('background: linear-gradient(var(--tw-gradient-stops, ), var(--tw-gradient-from) var(--tw-gradient-position, ), var(--tw-gradient-to, ));')
+    })
+
+    it('should leave var() with non-empty fallback unchanged', () => {
+      const input = 'color: var(--tw-text-color, blue);'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe(input)
+    })
+
+    it('should leave var() at end of line unchanged', () => {
+      const input = 'color: var(--tw-text-color);'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe(input)
+    })
+
+    it('should handle multiple declarations in one string', () => {
+      const input = 'color: var(--tw-text-color,); margin: var(--tw-margin)0px; padding: var(--tw-padding, )10px;'
+      const result = normalizeTailwindcssV4EmptyVarFallback(input)
+      expect(result).toBe('color: var(--tw-text-color, ); margin: var(--tw-margin) 0px; padding: var(--tw-padding, ) 10px;')
+    })
+  })
   it('styleHandler calc', async () => {
     const styleHandler = createStyleHandler({
       isMainChunk: true,


### PR DESCRIPTION
优化 normalizeTailwindcssV4EmptyVarFallback 函数，仅在需要时添加逗号后的空格，同时统一确保 var() 函数后有正确的空格，修复空格处理异常问题

Fixes: [#909](https://github.com/sonofmagic/weapp-tailwindcss/issues/909)