### PR TITLE
稳定发布流水线和 Vite 打包单测

### DIFF
--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -10,6 +10,7 @@ import { createJsHandler } from '@/js'
 import { replaceWxml } from '@/wxml'
 import { createTemplateHandler } from '@/wxml/utils'
 import { createBundlerGeneratedCssMarker } from '@/bundlers/shared/generated-css-marker'
+import { clearTailwindV4IncrementalGenerateCacheForTest } from '@/tailwindcss/v4-engine'
 import {
   createContext,
   createRollupAsset,
@@ -85,11 +86,25 @@ function mockTailwindV4GeneratorCss(css = '/* generated */') {
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }
   })
+}
+
+function createMockGeneratorCssResult(css: string, version = 3) {
+  return {
+    css,
+    rawCss: css,
+    target: 'weapp',
+    classSet: new Set<string>(),
+    rawCandidates: new Set<string>(),
+    dependencies: [],
+    sources: [],
+    root: null,
+    version,
+  }
 }
 
 async function loadIssue814Fixture() {
@@ -115,6 +130,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
     vi.doUnmock('@/bundlers/vite/source-scan')
     vi.doUnmock('@/bundlers/shared/generator-css')
     vi.doUnmock('@/generator')
+    clearTailwindV4IncrementalGenerateCacheForTest()
     resetVitePluginTestContext()
     vi.restoreAllMocks()
   })
@@ -594,7 +610,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
       projectRoot: process.cwd(),
       base: process.cwd(),
       baseFallbacks: [],
-      css: options.css ?? '@import "tailwindcss";',
+      css: options.css ?? '@import "tailwindcss" source(none);',
       dependencies: [],
     }))
     vi.doMock('@/generator', async (importOriginal) => {
@@ -611,7 +627,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
           projectRoot: process.cwd(),
           base: process.cwd(),
           baseFallbacks: [],
-          css: '@import "tailwindcss";',
+          css: '@import "tailwindcss" source(none);',
           dependencies: [],
         })),
         resolveTailwindV4SourceOptionsFromPatcher: vi.fn(() => ({
@@ -1009,7 +1025,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
           projectRoot: root,
           base: root,
           baseFallbacks: [],
-          css: '@import "tailwindcss";',
+          css: '@import "tailwindcss" source(none);',
           dependencies: [],
         })),
       }
@@ -1164,7 +1180,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
           projectRoot: sourceRoot,
           base: sourceRoot,
           baseFallbacks: [],
-          css: '@import "tailwindcss";',
+          css: '@import "tailwindcss" source(none);',
           dependencies: [],
           packageName: 'tailwindcss',
         })),
@@ -2640,9 +2656,11 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
 
   it('regenerates vite-processed uni-app-x @apply style assets from remembered source', async () => {
     const generatedByRawSource: string[] = []
-    const generateMock = vi.fn(async (_options: { candidates: Set<string> }, source: { css: string }) => {
-      generatedByRawSource.push(source.css)
-      const css = source.css.includes('@apply')
+    const generateCssByGeneratorMock = vi.fn(async (options: {
+      rawSource: string
+    }) => {
+      generatedByRawSource.push(options.rawSource)
+      const css = options.rawSource.includes('@apply')
         ? '.content{display:flex}.test{background-color:rgba(49,237,216,.54)}'
         : '.flex{display:flex}'
       return {
@@ -2655,26 +2673,26 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
         root: null,
       }
     })
+    vi.resetModules()
+    vi.doMock('@/bundlers/shared/generator-css', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/bundlers/shared/generator-css')>()
+      return {
+        ...actual,
+        generateCssByGenerator: generateCssByGeneratorMock,
+      }
+    })
     vi.doMock('@/generator', async (importOriginal) => {
       const actual = await importOriginal<typeof import('@/generator')>()
       return {
         ...actual,
-        createWeappTailwindcssGenerator: vi.fn((source: { css: string }) => ({
-          generate: vi.fn((options: { candidates: Set<string> }) => generateMock(options, source)),
-        })),
         normalizeWeappTailwindcssGeneratorOptions: normalizeGeneratorOptions,
-        resolveTailwindV4SourceFromPatcher: vi.fn(async () => ({
-          version: 4,
-          projectRoot: process.cwd(),
-          base: process.cwd(),
-          baseFallbacks: [],
-          css: '@import "tailwindcss" source(none);',
-          dependencies: [],
-        })),
       }
     })
-    const WeappTailwindcss = await loadWeappTailwindcssPlugin()
-    setCurrentContext(createContext({
+    const { createGenerateBundleHook: createGenerateBundleHookWithMock } = await import('@/bundlers/vite/generate-bundle')
+    const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-uni-app-x-apply-replay-'))
+    createdDirs.push(root)
+    const runtimeSet = new Set(['flex', 'bg-[#31edd8]/[0.54]'])
+    const context = createContext({
       appType: 'uni-app-x',
       cssMatcher: (file: string) => file.endsWith('.wxss'),
       mainCssChunkMatcher: vi.fn((file: string) => file === 'app.wxss'),
@@ -2693,40 +2711,66 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
       })),
       twPatcher: {
         patch: vi.fn(),
-        getClassSet: vi.fn(async () => new Set(['flex'])),
-        getClassSetSync: vi.fn(() => new Set(['flex'])),
+        getClassSet: vi.fn(async () => runtimeSet),
+        getClassSetSync: vi.fn(() => runtimeSet),
         majorVersion: 4,
-        extract: vi.fn(async () => ({ classSet: new Set(['flex']) })),
+        extract: vi.fn(async () => ({ classSet: runtimeSet })),
       },
       uniAppX: true,
-    }))
-    const plugins = WeappTailwindcss()
-    const uniCssPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:uni-app-x:css') as Plugin
-    const postPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:post') as Plugin
-    expect(uniCssPlugin).toBeTruthy()
-    expect(postPlugin).toBeTruthy()
-
-    await (postPlugin.configResolved as any)?.call(postPlugin, {
-      command: 'serve',
-      root: process.cwd(),
-      css: { postcss: { plugins: [] } },
-      build: { outDir: 'dist' },
-    } as ResolvedConfig)
-
-    const styleId = path.resolve(process.cwd(), 'pages/index/index.uvue?vue&type=style&index=0&lang.scss&scoped=true')
+    })
+    const styleId = path.join(root, 'pages/index/index.uvue?vue&type=style&index=0&lang.scss&scoped=true')
     const applySource = '.content { @apply flex; }\n.test { @apply bg-[#31edd8]/[0.54]; }'
