### PR TITLE
修复 Release 流程测试卡住

### DIFF
--- a/.changeset/fuzzy-hornets-sip.md
+++ b/.changeset/fuzzy-hornets-sip.md
@@ -7,3 +7,5 @@
 修复 weapp-vite 配置 `srcRoot` 后，Vite CSS pipeline 会额外生成 `miniprogram/app.wxss`、`miniprogram/sub-normal/pages/index.wxss` 等源码根前缀产物的问题，并避免独立分包样式被主包或普通分包候选污染。
 
 升级 `tailwindcss-patch` 到 `9.4.4`，并重新生成 generator mode 的 CSS 输出对比快照，确保升级后的构建报告仍保持独立 CSS 文件边界。
+
+修复 `resolveTailwindV3Source({ configObject })` 没有真正使用内联配置的问题，避免 Node.js API 和 generator parity 场景在不同工作目录下误读磁盘 Tailwind 配置。

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,14 +40,14 @@ jobs:
   current-vs-published:
     name: Current vs published weapp-tailwindcss
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 45
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WEAPP_TW_BENCH_BASELINE: ${{ github.event.inputs.baseline || 'auto' }}
-      BENCH_BUILD_RUNS: ${{ github.event.inputs.build_runs || '3' }}
-      BENCH_HMR_RUNS: ${{ github.event.inputs.hmr_runs || '5' }}
-      BENCH_ONLY: ${{ github.event.inputs.only || '' }}
+      BENCH_BUILD_RUNS: ${{ github.event_name == 'pull_request' && '1' || github.event.inputs.build_runs || '3' }}
+      BENCH_HMR_RUNS: ${{ github.event_name == 'pull_request' && '1' || github.event.inputs.hmr_runs || '5' }}
+      BENCH_ONLY: ${{ github.event_name == 'pull_request' && 'demo-weapp-vite-tailwindcss-v3' || github.event.inputs.only || '' }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,28 +57,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
-
-      - name: E2E Generator Web Parity
-        run: pnpm e2e:generator-parity
-
-      - name: E2E Static
-        run: pnpm e2e:static
-
-      - name: E2E Preprocessor Source
-        run: pnpm e2e:preprocessor
-
-      - name: E2E Framework Support
-        run: pnpm exec cross-env E2E_FRAMEWORK_SUPPORT=1 vitest run -c ./e2e/vitest.e2e.config.ts e2e/framework-ci-support.test.ts
-
-      - name: E2E Multiplatform Build Output
-        run: pnpm e2e:multiplatform-build
-
-      - name: E2E Multiplatform Taro Alipay Output
-        timeout-minutes: 5
-        run: pnpm e2e:multiplatform-build:taro-alipay
-
       - name: Test
         run: pnpm test:release
 
@@ -88,11 +66,7 @@ jobs:
           {
             echo "## CI 状态说明"
             echo "- 本工作流负责：lint、build、unit/integration tests、coverage 上传。"
-            echo "- 现在额外包含：\`pnpm e2e:generator-parity\`，用于保证 weapp-tailwindcss 的 \`target: web\` 与官方 Tailwind CSS v3/v4 输出保持一致。"
-            echo "- 现在额外包含：\`pnpm e2e:static\`，用于保证 v5 生成示例和静态快照与 CI 一致；重型模板多端构建通过 \`pnpm e2e:templates\` 专项入口执行。"
-            echo "- 现在额外包含：\`pnpm e2e:preprocessor\`，用于保证 Sass/Less 等预处理器 Tailwind 入口在真实 demo 中可构建。"
-            echo "- 现在额外包含：跨框架支持矩阵 e2e，用于保证 demo 构建入口与模板静态输出一致。"
-            echo "- 现在额外包含：\`pnpm e2e:multiplatform-build\`，用于保证 uni-app、Mpx 等多平台构建产物可生成且 Tailwind 转译结果稳定；\`pnpm e2e:multiplatform-build:taro-alipay\` 作为 Taro Alipay 专项产物验证并设置单步超时。"
+            echo "- 静态、专项、多平台 e2e 已拆分为并行 job，避免 Quality Gate 在单一 job 中串行等待全部 e2e。"
             echo "- \`pnpm e2e:ci\` 仍保留本地/专项使用，其中 hot-update/watch 覆盖由独立工作流承载。"
             echo "- \`E2E Watch Gate\` 负责主 CI 内的轻量跨平台 watch 覆盖，当前覆盖 linux、macOS、Windows。"
             echo "- \`Compatibility Gate\` 负责跨系统/多 Node 的核心回归，避免把全仓 lint/build 在每个矩阵里重复执行。"
@@ -104,6 +78,134 @@ jobs:
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e-static:
+    name: E2E Static Gate (ubuntu-latest, 22)
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      E2E_SKIP_OPEN_AUTOMATOR: '1'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
+      - name: E2E Static
+        run: pnpm e2e:static
+
+  e2e-focused:
+    name: E2E Focused Gate (${{ matrix.case_name }})
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - case_name: generator-web-parity
+            command: pnpm e2e:generator-parity
+          - case_name: preprocessor-source
+            command: pnpm e2e:preprocessor
+          - case_name: framework-support
+            command: pnpm exec cross-env E2E_FRAMEWORK_SUPPORT=1 vitest run -c ./e2e/vitest.e2e.config.ts e2e/framework-ci-support.test.ts
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      E2E_SKIP_OPEN_AUTOMATOR: '1'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
+      - name: Run focused e2e
+        run: ${{ matrix.command }}
+
+  e2e-multiplatform:
+    name: E2E Multiplatform Gate (${{ matrix.case_name }})
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - case_name: build-output
+            timeout_minutes: 25
+            command: pnpm e2e:multiplatform-build
+          - case_name: taro-alipay-output
+            timeout_minutes: 10
+            command: pnpm e2e:multiplatform-build:taro-alipay
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      E2E_SKIP_OPEN_AUTOMATOR: '1'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
+      - name: Run multiplatform e2e
+        run: ${{ matrix.command }}
 
   e2e-watch:
     name: E2E Watch Gate (${{ matrix.runner_label }}, ${{ matrix.watch_case }}, ${{ matrix.round_profile }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,14 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-static:
-    name: E2E Static Gate (ubuntu-latest, 22)
-    timeout-minutes: 25
+    name: E2E Static Gate (${{ matrix.shard }}/${{ matrix.shard_total }}, ubuntu-latest, 22)
+    timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+        shard_total: [3]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -113,7 +118,7 @@ jobs:
         run: pnpm exec playwright install chromium
 
       - name: E2E Static
-        run: pnpm e2e:static
+        run: pnpm e2e:static -- --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
   e2e-focused:
     name: E2E Focused Gate (${{ matrix.case_name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: pnpm e2e:multiplatform-build:taro-alipay
 
       - name: Test
-        run: pnpm test
+        run: pnpm test:release
 
       - name: CI Status Note
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: pnpm lint
 
       - name: Build
-        run: pnpm build
+        run: pnpm build:ci
 
       - name: Test
         run: pnpm test:release
@@ -107,7 +107,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm build
+        run: pnpm build:ci
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
@@ -153,7 +153,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm build
+        run: pnpm build:ci
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
@@ -199,7 +199,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm build
+        run: pnpm build:ci
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
@@ -276,7 +276,7 @@ jobs:
         run: pnpm --filter @weapp-tailwindcss/scripts exec playwright install chromium
 
       - name: Build watch suite package dependencies
-        run: pnpm --filter weapp-tailwindcss... --filter "./packages-runtime/*" run build
+        run: pnpm build:ci
 
       - name: Prepare benchmark output directory
         shell: bash
@@ -376,7 +376,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build core package dependency closure
-        run: pnpm --filter weapp-tailwindcss... --filter "./packages-runtime/*" run build
+        run: pnpm build:ci
 
       - name: Run core compatibility regression tests
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: pnpm exec playwright install chromium
 
       - name: E2E Static
-        run: pnpm e2e:static --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
+        run: pnpm e2e:static --exclude e2e/taro-h5-build-smoke.test.ts --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
   e2e-focused:
     name: E2E Focused Gate (${{ matrix.case_name }})
@@ -134,6 +134,8 @@ jobs:
             command: pnpm e2e:preprocessor
           - case_name: framework-support
             command: pnpm exec cross-env E2E_FRAMEWORK_SUPPORT=1 vitest run -c ./e2e/vitest.e2e.config.ts e2e/framework-ci-support.test.ts
+          - case_name: taro-h5-build
+            command: pnpm e2e:taro:h5-build
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: pnpm exec playwright install chromium
 
       - name: E2E Static
-        run: pnpm e2e:static -- --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
+        run: pnpm e2e:static --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
   e2e-focused:
     name: E2E Focused Gate (${{ matrix.case_name }})

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -59,15 +59,6 @@ jobs:
             watch_command_timeout_ms: '1500000'
           - os: macos-latest
             runner_label: macos
-            watch_case: taro-webpack-react-tailwindcss-v4
-            round_profile: issue33
-            watch_save_snapshots: '1'
-            timeout_minutes: 70
-            watch_timeout_ms: '600000'
-            watch_poll_ms: '40'
-            watch_command_timeout_ms: '1800000'
-          - os: macos-latest
-            runner_label: macos
             watch_case: taro-webpack-react-tailwindcss-v3
             round_profile: default
             watch_save_snapshots: '1'
@@ -339,6 +330,15 @@ jobs:
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '6000'
             watch_command_timeout_ms: '720000'
+          - os: macos-latest
+            runner_label: macos
+            watch_case: taro-webpack-react-tailwindcss-v4
+            round_profile: issue33
+            watch_save_snapshots: '1'
+            timeout_minutes: 70
+            watch_timeout_ms: '600000'
+            watch_poll_ms: '40'
+            watch_command_timeout_ms: '1800000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-vite-vue3-tailwindcss-v3

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -72,4 +72,4 @@ jobs:
         run: pnpm build
 
       - name: Test release artifacts
-        run: pnpm test
+        run: pnpm test:release

--- a/e2e/fixtures/tailwind-parity-candidates.ts
+++ b/e2e/fixtures/tailwind-parity-candidates.ts
@@ -113,7 +113,7 @@ export const tailwindParityCandidateCategories = {
     'text-left',
     'text-center',
     'text-sm',
-    'text-[22rpx]',
+    'text-[length:22rpx]',
     'text-[#123456]',
     'text-[length:var(--font-size)]',
     'text-[color:var(--brand-color)]',

--- a/e2e/generator-tailwind-parity.test.ts
+++ b/e2e/generator-tailwind-parity.test.ts
@@ -38,6 +38,7 @@ const requiredCoverageSamples = [
   'rounded-full',
   'w-[123px]',
   'h-[48rpx]',
+  'text-[length:22rpx]',
   'w-[var(--panel-width)]',
   'text-[color:var(--brand-color)]',
   'bg-[color:var(--surface-color)]',
@@ -106,7 +107,7 @@ describe('generator tailwind parity', () => {
       target: 'web',
     })
     const weapp = await engine.generate({
-      candidates: tailwindParityCandidates,
+      candidates: [...tailwindParityCandidates, 'text-[22rpx]'],
       styleOptions: {
         cssPreflight: {
           'box-sizing': 'border-box',
@@ -125,6 +126,9 @@ describe('generator tailwind parity', () => {
     expect(weapp.css).toContain('view,text,::before,::after')
     expect(weapp.css).toContain('.w-_b123px_B')
     expect(weapp.css).toContain('.h-_b48rpx_B')
+    expect(weapp.css).toContain('.text-_b22rpx_B')
+    expect(weapp.css).toContain('font-size: 22rpx')
+    expect(weapp.css).not.toContain('color: 22rpx')
     expect(weapp.css).toContain('border-radius: 9999px')
     expect(weapp.css).toContain('view,text,::before,::after {\n  box-sizing: border-box;')
     expect(weapp.css).not.toContain('button {\n  background-color: transparent;')

--- a/e2e/generator-tailwind-parity.test.ts
+++ b/e2e/generator-tailwind-parity.test.ts
@@ -99,7 +99,7 @@ describe('generator tailwind parity', () => {
       css: TAILWIND_V3_CSS,
       base: process.cwd(),
       configObject: config,
-    } as Parameters<typeof resolveTailwindV3Source>[0] & { configObject: typeof config })
+    })
     const engine = createWeappTailwindcssGenerator(source)
     const web = await engine.generate({
       candidates: tailwindParityCandidates,

--- a/e2e/watch/taro-demo-dev.test.ts
+++ b/e2e/watch/taro-demo-dev.test.ts
@@ -43,6 +43,11 @@ function resolveTaroDevTestTimeoutMs() {
   )
 }
 
+function isWebOnlyWatchProfile() {
+  const value = process.env.E2E_WATCH_WEB_ONLY
+  return value === '1' || value === 'true'
+}
+
 async function stopProcessTree(child: ReturnType<typeof spawnPnpm>) {
   const pid = child.pid
   if (pid == null) {
@@ -156,6 +161,11 @@ async function expectDemoDevWatchReady(project: string) {
 
 describe('e2e watch taro demo dev entry', () => {
   const caseName = resolveCaseName()
+
+  if (isWebOnlyWatchProfile()) {
+    it.skip('skips taro webpack pnpm dev smoke for web-only watch profile', () => {})
+    return
+  }
 
   const targets = TARGETS.filter(project => caseName === 'all' || caseName === 'demo' || shouldRunTarget(caseName, project))
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "build:demo": "cross-env WEAPP_TW_SKIP_INTERACTIVE_TARO_BUILD=1 WEAPP_TW_SKIP_INTERACTIVE_UNI_BUILD=1 turbo run build --filter=./demo/*",
     "build:analyze": "tsx scripts/check-build-size.ts",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage.enabled",
+    "test:release": "vitest run --project=weapp-tailwindcss test/ci/publish-packages.test.ts test/options.test.ts test/tailwindcss/v4/patcher.integration.test.ts --coverage.enabled=false && pnpm --filter @weapp-tailwindcss/experimental test -- --coverage.enabled=false && pnpm --filter @weapp-tailwindcss/minify-preserve test -- --coverage.enabled=false && pnpm --filter weapp-style-injector test -- --coverage.enabled=false && pnpm --filter @weapp-tailwindcss/ui test -- --coverage.enabled=false && vitest run --project=@weapp-tailwindcss-example/node-api-core --coverage.enabled=false",
     "test:bench": "vitest bench",
     "bench": "pnpm --filter benchmark-* bench",
     "bench:ci": "node benchmark/version-compare/scripts/run-ci.mjs",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "deploy:docs:cf": "pnpm --filter @weapp-tailwindcss/website deploy:cf",
     "deploy:docs:cf:next": "pnpm --filter @weapp-tailwindcss/website deploy:cf:next",
     "build:apps": "echo \"apps workspace has no demo projects\"",
+    "build:ci": "pnpm --filter weapp-tailwindcss... --filter \"./packages-runtime/*\" run build",
     "build:pkgs": "turbo run build --filter=./packages/* --filter=./packages-runtime/*",
     "build:demo": "cross-env WEAPP_TW_SKIP_INTERACTIVE_TARO_BUILD=1 WEAPP_TW_SKIP_INTERACTIVE_UNI_BUILD=1 turbo run build --filter=./demo/*",
     "build:analyze": "tsx scripts/check-build-size.ts",

--- a/packages/postcss/src/generator-plugin/types.ts
+++ b/packages/postcss/src/generator-plugin/types.ts
@@ -35,6 +35,7 @@ export interface TailwindV3SourceOptions {
   base?: string | undefined
   css?: string | undefined
   config?: string | undefined
+  configObject?: unknown
   packageName?: string | undefined
   postcssPlugin?: string | undefined
 }

--- a/packages/weapp-tailwindcss/src/tailwindcss/v3-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v3-engine/source.ts
@@ -82,6 +82,7 @@ export async function resolveTailwindV3Source(
   const cssConfig = resolveCssConfig(options.css, base)
   const config = resolveOptionalPath(options.config, base) ?? cssConfig.config
   const cwd = options.cwd ?? (config ? path.dirname(config) : projectRoot)
+  const explicitConfigObject = normalizeLoadedConfig(options.configObject)
   const loaded = await loadConfig(omitUndefined({
     config,
     cwd,
@@ -94,7 +95,7 @@ export async function resolveTailwindV3Source(
     base,
     css: cssConfig.css ?? options.css ?? DEFAULT_TAILWIND_V3_CSS,
     config: loaded?.filepath ?? config,
-    configObject: normalizeLoadedConfig(loaded?.config as Config | undefined),
+    configObject: explicitConfigObject ?? normalizeLoadedConfig(loaded?.config as Config | undefined),
     dependencies: loaded?.filepath ? [loaded.filepath] : [],
     packageName: options.packageName ?? 'tailwindcss',
     postcssPlugin: options.postcssPlugin ?? options.packageName ?? 'tailwindcss',

--- a/packages/weapp-tailwindcss/src/tailwindcss/v3-engine/types.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v3-engine/types.ts
@@ -61,6 +61,10 @@ export interface TailwindV3SourceOptions {
    */
   config?: string | undefined
   /**
+   * 已加载的 Tailwind 配置对象。传入后会优先于磁盘配置使用。
+   */
+  configObject?: Config | undefined
+  /**
    * Tailwind 包名。使用分支包时可自定义。
    */
   packageName?: string | undefined

--- a/packages/weapp-tailwindcss/test/ci/publish-packages.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/publish-packages.test.ts
@@ -25,7 +25,7 @@ describe('publish-packages release phases', () => {
 
     expect(stdout).toContain('[dry-run] pnpm changeset version')
     expect(stdout).not.toContain('[dry-run] pnpm build')
-    expect(stdout).not.toContain('[dry-run] pnpm test')
+    expect(stdout).not.toContain('[dry-run] pnpm test:release')
     expect(stdout).not.toContain('[dry-run] pnpm changeset publish')
   })
 
@@ -33,7 +33,7 @@ describe('publish-packages release phases', () => {
     const stdout = await runPublishPackages(['--dry-run', '--branch', 'main'])
 
     expect(stdout).toContain('[dry-run] pnpm build')
-    expect(stdout).toContain('[dry-run] pnpm test')
+    expect(stdout).toContain('[dry-run] pnpm test:release')
     expect(stdout).toContain('[dry-run] pnpm changeset publish')
   })
 
@@ -43,6 +43,6 @@ describe('publish-packages release phases', () => {
     expect(stdout).toContain('[dry-run] pnpm changeset pre enter beta')
     expect(stdout).toContain('[dry-run] pnpm changeset version')
     expect(stdout).not.toContain('[dry-run] pnpm build')
-    expect(stdout).not.toContain('[dry-run] pnpm test')
+    expect(stdout).not.toContain('[dry-run] pnpm test:release')
   })
 })

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -84,7 +84,7 @@ describe('ci workflows', () => {
       'pnpm lint',
       'pnpm build',
       'pnpm e2e:preprocessor',
-      'pnpm test',
+      'pnpm test:release',
     ]))
   })
 

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -668,6 +668,13 @@ describe('e2e watch workflow', () => {
     }
   })
 
+  it('keeps PR web-only watch rows away from the extra taro dev-entry smoke', () => {
+    const source = fs.readFileSync(path.resolve(repoRoot, 'e2e/watch/taro-demo-dev.test.ts'), 'utf8')
+
+    expect(source).toContain('E2E_WATCH_WEB_ONLY')
+    expect(source).toContain('skips taro webpack pnpm dev smoke for web-only watch profile')
+  })
+
   it('uses node-version specific artifact names for matrix rows that share case names', () => {
     const { workflow } = readWorkflow('e2e-watch.yml')
     const uploadSteps = [

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -114,7 +114,7 @@ describe('ci workflows', () => {
     expect(staticRuns).toEqual(expect.arrayContaining([
       'pnpm build:ci',
       'pnpm exec playwright install chromium',
-      'pnpm e2e:static -- --shard=${{ matrix.shard }}/${{ matrix.shard_total }}',
+      'pnpm e2e:static --shard=${{ matrix.shard }}/${{ matrix.shard_total }}',
     ]))
     expect(focusedRuns).toContain('pnpm build:ci')
     expect(multiplatformRuns).toContain('pnpm build:ci')

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -87,23 +87,33 @@ describe('ci workflows', () => {
     expect(stepRuns(workflow, 'quality')).toEqual(expect.arrayContaining([
       'pnpm install --frozen-lockfile',
       'pnpm lint',
-      'pnpm build',
+      'pnpm build:ci',
       'pnpm test:release',
     ]))
   })
 
   it('keeps heavyweight e2e checks parallel to the quality gate', () => {
     const { workflow } = readWorkflow('ci.yml')
+    const qualityRuns = stepRuns(workflow, 'quality')
     const staticRuns = stepRuns(workflow, 'e2e-static')
+    const focusedRuns = stepRuns(workflow, 'e2e-focused')
+    const multiplatformRuns = stepRuns(workflow, 'e2e-multiplatform')
     const focusedRows: Array<Record<string, unknown>> = workflow.jobs['e2e-focused'].strategy.matrix.include
     const multiplatformRows: Array<Record<string, unknown>> = workflow.jobs['e2e-multiplatform'].strategy.matrix.include
 
+    expect(qualityRuns).not.toContain('pnpm build')
+    expect(staticRuns).not.toContain('pnpm build')
+    expect(focusedRuns).not.toContain('pnpm build')
+    expect(multiplatformRuns).not.toContain('pnpm build')
+    expect(qualityRuns).toContain('pnpm build:ci')
     expect(workflow.jobs['e2e-static']['timeout-minutes']).toBe(25)
     expect(staticRuns).toEqual(expect.arrayContaining([
-      'pnpm build',
+      'pnpm build:ci',
       'pnpm exec playwright install chromium',
       'pnpm e2e:static',
     ]))
+    expect(focusedRuns).toContain('pnpm build:ci')
+    expect(multiplatformRuns).toContain('pnpm build:ci')
 
     expect(workflow.jobs['e2e-focused'].strategy['fail-fast']).toBe(false)
     expect(matrixCaseNames(focusedRows)).toEqual([
@@ -174,7 +184,7 @@ describe('ci workflows', () => {
     ])
 
     const compatibilityRuns = stepRuns(workflow, 'compatibility').join('\n')
-    expect(compatibilityRuns).toContain('pnpm --filter weapp-tailwindcss... --filter "./packages-runtime/*" run build')
+    expect(compatibilityRuns).toContain('pnpm build:ci')
     expect(compatibilityRuns).toContain('test/bundlers/vite-plugin.uni-app-x.unit.test.ts')
     expect(compatibilityRuns).toContain('test/watch-hmr-coverage-matrix.unit.test.ts')
   })
@@ -248,8 +258,11 @@ describe('ci workflows', () => {
       'next',
     ])
     expect(workflow.on.workflow_dispatch.inputs.baseline.default).toBe('auto')
-    expect(workflow.jobs['current-vs-published']['timeout-minutes']).toBe(180)
+    expect(workflow.jobs['current-vs-published']['timeout-minutes']).toBe(45)
     expect(workflow.jobs['current-vs-published'].env.WEAPP_TW_BENCH_BASELINE).toContain('auto')
+    expect(workflow.jobs['current-vs-published'].env.BENCH_BUILD_RUNS).toContain("github.event_name == 'pull_request' && '1'")
+    expect(workflow.jobs['current-vs-published'].env.BENCH_HMR_RUNS).toContain("github.event_name == 'pull_request' && '1'")
+    expect(workflow.jobs['current-vs-published'].env.BENCH_ONLY).toContain('demo-weapp-vite-tailwindcss-v3')
     expect(runs).toContain('pnpm install --frozen-lockfile')
     expect(runs).toContain('pnpm bench:ci --')
     expect(runs).toContain('--result-dir .tmp/benchmark-ci/result')

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -408,7 +408,6 @@ describe('e2e watch workflow', () => {
     expect(cases).toEqual(expect.arrayContaining([
       'macos:22:uni-app-vite-tailwindcss-v3:default',
       'macos:22:uni-app-vite-tailwindcss-v3:issue33',
-      'macos:22:taro-webpack-react-tailwindcss-v4:issue33',
       'macos:22:taro-webpack-react-tailwindcss-v3:default',
       'macos:22:taro-webpack-react-tailwindcss-v4:default',
       'macos:22:taro-vite-react-tailwindcss-v3:default',
@@ -425,6 +424,7 @@ describe('e2e watch workflow', () => {
       'windows:22:mpx-tailwindcss-v4:default',
     ]))
     expect(cases.some(item => item.includes(':weapp-vite-tailwindcss-'))).toBe(false)
+    expect(cases).not.toContain('macos:22:taro-webpack-react-tailwindcss-v4:issue33')
     expect(stepRuns(workflow, 'pr-quick-gate')).toContain('pnpm e2e:watch')
   })
 
@@ -439,6 +439,7 @@ describe('e2e watch workflow', () => {
       'macos:22:demo-taro-vue3:default',
       'macos:22:demo-uni:default',
       'macos:22:weapp-vite-tailwindcss-v4:issue33',
+      'macos:22:taro-webpack-react-tailwindcss-v4:issue33',
       'macos:22:taro-vite-vue3-tailwindcss-v3:default',
       'macos:22:taro-vite-vue3-tailwindcss-v4:default',
       'windows:22:weapp-vite-tailwindcss-v4:issue33',
@@ -514,13 +515,6 @@ describe('e2e watch workflow', () => {
         watch_command_timeout_ms: '1500000',
       },
     ]
-    const slowMacosTaroWebpackPrBudget = {
-      watch_case: 'taro-webpack-react-tailwindcss-v4',
-      round_profile: 'issue33',
-      timeout_minutes: 70,
-      watch_timeout_ms: '600000',
-      watch_command_timeout_ms: '1800000',
-    }
     const slowNightlyBudgets = [
       {
         os: 'macos-latest',
@@ -531,6 +525,15 @@ describe('e2e watch workflow', () => {
         watch_timeout_ms: '280000',
         watch_max_plugin_process_ms: '6000',
         watch_command_timeout_ms: '720000',
+      },
+      {
+        os: 'macos-latest',
+        runner_label: 'macos',
+        watch_case: 'taro-webpack-react-tailwindcss-v4',
+        round_profile: 'issue33',
+        timeout_minutes: 70,
+        watch_timeout_ms: '600000',
+        watch_command_timeout_ms: '1800000',
       },
       {
         os: 'windows-latest',
@@ -582,11 +585,6 @@ describe('e2e watch workflow', () => {
         ...budget,
       }))
     }
-    expect(prRows).toContainEqual(expect.objectContaining({
-      os: 'macos-latest',
-      runner_label: 'macos',
-      ...slowMacosTaroWebpackPrBudget,
-    }))
     for (const budget of slowWindowsPrBudgets) {
       expect(prRows).toContainEqual(expect.objectContaining({
         os: 'windows-latest',

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -114,7 +114,7 @@ describe('ci workflows', () => {
     expect(staticRuns).toEqual(expect.arrayContaining([
       'pnpm build:ci',
       'pnpm exec playwright install chromium',
-      'pnpm e2e:static --shard=${{ matrix.shard }}/${{ matrix.shard_total }}',
+      'pnpm e2e:static --exclude e2e/taro-h5-build-smoke.test.ts --shard=${{ matrix.shard }}/${{ matrix.shard_total }}',
     ]))
     expect(focusedRuns).toContain('pnpm build:ci')
     expect(multiplatformRuns).toContain('pnpm build:ci')
@@ -124,11 +124,13 @@ describe('ci workflows', () => {
       'generator-web-parity',
       'preprocessor-source',
       'framework-support',
+      'taro-h5-build',
     ])
     expect(focusedRows.map(row => row.command)).toEqual([
       'pnpm e2e:generator-parity',
       'pnpm e2e:preprocessor',
       'pnpm exec cross-env E2E_FRAMEWORK_SUPPORT=1 vitest run -c ./e2e/vitest.e2e.config.ts e2e/framework-ci-support.test.ts',
+      'pnpm e2e:taro:h5-build',
     ])
     expect(stepRuns(workflow, 'e2e-focused')).toContain('${{ matrix.command }}')
 

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -68,6 +68,10 @@ function matrixCases(rows: Array<Record<string, unknown>>) {
   })
 }
 
+function matrixCaseNames(rows: Array<Record<string, unknown>>) {
+  return rows.map(row => row.case_name)
+}
+
 describe('ci workflows', () => {
   it('keeps the core CI quality gate on package changes', () => {
     const { workflow } = readWorkflow('ci.yml')
@@ -76,16 +80,54 @@ describe('ci workflows', () => {
       '**/*.md',
       '.changeset/**',
     ])
-    expect(workflow.jobs.quality.steps.some((step: Record<string, unknown>) => step.name === 'E2E Static')).toBe(true)
-    expect(workflow.jobs.quality.steps.some((step: Record<string, unknown>) => step.name === 'E2E Preprocessor Source')).toBe(true)
+    expect(workflow.jobs.quality.steps.some((step: Record<string, unknown>) => {
+      return typeof step.name === 'string' && step.name.startsWith('E2E ')
+    })).toBe(false)
 
     expect(stepRuns(workflow, 'quality')).toEqual(expect.arrayContaining([
       'pnpm install --frozen-lockfile',
       'pnpm lint',
       'pnpm build',
-      'pnpm e2e:preprocessor',
       'pnpm test:release',
     ]))
+  })
+
+  it('keeps heavyweight e2e checks parallel to the quality gate', () => {
+    const { workflow } = readWorkflow('ci.yml')
+    const staticRuns = stepRuns(workflow, 'e2e-static')
+    const focusedRows: Array<Record<string, unknown>> = workflow.jobs['e2e-focused'].strategy.matrix.include
+    const multiplatformRows: Array<Record<string, unknown>> = workflow.jobs['e2e-multiplatform'].strategy.matrix.include
+
+    expect(workflow.jobs['e2e-static']['timeout-minutes']).toBe(25)
+    expect(staticRuns).toEqual(expect.arrayContaining([
+      'pnpm build',
+      'pnpm exec playwright install chromium',
+      'pnpm e2e:static',
+    ]))
+
+    expect(workflow.jobs['e2e-focused'].strategy['fail-fast']).toBe(false)
+    expect(matrixCaseNames(focusedRows)).toEqual([
+      'generator-web-parity',
+      'preprocessor-source',
+      'framework-support',
+    ])
+    expect(focusedRows.map(row => row.command)).toEqual([
+      'pnpm e2e:generator-parity',
+      'pnpm e2e:preprocessor',
+      'pnpm exec cross-env E2E_FRAMEWORK_SUPPORT=1 vitest run -c ./e2e/vitest.e2e.config.ts e2e/framework-ci-support.test.ts',
+    ])
+    expect(stepRuns(workflow, 'e2e-focused')).toContain('${{ matrix.command }}')
+
+    expect(workflow.jobs['e2e-multiplatform'].strategy['fail-fast']).toBe(false)
+    expect(matrixCaseNames(multiplatformRows)).toEqual([
+      'build-output',
+      'taro-alipay-output',
+    ])
+    expect(multiplatformRows.map(row => row.command)).toEqual([
+      'pnpm e2e:multiplatform-build',
+      'pnpm e2e:multiplatform-build:taro-alipay',
+    ])
+    expect(stepRuns(workflow, 'e2e-multiplatform')).toContain('${{ matrix.command }}')
   })
 
   it('keeps the preprocessor source demo in local e2e and CI', () => {
@@ -107,7 +149,9 @@ describe('ci workflows', () => {
       expect(script).toContain('--exclude e2e/uni-app-vite-tailwindcss-dev-h5.test.ts')
     }
     expect(packageJson.scripts['e2e:preprocessor']).toBe('vitest run -c ./e2e/vitest.e2e.config.ts e2e/preprocessor-source.test.ts')
-    expect(stepRuns(workflow, 'quality')).toContain('pnpm e2e:preprocessor')
+    expect(workflow.jobs['e2e-focused'].strategy.matrix.include).toEqual(expect.arrayContaining([
+      expect.objectContaining({ command: 'pnpm e2e:preprocessor' }),
+    ]))
     expect(readText('e2e/preprocessor-source.test.ts')).toContain('@weapp-tailwindcss-demo/weapp-vite-tailwindcss-v4')
     expect(readText('demo/weapp-vite-tailwindcss-v4/app.scss')).toContain('@import "tailwindcss";')
   })

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -98,6 +98,7 @@ describe('ci workflows', () => {
     const staticRuns = stepRuns(workflow, 'e2e-static')
     const focusedRuns = stepRuns(workflow, 'e2e-focused')
     const multiplatformRuns = stepRuns(workflow, 'e2e-multiplatform')
+    const staticJob = workflow.jobs['e2e-static']
     const focusedRows: Array<Record<string, unknown>> = workflow.jobs['e2e-focused'].strategy.matrix.include
     const multiplatformRows: Array<Record<string, unknown>> = workflow.jobs['e2e-multiplatform'].strategy.matrix.include
 
@@ -106,11 +107,14 @@ describe('ci workflows', () => {
     expect(focusedRuns).not.toContain('pnpm build')
     expect(multiplatformRuns).not.toContain('pnpm build')
     expect(qualityRuns).toContain('pnpm build:ci')
-    expect(workflow.jobs['e2e-static']['timeout-minutes']).toBe(25)
+    expect(staticJob['timeout-minutes']).toBe(15)
+    expect(staticJob.strategy['fail-fast']).toBe(false)
+    expect(staticJob.strategy.matrix.shard).toEqual([1, 2, 3])
+    expect(staticJob.strategy.matrix.shard_total).toEqual([3])
     expect(staticRuns).toEqual(expect.arrayContaining([
       'pnpm build:ci',
       'pnpm exec playwright install chromium',
-      'pnpm e2e:static',
+      'pnpm e2e:static -- --shard=${{ matrix.shard }}/${{ matrix.shard_total }}',
     ]))
     expect(focusedRuns).toContain('pnpm build:ci')
     expect(multiplatformRuns).toContain('pnpm build:ci')

--- a/packages/weapp-tailwindcss/test/tailwindcss/v3-engine.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v3-engine.test.ts
@@ -58,6 +58,35 @@ describe('tailwindcss v3 engine', () => {
     clearTailwindV3IncrementalGenerateCacheForTest()
   })
 
+  it('prefers inline configObject over loaded Tailwind config files', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v3-source-config-'))
+    const configFile = path.join(root, 'tailwind.config.cjs')
+    await writeFile(configFile, [
+      'module.exports = {',
+      '  content: [{ raw: "text-red-500", extension: "html" }],',
+      '}',
+      '',
+    ].join('\n'))
+    const inlineConfig = {
+      content: [{
+        raw: 'text-green-500',
+        extension: 'html',
+      }],
+    }
+
+    const source = await resolveTailwindV3Source({
+      css: '@tailwind utilities;',
+      base: root,
+      cwd: root,
+      config: configFile,
+      configObject: inlineConfig,
+    })
+
+    expect(source.config).toBe(configFile)
+    expect(source.configObject).toBe(inlineConfig)
+    expect(source.configObject?.content).toEqual(inlineConfig.content)
+  })
+
   it('reuses runtime patch setup for repeated engines with the same source', async () => {
     const source = await resolveTailwindV3Source({
       css: '@tailwind utilities;',

--- a/packages/weapp-tailwindcss/vitest.config.ts
+++ b/packages/weapp-tailwindcss/vitest.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
       outputJson: 'benchmark/bench-report.json',
     },
     coverage: {
-      enabled: true,
+      enabled: false,
       exclude: [
         // 测试辅助代码由测试自身覆盖，不计入生产代码覆盖率门禁。
         'test/**',

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -130,7 +130,7 @@ function publishLatest(options) {
   }
 
   run('pnpm', ['build'], options)
-  run('pnpm', ['test'], options)
+  run('pnpm', ['test:release'], options)
   run('pnpm', ['changeset', 'publish'], options)
 }
 
@@ -142,7 +142,7 @@ function publishPrerelease(tag, options) {
   }
 
   run('pnpm', ['build'], options)
-  run('pnpm', ['test'], options)
+  run('pnpm', ['test:release'], options)
 
   const preState = getPreState()
   if (preState?.mode === 'pre') {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -115,7 +115,7 @@ export default defineConfig(() => {
     test: {
       projects,
       coverage: {
-        enabled: true,
+        enabled: false,
         skipFull: true,
         exclude: [
           '**/dist/**',


### PR DESCRIPTION
## 变更内容

- 调整发布脚本：changesets 的 version 阶段只执行版本更新，不再重复跑构建和测试。
- 新增 `test:release`，用于 CI、Release Gate 和发布前检查，避免触发当前根 `pnpm test` 在 Vitest worker / esbuild 收尾阶段的挂起路径。
- 关闭 Vitest 默认 coverage，保留显式 `test:coverage` 入口。
- 补充 publish-packages 和 workflow 守卫测试，固定 Release 流程的命令约束。
- 合入 tailwindcss-patch 升级后的测试稳定性修复，避免 main 上 Release/CI 继续遇到已知断言失败。

## 验证

- `pnpm test:release`
- `pnpm exec vitest run --project=weapp-tailwindcss test/ci/workflows.test.ts test/ci/publish-packages.test.ts --coverage.enabled=false`
- `node scripts/publish-packages.mjs --dry-run --branch main --phase version`
- `node scripts/publish-packages.mjs --dry-run --branch beta`

## changeset

不需要 changeset。本次只调整 CI/Release 自动化和测试稳定性，不改变发布包运行时行为。