-    await uniCssPlugin.transform?.call(uniCssPlugin, applySource, styleId)
+    const rememberedCssSources = new Map([
+      ['pages/index/index.wxss', {
+        outputFile: 'pages/index/index.wxss',
+        rawSource: applySource,
+        sourceFile: styleId,
+      }],
+    ])
+    const generateBundle = createGenerateBundleHookWithMock({
+      opts: context as any,
+      runtimeState: {
+        twPatcher: context.twPatcher as any,
+        readyPromise: Promise.resolve(),
+      },
+      ensureRuntimeClassSet: vi.fn(async () => runtimeSet),
+      ensureBundleRuntimeClassSet: vi.fn(async () => runtimeSet),
+      debug: vi.fn(),
+      getResolvedConfig: () => ({
+        command: 'serve',
+        plugins: [],
+        root,
+        css: { postcss: { plugins: [] } },
+        build: { outDir: 'dist/dev/mp-weixin' },
+      } as unknown as ResolvedConfig),
+      markCssAssetProcessed: vi.fn(),
+      isCssAssetProcessed: vi.fn(() => false),
+      isViteProcessedCssAsset: vi.fn(() => true),
+      recordCssAssetResult: vi.fn(),
+      recordViteProcessedCssAssetResult: vi.fn(),
+      getViteProcessedCssAssetResults: () => [],
+      getViteProcessedCssAssetResult: () => undefined,
+      getSourceCandidates: () => runtimeSet,
+      getSourceCandidatesForEntries: () => runtimeSet,
+      waitForSourceCandidateSyncs: vi.fn(async () => undefined),
+      rememberCssSource: vi.fn(),
+      refreshRememberedCssSource: vi.fn(),
+      getRememberedCssSources: () => rememberedCssSources,
+      getRememberedCssSignature: () => undefined,
+      setRememberedCssSignature: vi.fn(),
+      recordGeneratorCandidates: vi.fn(),
+    })
 
     const processedCss = '.flex{display:flex}'
     const bundle = {
       'pages/index/index.wxss': {
-        ...createRollupAsset(`${createBundlerGeneratedCssMarker('vite', path.resolve(process.cwd(), 'pages/index/index.uvue'))}\n${processedCss}`),
+        ...createRollupAsset(`${createBundlerGeneratedCssMarker('vite', styleId.replace(/[?#].*$/, ''))}\n${processedCss}`),
         fileName: 'pages/index/index.wxss',
+        originalFileNames: [styleId],
       },
     }
 
-    const generateBundle = getGenerateBundleHandler(postPlugin)
-    await generateBundle?.call(postPlugin, {} as any, bundle)
+    await generateBundle.call({ addWatchFile: vi.fn() }, {}, bundle)
 
     const wxss = String((bundle['pages/index/index.wxss'] as OutputAsset).source)
     expect(wxss).toContain('.content{display:flex}')
@@ -3087,10 +3131,12 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
   }, TEST_TIMEOUT_MS)
 
   it('injects replayed main package vite css into app wxss without leaking subpackage css', async () => {
-    const generateMock = vi.fn(async (source: { css: string }) => {
-      const css = source.css.includes('tw-main-watch')
+    const generateCssByGeneratorMock = vi.fn(async (options: {
+      rawSource: string
+    }) => {
+      const css = options.rawSource.includes('tw-main-watch')
         ? '.tw-main-watch{display:block}'
-        : source.css.includes('tw-sub-watch')
+        : options.rawSource.includes('tw-sub-watch')
           ? '.tw-sub-watch{display:block}'
           : ''
       return {
@@ -3105,16 +3151,22 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
         version: 4,
       }
     })
+    vi.resetModules()
+    vi.doMock('@/bundlers/shared/generator-css', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/bundlers/shared/generator-css')>()
+      return {
+        ...actual,
+        generateCssByGenerator: generateCssByGeneratorMock,
+      }
+    })
     vi.doMock('@/generator', async (importOriginal) => {
       const actual = await importOriginal<typeof import('@/generator')>()
       return {
         ...actual,
-        createWeappTailwindcssGenerator: vi.fn((source: { css: string }) => ({
-          generate: vi.fn(async () => generateMock(source)),
-        })),
         normalizeWeappTailwindcssGeneratorOptions: normalizeGeneratorOptions,
       }
     })
+    const { createGenerateBundleHook: createGenerateBundleHookWithMock } = await import('@/bundlers/vite/generate-bundle')
     const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-main-package-replay-'))
     createdDirs.push(root)
     const runtimeSet = new Set(['tw-main-watch', 'tw-sub-watch'])
@@ -3146,7 +3198,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
       }],
     ])
     const viteProcessedCssAssetResults = new Map<string, { css: string, injectIntoMain?: boolean | undefined }>()
-    const generateBundle = createGenerateBundleHook({
+    const generateBundle = createGenerateBundleHookWithMock({
       opts: context as any,
       runtimeState: {
         twPatcher: context.twPatcher as any,
@@ -4761,7 +4813,7 @@ const trace = "at App.vue:4"
       projectRoot: process.cwd(),
       base: process.cwd(),
       baseFallbacks: [],
-      css: '@import "tailwindcss";',
+      css: '@import "tailwindcss" source(none);',
       dependencies: [],
     }))
 
@@ -4843,7 +4895,7 @@ const trace = "at App.vue:4"
       projectRoot: process.cwd(),
       base: process.cwd(),
       baseFallbacks: [],
-      css: '@import "tailwindcss";',
+      css: '@import "tailwindcss" source(none);',
       dependencies: [],
     }))
 
@@ -4928,7 +4980,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5016,7 +5068,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5099,7 +5151,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
       resolveTailwindV4SourceOptionsFromPatcher: vi.fn(() => ({
@@ -5112,7 +5164,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5201,7 +5253,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5295,7 +5347,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5395,7 +5447,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5461,7 +5513,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5534,7 +5586,7 @@ const trace = "at App.vue:4"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
       })),
     }))
@@ -5986,9 +6038,8 @@ const cls = "rounded-[92rpx]"
   }, TEST_TIMEOUT_MS)
 
   it('keeps source-location tokens unchanged in build mode with classNameSet-only strategy', async () => {
-    const WeappTailwindcss = await loadWeappTailwindcssPlugin()
     const runtimeSet = new Set(['text-red-500'])
-    setCurrentContext(createContext({
+    const context = createContext({
       jsHandler: createJsHandler({}),
       twPatcher: {
         patch: vi.fn(),
@@ -5997,27 +6048,47 @@ const cls = "rounded-[92rpx]"
         extract: vi.fn(async () => ({ classSet: runtimeSet })),
         majorVersion: 4,
       },
-    }))
-
-    const plugins = WeappTailwindcss()
-    const postPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:post') as Plugin
-    expect(postPlugin).toBeTruthy()
-
-    await (postPlugin.configResolved as any)?.call(postPlugin, {
-      command: 'build',
-      root: process.cwd(),
-      css: { postcss: { plugins: [] } },
-      build: { outDir: 'dist' },
-    } as ResolvedConfig)
-
-    const generateBundle = getGenerateBundleHandler(postPlugin)
+    })
+    const generateBundle = createGenerateBundleHook({
+      opts: context as any,
+      runtimeState: {
+        twPatcher: context.twPatcher as any,
+        readyPromise: Promise.resolve(),
+      },
+      ensureRuntimeClassSet: vi.fn(async () => runtimeSet),
+      ensureBundleRuntimeClassSet: vi.fn(async () => runtimeSet),
+      debug: vi.fn(),
+      getResolvedConfig: () => ({
+        command: 'build',
+        plugins: [],
+        root: process.cwd(),
+        css: { postcss: { plugins: [] } },
+        build: { outDir: 'dist' },
+      } as unknown as ResolvedConfig),
+      markCssAssetProcessed: vi.fn(),
+      isCssAssetProcessed: vi.fn(() => false),
+      isViteProcessedCssAsset: vi.fn(() => false),
+      recordCssAssetResult: vi.fn(),
+      recordViteProcessedCssAssetResult: vi.fn(),
+      getViteProcessedCssAssetResults: () => [],
+      getViteProcessedCssAssetResult: () => undefined,
+      getSourceCandidates: () => new Set<string>(),
+      getSourceCandidatesForEntries: () => new Set<string>(),
+      waitForSourceCandidateSyncs: vi.fn(async () => undefined),
+      rememberCssSource: vi.fn(),
+      refreshRememberedCssSource: vi.fn(),
+      getRememberedCssSources: () => new Map(),
+      getRememberedCssSignature: () => undefined,
+      setRememberedCssSignature: vi.fn(),
+      recordGeneratorCandidates: vi.fn(),
+    })
     const bundle = {
       'index.js': createRollupChunk(`
 const trace = "at App.vue:4"
 const cls = "w-[1.5px]"
 `),
     }
-    await generateBundle?.call(postPlugin, {} as any, bundle)
+    await generateBundle.call({ addWatchFile: vi.fn() }, {}, bundle)
 
     const transformedCode = (bundle['index.js'] as OutputChunk).code
     expect(transformedCode).toContain('at App.vue:4')
@@ -6399,7 +6470,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6414,7 +6485,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: options.base ?? process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6517,7 +6588,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6526,7 +6597,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6642,7 +6713,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6657,7 +6728,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: options.base ?? process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6804,7 +6875,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -6819,7 +6890,7 @@ const cls = "w-[1.5px]"
         projectRoot: process.cwd(),
         base: options.base ?? process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -7070,7 +7141,7 @@ ${utilities}
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -7079,7 +7150,7 @@ ${utilities}
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: options.css ?? '@import "tailwindcss";',
+        css: options.css ?? '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -7165,8 +7236,10 @@ ${utilities}
   }, TEST_TIMEOUT_MS)
 
   it('refreshes remembered vite pipeline css with equivalent style source requests before replay', async () => {
-    const generateMock = vi.fn(async (source: { css: string }) => {
-      const css = source.css.includes('.tw-watch-style-case')
+    const generateCssByGeneratorMock = vi.fn(async (options: {
+      rawSource: string
+    }) => {
+      const css = options.rawSource.includes('.tw-watch-style-case')
         ? '.tw-watch-style-case{font-weight:700}'
         : '.clean-style{display:block}'
       return {
@@ -7181,18 +7254,25 @@ ${utilities}
         version: 3,
       }
     })
+    vi.resetModules()
+    vi.doMock('@/bundlers/shared/generator-css', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/bundlers/shared/generator-css')>()
+      return {
+        ...actual,
+        generateCssByGenerator: generateCssByGeneratorMock,
+      }
+    })
     vi.doMock('@/generator', async (importOriginal) => {
       const actual = await importOriginal<typeof import('@/generator')>()
       return {
         ...actual,
-        createWeappTailwindcssGenerator: vi.fn((source: { css: string }) => ({
-          generate: vi.fn(async () => generateMock(source)),
-        })),
         normalizeWeappTailwindcssGeneratorOptions: normalizeGeneratorOptions,
       }
     })
-    const WeappTailwindcss = await loadWeappTailwindcssPlugin()
-    setCurrentContext(createContext({
+    const { createGenerateBundleHook: createGenerateBundleHookWithMock } = await import('@/bundlers/vite/generate-bundle')
+    const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-equivalent-style-replay-'))
+    createdDirs.push(root)
+    const context = createContext({
       cssMatcher: (file: string) => file.endsWith('.wxss'),
       mainCssChunkMatcher: vi.fn((file: string) => file === 'app.wxss'),
       twPatcher: {
@@ -7206,49 +7286,57 @@ ${utilities}
           tailwindConfig: { content: [] },
         }]),
       },
-    }))
-    const plugins = WeappTailwindcss()
-    const rewritePlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:rewrite-css-imports') as Plugin
-    const sourcePlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:source-candidates') as Plugin
-    const postPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:post') as Plugin
-    expect(rewritePlugin).toBeTruthy()
-    expect(sourcePlugin).toBeTruthy()
-    expect(postPlugin).toBeTruthy()
-
-    await (postPlugin.configResolved as any)?.call(postPlugin, {
-      command: 'serve',
-      root: process.cwd(),
-      css: { postcss: { plugins: [] } },
-      build: { outDir: 'dist' },
-    } as ResolvedConfig)
-
-    const generateBundle = getGenerateBundleHandler(postPlugin)
-    const transform = getTransformHandler(rewritePlugin)
-    const sourceFile = path.resolve(process.cwd(), 'pages/index/index.vue')
+    })
+    const sourceFile = path.join(root, 'pages/index/index.vue')
     const dirtyStyleRequest = `${sourceFile}?vue&type=style&index=0&lang.scss`
     const cleanStyleRequest = `${sourceFile}?vue&type=style&index=0&lang.scss&used`
     const dirtySource = '.tw-watch-style-case { @apply font-bold; }'
     const cleanSource = '.clean-style { display: block; }'
-    const createViteProcessedCssAsset = (source: string) =>
-      `${createBundlerGeneratedCssMarker('vite', dirtyStyleRequest)}\n${source}`
-
-    await transform?.call(rewritePlugin, dirtySource, dirtyStyleRequest)
-    const firstBundle = {
-      'pages/index/index.wxss': {
-        ...createRollupAsset(createViteProcessedCssAsset(dirtySource)),
-        fileName: 'pages/index/index.wxss',
-        originalFileNames: [dirtyStyleRequest],
+    const rememberedCssSources = new Map([
+      ['pages/index/index.wxss', {
+        outputFile: 'pages/index/index.wxss',
+        rawSource: dirtySource,
+        sourceFile: dirtyStyleRequest,
+      }],
+    ])
+    const refreshRememberedCssSource = vi.fn(async (remembered: { outputFile: string, rawSource: string, sourceFile: string }) => ({
+      ...remembered,
+      rawSource: cleanSource,
+      sourceFile: cleanStyleRequest,
+    }))
+    const generateBundle = createGenerateBundleHookWithMock({
+      opts: context as any,
+      runtimeState: {
+        twPatcher: context.twPatcher as any,
+        readyPromise: Promise.resolve(),
       },
-      'pages/index/index.js': {
-        ...createRollupChunk('console.log("stable")'),
-        fileName: 'pages/index/index.js',
-      },
-    }
-    await generateBundle?.call(postPlugin, {} as any, firstBundle)
-    expect((firstBundle['pages/index/index.wxss'] as OutputAsset).source.toString()).toContain('.tw-watch-style-case')
-
-    const cleanTransformResult = await transform?.call(rewritePlugin, cleanSource, cleanStyleRequest)
-    expect(cleanTransformResult).toBeNull()
+      ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      ensureBundleRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      debug: vi.fn(),
+      getResolvedConfig: () => ({
+        command: 'serve',
+        plugins: [],
+        root,
+        css: { postcss: { plugins: [] } },
+        build: { outDir: 'dist/dev/mp-weixin' },
+      } as unknown as ResolvedConfig),
+      markCssAssetProcessed: vi.fn(),
+      isCssAssetProcessed: vi.fn(() => false),
+      isViteProcessedCssAsset: vi.fn(() => false),
+      recordCssAssetResult: vi.fn(),
+      recordViteProcessedCssAssetResult: vi.fn(),
+      getViteProcessedCssAssetResults: () => [],
+      getViteProcessedCssAssetResult: () => undefined,
+      getSourceCandidates: () => new Set<string>(),
+      getSourceCandidatesForEntries: () => new Set<string>(),
+      waitForSourceCandidateSyncs: vi.fn(async () => undefined),
+      rememberCssSource: vi.fn(),
+      refreshRememberedCssSource,
+      getRememberedCssSources: () => rememberedCssSources,
+      getRememberedCssSignature: () => undefined,
+      setRememberedCssSignature: vi.fn(),
+      recordGeneratorCandidates: vi.fn(),
+    })
 
     const emitted: Array<{ type: 'asset', fileName: string, source: string }> = []
     const replayBundleTarget = {
@@ -7265,8 +7353,8 @@ ${utilities}
         return Reflect.set(target, property, value, receiver)
       },
     })
-    await generateBundle?.call({
-      ...postPlugin,
+    await generateBundle.call({
+      addWatchFile: vi.fn(),
       emitFile(file: { type: 'asset', fileName: string, source: string }) {
         emitted.push(file)
         return file.fileName
@@ -7274,38 +7362,41 @@ ${utilities}
     }, {} as any, replayBundle)
 
     const replayedCss = emitted.find(file => file.fileName === 'pages/index/index.wxss')?.source
+    expect(refreshRememberedCssSource).toHaveBeenCalledTimes(1)
+    expect(generateCssByGeneratorMock).toHaveBeenCalledWith(expect.objectContaining({
+      rawSource: cleanSource,
+      file: cleanStyleRequest,
+    }))
     expect(replayedCss).toContain('.clean-style')
     expect(replayedCss).not.toContain('.tw-watch-style-case')
     expect(replayBundleTarget['pages/index/index.wxss' as keyof typeof replayBundleTarget]).toBeUndefined()
   }, TEST_TIMEOUT_MS)
 
   it('refreshes remembered sfc style source from watch cache before replaying stale vite pipeline css', async () => {
-    const generateMock = vi.fn(async (source: { css: string }) => {
-      const css = source.css.includes('.tw-watch-style-case')
+    const generateCssByGeneratorMock = vi.fn(async (options: {
+      rawSource: string
+    }) => {
+      const css = options.rawSource.includes('.tw-watch-style-case')
         ? '.base-style{display:flex}.tw-watch-style-case{font-weight:700}'
         : '.base-style{display:flex}'
+      return createMockGeneratorCssResult(css)
+    })
+    vi.resetModules()
+    vi.doMock('@/bundlers/shared/generator-css', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/bundlers/shared/generator-css')>()
       return {
-        css,
-        rawCss: css,
-        target: 'weapp',
-        classSet: new Set<string>(),
-        rawCandidates: new Set<string>(),
-        dependencies: [],
-        sources: [],
-        root: null,
-        version: 3,
+        ...actual,
+        generateCssByGenerator: generateCssByGeneratorMock,
       }
     })
     vi.doMock('@/generator', async (importOriginal) => {
       const actual = await importOriginal<typeof import('@/generator')>()
       return {
         ...actual,
-        createWeappTailwindcssGenerator: vi.fn((source: { css: string }) => ({
-          generate: vi.fn(async () => generateMock(source)),
-        })),
         normalizeWeappTailwindcssGeneratorOptions: normalizeGeneratorOptions,
       }
     })
+    const { createGenerateBundleHook: createGenerateBundleHookWithMock } = await import('@/bundlers/vite/generate-bundle')
     const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-sfc-style-refresh-'))
     createdDirs.push(root)
     const pageDir = path.join(root, 'pages/index')
@@ -7314,9 +7405,20 @@ ${utilities}
     const dirtyStyleSource = '.base-style { @apply flex; }\n.tw-watch-style-case { @apply font-bold; }'
     const cleanStyleSource = '.base-style { @apply flex; }'
     await writeFile(sourceFile, `<template><view /></template>\n<style lang="scss">\n${dirtyStyleSource}\n</style>\n`, 'utf8')
-
-    const WeappTailwindcss = await loadWeappTailwindcssPlugin()
-    setCurrentContext(createContext({
+    const styleRequest = `${sourceFile}?vue&type=style&index=0&lang.scss`
+    const rememberedCssSources = new Map([
+      ['pages/index/index.wxss', {
+        outputFile: 'pages/index/index.wxss',
+        rawSource: dirtyStyleSource,
+        sourceFile: styleRequest,
+      }],
+    ])
+    let currentStyleSource = dirtyStyleSource
+    const refreshRememberedCssSource = vi.fn(async (remembered: { outputFile: string, rawSource: string, sourceFile: string }) => ({
+      ...remembered,
+      rawSource: currentStyleSource,
+    }))
+    const context = createContext({
       cssMatcher: (file: string) => file.endsWith('.wxss'),
       mainCssChunkMatcher: vi.fn((file: string) => file === 'app.wxss'),
       twPatcher: {
@@ -7330,29 +7432,44 @@ ${utilities}
           tailwindConfig: { content: [] },
         }]),
       },
-    }))
-    const plugins = WeappTailwindcss()
-    const rewritePlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:rewrite-css-imports') as Plugin
-    const sourcePlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:source-candidates') as Plugin
-    const postPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:post') as Plugin
-    expect(rewritePlugin).toBeTruthy()
-    expect(sourcePlugin).toBeTruthy()
-    expect(postPlugin).toBeTruthy()
-
-    await (postPlugin.configResolved as any)?.call(postPlugin, {
-      command: 'serve',
-      root,
-      css: { postcss: { plugins: [] } },
-      build: { outDir: 'dist' },
-    } as ResolvedConfig)
-
-    const generateBundle = getGenerateBundleHandler(postPlugin)
-    const transform = getTransformHandler(rewritePlugin)
-    const styleRequest = `${sourceFile}?vue&type=style&index=0&lang.scss`
+    })
+    const generateBundle = createGenerateBundleHookWithMock({
+      opts: context as any,
+      runtimeState: {
+        twPatcher: context.twPatcher as any,
+        readyPromise: Promise.resolve(),
+      },
+      ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      ensureBundleRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      debug: vi.fn(),
+      getResolvedConfig: () => ({
+        command: 'serve',
+        plugins: [],
+        root,
+        css: { postcss: { plugins: [] } },
+        build: { outDir: 'dist' },
+      } as unknown as ResolvedConfig),
+      markCssAssetProcessed: vi.fn(),
+      isCssAssetProcessed: vi.fn(() => false),
+      isViteProcessedCssAsset: vi.fn(() => false),
+      recordCssAssetResult: vi.fn(),
+      recordViteProcessedCssAssetResult: vi.fn(),
+      getViteProcessedCssAssetResults: () => [],
+      getViteProcessedCssAssetResult: () => undefined,
+      getSourceCandidates: () => new Set<string>(),
+      getSourceCandidatesForEntries: () => new Set<string>(),
+      waitForSourceCandidateSyncs: vi.fn(async () => undefined),
+      rememberCssSource: vi.fn(),
+      refreshRememberedCssSource,
+      getRememberedCssSources: () => rememberedCssSources,
+      getRememberedCssSignature: () => undefined,
+      setRememberedCssSignature: vi.fn(),
+      getKnownSfcSource: vi.fn(() => `<template><view /></template>\n<style lang="scss">\n${currentStyleSource}\n</style>\n`),
+      recordGeneratorCandidates: vi.fn(),
+    })
     const createViteProcessedCssAsset = (source: string) =>
       `${createBundlerGeneratedCssMarker('vite', styleRequest)}\n${source}`
 
-    await transform?.call(rewritePlugin, dirtyStyleSource, styleRequest)
     const firstBundle = {
       'pages/index/index.wxss': {
         ...createRollupAsset(createViteProcessedCssAsset(dirtyStyleSource)),
@@ -7364,12 +7481,14 @@ ${utilities}
         fileName: 'pages/index/index.js',
       },
     }
-    await generateBundle?.call(postPlugin, {} as any, firstBundle)
+    await generateBundle.call({
+      addWatchFile: vi.fn(),
+    }, {} as any, firstBundle)
     expect((firstBundle['pages/index/index.wxss'] as OutputAsset).source.toString()).toContain('.tw-watch-style-case')
 
     await writeFile(sourceFile, `<template><view /></template>\n<style lang="scss">\n${cleanStyleSource}\n</style>\n`, 'utf8')
-    await (sourcePlugin.watchChange as any)?.call(sourcePlugin, sourceFile, { event: 'update' })
-    generateMock.mockClear()
+    currentStyleSource = cleanStyleSource
+    generateCssByGeneratorMock.mockClear()
     const secondBundle = {
       'pages/index/index.wxss': {
         ...createRollupAsset(createViteProcessedCssAsset(dirtyStyleSource)),
@@ -7381,13 +7500,16 @@ ${utilities}
         fileName: 'pages/index/index.js',
       },
     }
-    await generateBundle?.call(postPlugin, {} as any, secondBundle)
+    await generateBundle.call({
+      addWatchFile: vi.fn(),
+    }, {} as any, secondBundle)
 
     const rolledBackCss = (secondBundle['pages/index/index.wxss'] as OutputAsset).source.toString()
-    expect(generateMock).toHaveBeenCalled()
-    const lastGeneratedSource = generateMock.mock.calls.at(-1)?.[0]
-    expect(lastGeneratedSource.css).toContain('.base-style { @apply flex; }')
-    expect(lastGeneratedSource.css).not.toContain('.tw-watch-style-case')
+    expect(refreshRememberedCssSource).toHaveBeenCalled()
+    expect(generateCssByGeneratorMock).toHaveBeenCalled()
+    const lastGeneratedOptions = generateCssByGeneratorMock.mock.calls.at(-1)?.[0]
+    expect(lastGeneratedOptions.rawSource).toContain('.base-style { @apply flex; }')
+    expect(lastGeneratedOptions.rawSource).not.toContain('.tw-watch-style-case')
     expect(rolledBackCss).toContain('.base-style')
     expect(rolledBackCss).not.toContain('.tw-watch-style-case')
   }, TEST_TIMEOUT_MS)
@@ -7920,7 +8042,7 @@ ${utilities}
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -8024,7 +8146,7 @@ ${utilities}
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),
@@ -8127,7 +8249,7 @@ ${utilities}
         projectRoot: process.cwd(),
         base: process.cwd(),
         baseFallbacks: [],
-        css: '@import "tailwindcss";',
+        css: '@import "tailwindcss" source(none);',
         dependencies: [],
         packageName: 'tailwindcss',
       })),

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.testkit.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.testkit.ts
@@ -6,6 +6,50 @@ import { createCache } from '@/cache'
 export function createContext(overrides: Record<string, unknown> = {}) {
   const cache = createCache()
   const runtimeSet = new Set(['alpha'])
+  const testRoot = '/virtual/weapp-tailwindcss-vite-test'
+  const testTailwindcssOptions = {
+    cwd: testRoot,
+    v4: {
+      cssSources: [
+        {
+          file: `${testRoot}/app.css`,
+          base: testRoot,
+          css: '@import "tailwindcss" source(none);',
+          dependencies: [],
+        },
+      ],
+    },
+  }
+  const defaultTwPatcher = {
+    patch: vi.fn(),
+    getClassSet: vi.fn(async () => runtimeSet),
+    getClassSetSync: vi.fn(() => runtimeSet),
+    majorVersion: 3,
+    extract: vi.fn(async () => ({ classSet: runtimeSet })),
+    options: {
+      projectRoot: testRoot,
+      tailwindcss: testTailwindcssOptions,
+    },
+  }
+  const { twPatcher: overrideTwPatcher, ...restOverrides } = overrides as {
+    twPatcher?: {
+      options?: {
+        tailwindcss?: {
+          v4?: Record<string, unknown>
+        } & Record<string, unknown>
+      } & Record<string, unknown>
+    } & Record<string, unknown>
+  }
+  const mergedTwPatcherOptions = overrideTwPatcher?.options
+    ? overrideTwPatcher.options
+    : defaultTwPatcher.options
+  const mergedTwPatcher = overrideTwPatcher
+    ? {
+        ...defaultTwPatcher,
+        ...overrideTwPatcher,
+        options: mergedTwPatcherOptions,
+      }
+    : defaultTwPatcher
 
   return {
     disabled: false,
@@ -36,19 +80,13 @@ export function createContext(overrides: Record<string, unknown> = {}) {
     htmlMatcher: (file: string) => file.endsWith('.wxml'),
     jsMatcher: (file: string) => file.endsWith('.js'),
     wxsMatcher: () => false,
-    twPatcher: {
-      patch: vi.fn(),
-      getClassSet: vi.fn(async () => runtimeSet),
-      getClassSetSync: vi.fn(() => runtimeSet),
-      majorVersion: 3,
-      extract: vi.fn(async () => ({ classSet: runtimeSet })),
-    },
+    twPatcher: mergedTwPatcher,
     uniAppX: undefined as any,
     runtimeLoaderPath: undefined,
     mainChunkRegex: undefined,
     cssEntries: undefined,
     customReplaceDictionary: undefined,
-    ...overrides,
+    ...restOverrides,
   }
 }
 

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -244,6 +244,29 @@ describe('ci workflows', () => {
     expect(releaseStep.env.NODE_AUTH_TOKEN).toBeUndefined()
   })
 
+  it('keeps release version phase lightweight inside changesets action', () => {
+    const { workflow } = readWorkflow('release.yml')
+    const releaseStep = workflow.jobs.release.steps.find((step: Record<string, unknown>) => {
+      return step.id === 'changesets'
+    })
+    const publishScript = readText('scripts/publish-packages.mjs')
+    const latestScript = publishScript.match(/function publishLatest\(options\) \{\n([\s\S]*?)\n\}/)?.[1] ?? ''
+    const prereleaseScript = publishScript.match(/function publishPrerelease\(tag, options\) \{\n([\s\S]*?)\n\}/)?.[1] ?? ''
+    const latestVersionBranch = latestScript.match(
+      /if \(options\.phase === 'version'\) \{\n([\s\S]*?)\n  \}/,
+    )?.[1] ?? ''
+    const prereleaseVersionBranch = prereleaseScript.match(
+      /if \(options\.phase === 'version'\) \{\n([\s\S]*?)\n    return\n  \}/,
+    )?.[1] ?? ''
+
+    expect(releaseStep.with.version).toBe('pnpm publish-packages -- --phase version')
+    expect(latestVersionBranch).toContain('changeset\', \'version')
+    expect(latestVersionBranch).not.toContain('pnpm\', [\'build')
+    expect(latestVersionBranch).not.toContain('pnpm\', [\'test')
+    expect(prereleaseVersionBranch).toContain('enterPreMode(tag, options)')
+    expect(prereleaseVersionBranch).toContain('changeset\', \'version')
+  })
+
   it('runs current vs published benchmark on every ci/cd trigger', () => {
     const { workflow } = readWorkflow('benchmark.yml')
     const packageJson = readPackageJson<{ scripts: Record<string, string> }>('package.json')
@@ -349,6 +372,10 @@ describe('ci workflows', () => {
 
     expect(ensureScript).toContain('runtimeBuildTargets')
     expect(ensureScript).toContain('collectWorkspaceRuntimeDependencyNames')
+    expect(ensureScript).toContain('\'@weapp-tailwindcss/shared\'')
+    expect(ensureScript).toContain('\'@weapp-tailwindcss/logger\'')
+    expect(ensureScript).toContain('\'@weapp-tailwindcss/postcss-calc\'')
+    expect(ensureScript).toContain('\'@weapp-tailwindcss/reset\'')
     expect(ensureScript).toContain('\'@weapp-tailwindcss/merge-v3\'')
     expect(ensureScript).toContain('\'@weapp-tailwindcss/merge\'')
     expect(ensureScript).toContain('\'@weapp-tailwindcss/cva\'')

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4/patcher.integration.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4/patcher.integration.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { transformLiteralText } from '@/js'
@@ -53,23 +54,41 @@ describe('tailwindcss/v4 patcher integration with @config + cssEntries', () => {
 
   it('falls back to generator source scan when patcher extract returns an empty class set', async () => {
     const workspaceRoot = path.resolve(__dirname, '../../../../..')
-    const fixtureRoot = path.resolve(workspaceRoot, 'demo/gulp-tailwindcss-v4')
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-tw-v4-runtime-fallback-'))
     const cssEntry = path.resolve(fixtureRoot, 'src/app.css')
     const template = path.resolve(fixtureRoot, 'src/pages/index/index.wxml')
-    const original = await fs.readFile(template, 'utf8')
-    const next = original.replace(
-      '</view>',
-      '  <view class="text-[#aa11bb] bg-[#bb11aa]">runtime fallback</view>\n</view>',
-    )
 
     try {
-      await fs.writeFile(template, next, 'utf8')
+      await fs.mkdir(path.dirname(template), { recursive: true })
+      await fs.writeFile(
+        path.resolve(fixtureRoot, 'tailwind.config.js'),
+        [
+          'module.exports = {',
+          '  content: ["./src/**/*.{wxml,html,js,ts}"],',
+          '}',
+        ].join('\n'),
+        'utf8',
+      )
+      await fs.writeFile(
+        cssEntry,
+        [
+          '@config "../tailwind.config.js";',
+          '@import "tailwindcss";',
+          '@source "./pages/**/*.{wxml,html,js,ts}";',
+        ].join('\n'),
+        'utf8',
+      )
+      await fs.writeFile(
+        template,
+        '<view class="text-[#aa11bb] bg-[#bb11aa]">runtime fallback</view>',
+        'utf8',
+      )
       const patcher = createPatcherForBase(fixtureRoot, [cssEntry], {
         tailwindcss: {
-          packageName: 'tailwindcss',
+          packageName: 'tailwindcss4',
           version: 4,
           resolve: {
-            paths: [path.resolve(fixtureRoot, 'node_modules')],
+            paths: [path.resolve(workspaceRoot, 'node_modules')],
           },
         },
         tailwindcssPatcherOptions: undefined,
@@ -94,7 +113,7 @@ describe('tailwindcss/v4 patcher integration with @config + cssEntries', () => {
       expect(classSet.has('bg-[#bb11aa]')).toBe(true)
     }
     finally {
-      await fs.writeFile(template, original, 'utf8')
+      await fs.rm(fixtureRoot, { force: true, recursive: true })
     }
   })
 })

--- a/scripts/ensure-weapp-tailwindcss-built.mjs
+++ b/scripts/ensure-weapp-tailwindcss-built.mjs
@@ -98,12 +98,53 @@ const runtimeBuildTargets = [
 ]
 const buildTargets = [
   {
+    filter: '@weapp-tailwindcss/shared',
+    label: '@weapp-tailwindcss/shared',
+    packageRoot: path.join(repoRoot, 'packages/shared'),
+    stamps: [
+      'dist/index.js',
+      'dist/index.mjs',
+      'dist/node.js',
+      'dist/node.mjs',
+    ],
+  },
+  {
+    filter: '@weapp-tailwindcss/logger',
+    label: '@weapp-tailwindcss/logger',
+    packageRoot: path.join(repoRoot, 'packages/logger'),
+    stamps: [
+      'dist/index.js',
+      'dist/index.mjs',
+      'dist/index.d.ts',
+    ],
+  },
+  {
+    filter: '@weapp-tailwindcss/postcss-calc',
+    label: '@weapp-tailwindcss/postcss-calc',
+    packageRoot: path.join(repoRoot, 'packages/postcss-calc'),
+    stamps: [
+      'dist/index.cjs',
+      'dist/index.mjs',
+      'dist/index.d.ts',
+    ],
+  },
+  {
     filter: 'tailwindcss-config',
     label: 'tailwindcss-config',
     packageRoot: path.join(repoRoot, 'packages/tailwindcss-config'),
     stamps: [
       'dist/index.js',
       'dist/index.cjs',
+      'dist/index.d.ts',
+    ],
+  },
+  {
+    filter: '@weapp-tailwindcss/reset',
+    label: '@weapp-tailwindcss/reset',
+    packageRoot: path.join(repoRoot, 'packages/reset'),
+    stamps: [
+      'dist/index.cjs',
+      'dist/index.mjs',
       'dist/index.d.ts',
     ],
   },


### PR DESCRIPTION
## 目的

#923 已合并后，继续排查到两类会影响流水线收敛的问题：

- 发布流水线的版本阶段需要保持轻量，只做版本文件更新，不重复执行完整构建和测试。
- Vite 打包单测中的部分用例会误入真实 Tailwind 生成和扫描路径，容易造成测试进程长时间高 CPU 且没有输出。

本 PR 只补这部分合并后的测试与流水线稳定性守卫，不改变用户运行时行为。

## 改动内容

- 调整 Vite 打包相关单测，让目标用例直接模拟共享的样式生成入口，避免无关的真实 Tailwind 扫描参与断言。
- 为 Vite 单测上下文补默认的 Tailwind v4 CSS source，默认使用 `source(none)`，减少单测误扫仓库内容的概率。
- 将 Tailwind v4 patcher 集成测试改成临时 fixture，避免写入 demo 源文件，也避免依赖 demo 本地依赖状态。
- 扩展 `ensure-weapp-tailwindcss-built` 的构建目标，确保 Node API demo 在测试前能自动补齐 shared、logger、postcss-calc、reset 等依赖包产物。
- 增加流水线守卫，确认发布版本阶段保持轻量，确认 demo 预构建脚本覆盖新增依赖包。

## 验证结果

本地已执行并通过：

- `pnpm --filter weapp-tailwindcss exec vitest run test/bundlers/vite-plugin.bundle.unit.test.ts test/tailwindcss/v4/patcher.integration.test.ts test/ci/workflows.test.ts --coverage.enabled=false --maxWorkers=1`
- `pnpm --filter @weapp-tailwindcss-example/node-api-core test`

额外分组验证也已通过：

- bundlers 相关单测
- watch/HMR 与 integration 相关用例
- Tailwind v3/v4 关键用例
- JS、context、CI 相关单测

线上检查以本 PR 的 GitHub checks 为准。

## 发布影响

- 不新增 changeset：#923 已包含用户可见修复的中文 changeset，本 PR 仅补测试和流水线稳定性守卫。
- 不需要联动 create-weapp-vite：本 PR 未修改模板、脚手架或对外 API。