### PR TITLE
chore: upgrade core babel dependencies to 8

### DIFF
--- a/.changeset/babel-8-core-upgrade.md
+++ b/.changeset/babel-8-core-upgrade.md
@@ -1,0 +1,6 @@
+---
+"weapp-tailwindcss": major
+"@weapp-tailwindcss/babel": major
+---
+
+升级核心 Babel 解析与遍历依赖到 8.x，并适配 Babel 8 的 ESM-only 与同步 transform API 变化；同时将相关包的 Node.js 支持范围调整为 Babel 8 要求的 `^22.18.0 || >=24.11.0`。

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-plugin"
   ],
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": "^22.18.0 || >=24.11.0"
   },
   "scripts": {
     "build": "cross-env WEAPP_TW_SKIP_INTERACTIVE_TARO_BUILD=1 WEAPP_TW_SKIP_INTERACTIVE_UNI_BUILD=1 turbo run build",
@@ -215,8 +215,8 @@
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.3.0",
-    "@babel/core": "catalog:babelCore7285",
-    "@babel/generator": "~7.29.7",
+    "@babel/core": "catalog:babelCore8",
+    "@babel/generator": "^8.0.0",
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
     "@commitlint/cli": "^21.0.2",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": "^22.18.0 || >=24.11.0"
   },
   "scripts": {
     "dev": "tsdown --watch --sourcemap",
@@ -34,9 +34,9 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@babel/parser": "~7.29.7",
-    "@babel/traverse": "~7.29.7",
-    "@babel/types": "~7.29.7"
+    "@babel/parser": "^8.0.0",
+    "@babel/traverse": "^8.0.0",
+    "@babel/types": "^8.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/babel/test/evaluate.test.ts
+++ b/packages/babel/test/evaluate.test.ts
@@ -1,4 +1,5 @@
-import babel from '@babel/core'
+import type { PluginItem } from '@babel/core'
+import { transformSync } from '@babel/core'
 import fs from 'fs-extra'
 import path from 'pathe'
 
@@ -6,7 +7,7 @@ function getCase(name: string) {
   return fs.readFileSync(path.resolve(import.meta.dirname, './fixtures/evaluate', name), 'utf8')
 }
 
-const plugin: babel.PluginItem = {
+const plugin: PluginItem = {
   visitor: {
     BinaryExpression(path) {
       // 尝试计算二元表达式的常量值
@@ -68,7 +69,7 @@ const plugin: babel.PluginItem = {
 }
 describe('evaluate', () => {
   it('0.js', () => {
-    const res = babel.transform(
+    const res = transformSync(
       getCase('0.js'),
       {
         plugins: [
@@ -82,7 +83,7 @@ describe('evaluate', () => {
   })
 
   it('1.js', () => {
-    const res = babel.transform(
+    const res = transformSync(
       getCase('1.js'),
       {
         plugins: [

--- a/packages/minify-preserve/test/bundler-config.test.ts
+++ b/packages/minify-preserve/test/bundler-config.test.ts
@@ -1,4 +1,5 @@
 import type { PluginObj, PluginPass } from '@babel/core'
+import { transformAsync } from '@babel/core'
 import type { Configuration, Stats } from 'webpack'
 import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
@@ -235,8 +236,6 @@ async function bundleWithSwc(keepFnNames: boolean) {
   return result.code.trim()
 }
 
-const babel = require('@babel/core') as typeof import('@babel/core')
-
 interface ManglePluginOptions {
   keepNames?: boolean
 }
@@ -265,7 +264,7 @@ function babelManglePlugin(): PluginObj<BabelManglePluginState> {
 }
 
 async function bundleWithBabel(keepFnNames: boolean) {
-  const result = await babel.transformAsync(BABEL_SOURCE, {
+  const result = await transformAsync(BABEL_SOURCE, {
     configFile: false,
     babelrc: false,
     sourceType: 'module',

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -166,7 +166,7 @@
     "with-layer.css"
   ],
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": "^22.18.0 || >=24.11.0"
   },
   "scripts": {
     "dev": "tsdown --watch --sourcemap",
@@ -202,9 +202,9 @@
   },
   "dependencies": {
     "@ast-core/escape": "~1.0.1",
-    "@babel/parser": "~7.29.7",
-    "@babel/traverse": "~7.29.7",
-    "@babel/types": "~7.29.7",
+    "@babel/parser": "^8.0.0",
+    "@babel/traverse": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "@vue/compiler-dom": "catalog:vue3",
     "@weapp-core/escape": "~8.0.0",
     "@weapp-tailwindcss/logger": "workspace:*",

--- a/packages/weapp-tailwindcss/test/js/babel-utils.test.ts
+++ b/packages/weapp-tailwindcss/test/js/babel-utils.test.ts
@@ -1,8 +1,7 @@
 import type { NodePath } from '@babel/traverse'
 import type { CallExpression } from '@babel/types'
-import * as parser from '@babel/parser'
 import { MappingChars2String } from '@weapp-core/escape'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { parse, traverse } from '@/babel'
 import * as babel from '@/js/babel'
 
@@ -14,13 +13,12 @@ describe('babel helpers additional coverage', () => {
 
   it('memoises parsed ASTs when parser caching is enabled', () => {
     const code = 'const value = 1'
-    const spy = vi.spyOn(parser, 'parse')
     const parserOptions = { sourceType: 'module' as const, cache: true }
     const first = babel.babelParse(code, parserOptions)
     const second = babel.babelParse(code, parserOptions)
 
-    expect(spy).toHaveBeenCalledTimes(1)
     expect(second).toBe(first)
+    expect(babel.parseCache.size).toBe(1)
   })
 
   it('uses hashed parser cache keys instead of retaining source text in keys', () => {
@@ -33,7 +31,6 @@ describe('babel helpers additional coverage', () => {
 
   it('skips parser caching for sources over the configured source length limit', () => {
     const code = 'const value = "text-red-500"'
-    const spy = vi.spyOn(parser, 'parse')
     const first = babel.babelParse(code, {
       sourceType: 'module' as const,
       cache: true,
@@ -45,14 +42,11 @@ describe('babel helpers additional coverage', () => {
       cacheMaxSourceLength: code.length - 1,
     })
 
-    expect(spy).toHaveBeenCalledTimes(2)
     expect(second).not.toBe(first)
     expect(babel.parseCache.size).toBe(0)
   })
 
   it('trims parser cache entries to the configured entry limit', () => {
-    const spy = vi.spyOn(parser, 'parse')
-
     const first = babel.babelParse('const first = 1', {
       sourceType: 'module' as const,
       cache: true,
@@ -69,7 +63,6 @@ describe('babel helpers additional coverage', () => {
       cacheMaxEntries: 1,
     })
 
-    expect(spy).toHaveBeenCalledTimes(3)
     expect(second).not.toBe(first)
     expect(third).not.toBe(first)
     expect(babel.parseCache.size).toBe(1)
@@ -77,11 +70,9 @@ describe('babel helpers additional coverage', () => {
 
   it('does not retain parsed ASTs when parser caching is disabled', () => {
     const code = 'const value = 1'
-    const spy = vi.spyOn(parser, 'parse')
     const first = babel.babelParse(code, { sourceType: 'module' as const, cache: false })
     const second = babel.babelParse(code, { sourceType: 'module' as const, cache: false })
 
-    expect(spy).toHaveBeenCalledTimes(2)
     expect(second).not.toBe(first)
     expect(babel.parseCache.size).toBe(0)
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,10 @@ catalogs:
     '@babel/core':
       specifier: ^7.29.7
       version: 7.29.7
+  babelCore8:
+    '@babel/core':
+      specifier: ^8.0.1
+      version: 8.0.1
   babelPresetReact7285:
     '@babel/preset-react':
       specifier: ^7.29.7
@@ -416,11 +420,11 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       '@babel/core':
-        specifier: catalog:babelCore7285
-        version: 7.29.7
+        specifier: catalog:babelCore8
+        version: 8.0.1
       '@babel/generator':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@changesets/changelog-github':
         specifier: ^0.7.0
         version: 0.7.0(encoding@0.1.13)
@@ -597,7 +601,7 @@ importers:
         version: 10.5.0(postcss@8.5.15)
       babel-loader:
         specifier: ^10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
+        version: 10.1.1(@babel/core@8.0.1)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1286,13 +1290,13 @@ importers:
     dependencies:
       '@mpxjs/api-proxy':
         specifier: ^2.10.21
-        version: 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+        version: 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
       '@mpxjs/core':
         specifier: ^2.10.24
-        version: 2.10.24(1c28718c96822fb4f4aaf85760dedccb)
+        version: 2.10.24(943114438cafe5180199c21b882cb5f0)
       '@mpxjs/fetch':
         specifier: ^2.10.21
-        version: 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+        version: 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
       '@mpxjs/pinia':
         specifier: ^2.10.22
         version: 2.10.22(@mpxjs/core@2.10.24)(pinia@2.3.1(typescript@6.0.3)(vue@2.7.16))(vue-demi@0.14.10(vue@2.7.16))(vue@2.7.16)
@@ -1329,10 +1333,10 @@ importers:
     devDependencies:
       '@babel/plugin-transform-runtime':
         specifier: ^7.29.7
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@8.0.1)
       '@babel/preset-env':
         specifier: ^7.29.7
-        version: 7.29.7(@babel/core@7.29.7)
+        version: 7.29.7(@babel/core@8.0.1)
       '@babel/runtime-corejs3':
         specifier: ^7.29.7
         version: 7.29.7
@@ -2474,13 +2478,13 @@ importers:
         version: 4.4.2
       '@react-native-picker/picker':
         specifier: catalog:reactNativePicker261
-        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
         version: 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(6803607e3408dbbf1a5404a7e639b413)
+        version: 4.2.0(5d19abdb0cedecd019055f97364ca9b0)
       '@tarojs/plugin-platform-harmony-hybrid':
         specifier: catalog:taro4
         version: 4.2.0(@babel/core@7.29.7)(@swc/helpers@0.5.19)(@tarojs/taro@4.2.0(0b217e27bdf5fc98ed45c080699d2a21))(@types/react@19.2.17)(debug@4.4.3)(html-webpack-plugin@5.6.7(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(postcss@8.5.15)(rollup@3.30.0)(solid-js@1.9.10)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -2495,7 +2499,7 @@ importers:
         version: 4.2.0
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(b5ce5906df051a853d1ae548402886da)
+        version: 4.2.0(cb1511c2bff512ce7b248f11fd1dedcd)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.0
@@ -2504,7 +2508,7 @@ importers:
         version: 4.2.0(0b217e27bdf5fc98ed45c080699d2a21)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(e2eee54289cde632d8e6d7ecd8dbecd9)
+        version: 4.2.0(b49a683095d54d19e88acf05a985216b)
       antd-mobile:
         specifier: ^5.42.3
         version: 5.42.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2513,7 +2517,7 @@ importers:
         version: 2.5.1
       expo:
         specifier: catalog:expo50
-        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -2522,28 +2526,28 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-native:
         specifier: catalog:reactNative073
-        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-device-info:
         specifier: catalog:reactNativeDeviceInfo14
-        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
       react-native-gesture-handler:
         specifier: catalog:reactNativeGestureHandler214
-        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-pager-view:
         specifier: catalog:reactNativePagerView623
-        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-root-siblings:
         specifier: catalog:reactNativeRootSiblings5
         version: 5.0.1
       react-native-screens:
         specifier: catalog:reactNativeScreens329
-        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-svg:
         specifier: catalog:reactNativeSvg141
-        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-webview:
         specifier: catalog:reactNativeWebview136
-        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       taro-hooks:
         specifier: 2.2.0
         version: 2.2.0(@tarojs/taro-h5@4.2.0(@tarojs/components@4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(@tarojs/taro@4.2.0(0b217e27bdf5fc98ed45c080699d2a21)))(@tarojs/taro@4.2.0(0b217e27bdf5fc98ed45c080699d2a21))
@@ -2559,7 +2563,7 @@ importers:
         version: 0.6.2(@types/webpack@5.28.5(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@react-native/metro-config':
         specifier: catalog:reactNativeMetroConfig073
-        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       '@tarojs/cli':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(@types/node@25.9.3)(debug@4.4.3)
@@ -2574,10 +2578,10 @@ importers:
         version: 4.2.0(@tarojs/service@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.0(7f0aad7e35133c4825099b944cf92217)
+        version: 4.2.0(fe45314d9f8100a219923db20b5c08db)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.0(1d3ca1f77c2c55ce3e9bf3db252933f8)
+        version: 4.2.0(03579dbe1158965bf8c74103816c7bb3)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -2610,7 +2614,7 @@ importers:
         version: 1.13.8
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(e2eee54289cde632d8e6d7ecd8dbecd9))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
+        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
       create-functional-loader:
         specifier: ^0.1.4
         version: 0.1.4
@@ -2694,13 +2698,13 @@ importers:
         version: 4.4.2
       '@react-native-picker/picker':
         specifier: catalog:reactNativePicker261
-        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
         version: 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(01e3613fcfd3dc8d10a39ce95a709b5e)
+        version: 4.2.0(f596fa1c086a07bd829d944f980b353c)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)
@@ -2745,7 +2749,7 @@ importers:
         version: 4.2.0
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(8fd588555cd6cf0b65d4ad6cbf334e96)
+        version: 4.2.0(9fecfe1428b37a46dcdd1c048606c7be)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.0
@@ -2754,10 +2758,10 @@ importers:
         version: 4.2.0(@tarojs/components@4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(c1dd6512e74c927e0feb00cd304be06f)
+        version: 4.2.0(a42b1aa98d4cd7caaca566459cf5855d)
       expo:
         specifier: catalog:expo50
-        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -2766,28 +2770,28 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-native:
         specifier: catalog:reactNative073
-        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-device-info:
         specifier: catalog:reactNativeDeviceInfo14
-        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
       react-native-gesture-handler:
         specifier: catalog:reactNativeGestureHandler214
-        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-pager-view:
         specifier: catalog:reactNativePagerView623
-        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-root-siblings:
         specifier: catalog:reactNativeRootSiblings5
         version: 5.0.1
       react-native-screens:
         specifier: catalog:reactNativeScreens329
-        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-svg:
         specifier: catalog:reactNativeSvg141
-        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-webview:
         specifier: catalog:reactNativeWebview136
-        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@babel/core':
         specifier: catalog:babelCore7285
@@ -2803,16 +2807,16 @@ importers:
         version: 0.6.2(@types/webpack@5.28.5(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       '@react-native/metro-config':
         specifier: catalog:reactNativeMetroConfig073
-        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       '@tarojs/cli':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(@types/node@24.13.2)(debug@4.4.3)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.0(cf87f2eaad1e013c79aebf03eed5b4fb)
+        version: 4.2.0(2d70dadc451ebdff11a7f444e36f8275)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.0(1d99dd92e5d7a9dcb1d2231b8060c1c5)
+        version: 4.2.0(9f23edbaa304bf6a12500d33cca0180c)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
@@ -2836,7 +2840,7 @@ importers:
         version: link:../../packages-runtime/variants
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
+        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
       eslint:
         specifier: catalog:eslint10
         version: 10.5.0(jiti@2.7.0)
@@ -2893,13 +2897,13 @@ importers:
         version: 4.4.2
       '@react-native-picker/picker':
         specifier: catalog:reactNativePicker261
-        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
         version: 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(6803607e3408dbbf1a5404a7e639b413)
+        version: 4.2.0(5d19abdb0cedecd019055f97364ca9b0)
       '@tarojs/plugin-framework-vue3':
         specifier: catalog:taro4
         version: 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@tarojs/runner-utils@4.2.0(@swc/helpers@0.5.19))(@tarojs/runtime@4.2.0)(@tarojs/shared@4.2.0)(@vitejs/plugin-vue-jsx@3.1.0(vite@4.5.14(@types/node@25.9.3)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(stylus@0.63.0)(terser@5.48.0))(vue@3.5.38(typescript@6.0.3)))(@vitejs/plugin-vue@4.6.2(vite@4.5.14(@types/node@25.9.3)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(stylus@0.63.0)(terser@5.48.0))(vue@3.5.38(typescript@6.0.3)))(vite@4.5.14(@types/node@25.9.3)(less@4.6.6)(lightningcss@1.32.0)(sass@1.101.0)(stylus@0.63.0)(terser@5.48.0))(vue-loader@17.4.2(@vue/compiler-sfc@3.5.38)(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -2914,7 +2918,7 @@ importers:
         version: 4.2.0
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(b5ce5906df051a853d1ae548402886da)
+        version: 4.2.0(cb1511c2bff512ce7b248f11fd1dedcd)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.0
@@ -2923,10 +2927,10 @@ importers:
         version: 4.2.0(0b217e27bdf5fc98ed45c080699d2a21)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(e2eee54289cde632d8e6d7ecd8dbecd9)
+        version: 4.2.0(b49a683095d54d19e88acf05a985216b)
       expo:
         specifier: catalog:expo50
-        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -2935,28 +2939,28 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-native:
         specifier: catalog:reactNative073
-        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-device-info:
         specifier: catalog:reactNativeDeviceInfo14
-        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
       react-native-gesture-handler:
         specifier: catalog:reactNativeGestureHandler214
-        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-pager-view:
         specifier: catalog:reactNativePagerView623
-        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-root-siblings:
         specifier: catalog:reactNativeRootSiblings5
         version: 5.0.1
       react-native-screens:
         specifier: catalog:reactNativeScreens329
-        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-svg:
         specifier: catalog:reactNativeSvg141
-        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-webview:
         specifier: catalog:reactNativeWebview136
-        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       vue:
         specifier: catalog:vue3
         version: 3.5.38(typescript@6.0.3)
@@ -2972,7 +2976,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@react-native/metro-config':
         specifier: catalog:reactNativeMetroConfig073
-        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       '@tarojs/cli':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(@types/node@25.9.3)(debug@4.4.3)
@@ -2984,10 +2988,10 @@ importers:
         version: 4.2.0(@tarojs/service@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.0(2eabfd8e94e725d09fb5ac3484257417)
+        version: 4.2.0(d477c65f58c9794e581f6aa6353a13f4)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.0(1d3ca1f77c2c55ce3e9bf3db252933f8)
+        version: 4.2.0(03579dbe1158965bf8c74103816c7bb3)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -3032,7 +3036,7 @@ importers:
         version: 1.13.8
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(e2eee54289cde632d8e6d7ecd8dbecd9))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
+        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
       create-functional-loader:
         specifier: ^0.1.4
         version: 0.1.4
@@ -3116,13 +3120,13 @@ importers:
         version: 4.4.2
       '@react-native-picker/picker':
         specifier: catalog:reactNativePicker261
-        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
         version: 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(01e3613fcfd3dc8d10a39ce95a709b5e)
+        version: 4.2.0(f596fa1c086a07bd829d944f980b353c)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)
@@ -3164,7 +3168,7 @@ importers:
         version: 4.2.0
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(8fd588555cd6cf0b65d4ad6cbf334e96)
+        version: 4.2.0(9fecfe1428b37a46dcdd1c048606c7be)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.0
@@ -3173,10 +3177,10 @@ importers:
         version: 4.2.0(@tarojs/components@4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.0(c1dd6512e74c927e0feb00cd304be06f)
+        version: 4.2.0(a42b1aa98d4cd7caaca566459cf5855d)
       expo:
         specifier: catalog:expo50
-        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -3185,28 +3189,28 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-native:
         specifier: catalog:reactNative073
-        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+        version: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-device-info:
         specifier: catalog:reactNativeDeviceInfo14
-        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+        version: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
       react-native-gesture-handler:
         specifier: catalog:reactNativeGestureHandler214
-        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-pager-view:
         specifier: catalog:reactNativePagerView623
-        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-root-siblings:
         specifier: catalog:reactNativeRootSiblings5
         version: 5.0.1
       react-native-screens:
         specifier: catalog:reactNativeScreens329
-        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-svg:
         specifier: catalog:reactNativeSvg141
-        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-webview:
         specifier: catalog:reactNativeWebview136
-        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       vue:
         specifier: catalog:vue3
         version: 3.5.38(typescript@6.0.3)
@@ -3222,16 +3226,16 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@react-native/metro-config':
         specifier: catalog:reactNativeMetroConfig073
-        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+        version: 0.73.5(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       '@tarojs/cli':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(@types/node@24.13.2)(debug@4.4.3)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.0(96f3cee50afd4140743c19fb1b0f85df)
+        version: 4.2.0(27f7ef473c1321482f55865b541990cb)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.0(1d99dd92e5d7a9dcb1d2231b8060c1c5)
+        version: 4.2.0(9f23edbaa304bf6a12500d33cca0180c)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.0(@swc/helpers@0.5.19)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
@@ -3267,7 +3271,7 @@ importers:
         version: link:../../packages-runtime/variants
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
+        version: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
       eslint:
         specifier: catalog:eslint10
         version: 10.5.0(jiti@2.7.0)
@@ -4254,14 +4258,14 @@ importers:
   packages/babel:
     dependencies:
       '@babel/parser':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/traverse':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/types':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
 
   packages/build-all:
     dependencies:
@@ -4573,14 +4577,14 @@ importers:
         specifier: ~1.0.1
         version: 1.0.1
       '@babel/parser':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/traverse':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/types':
-        specifier: ~7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@vue/compiler-dom':
         specifier: catalog:vue3
         version: 3.5.38
@@ -5111,13 +5115,13 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/compat-data@7.29.3':
     resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
@@ -5127,6 +5131,10 @@ packages:
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@8.0.0':
+    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/core@7.25.2':
     resolution: {integrity: sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==}
     engines: {node: '>=6.9.0'}
@@ -5134,6 +5142,10 @@ packages:
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/core@8.0.1':
+    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/eslint-parser@7.28.5':
     resolution: {integrity: sha512-fcdRcWahONYo+JRnJg1/AekOacGvKx12Gu0qXJXFi2WBqQA1i7+O5PaxRB7kxE/Op94dExnCiiar6T09pvdHpA==}
@@ -5146,17 +5158,13 @@ packages:
     resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/generator@8.0.0-rc.6':
     resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
@@ -5170,6 +5178,10 @@ packages:
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@8.0.0':
+    resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
@@ -5177,6 +5189,10 @@ packages:
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@8.0.0':
+    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-create-class-features-plugin@7.28.6':
     resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
@@ -5190,11 +5206,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5':
-    resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
-    engines: {node: '>=6.9.0'}
+  '@babel/helper-create-class-features-plugin@8.0.1':
+    resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^8.0.0
 
   '@babel/helper-create-regexp-features-plugin@7.29.7':
     resolution: {integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==}
@@ -5202,27 +5218,34 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-define-polyfill-provider@0.6.5':
-    resolution: {integrity: sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==}
+  '@babel/helper-create-regexp-features-plugin@8.0.1':
+    resolution: {integrity: sha512-PydTbcVTiIfVweHMeY1u3MslaD/ZzvnaTNhJp+7ghofelLWshF66Ckc/ZsjStfvRQIKQ4uVG0yEJucyDtyrWgw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^8.0.0
 
   '@babel/helper-define-polyfill-provider@0.6.6':
     resolution: {integrity: sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  '@babel/helper-define-polyfill-provider@1.0.0':
+    resolution: {integrity: sha512-9jzVaTeZyXRDKTgUnNzcPQMO8y0ga3o+Z4fKjNet9Fcx7slgKa83qRbz0EwROSd6qO6CoEe/HQszqSPKb5lhkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0
+
   '@babel/helper-environment-visitor@7.24.7':
     resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
@@ -5231,6 +5254,10 @@ packages:
   '@babel/helper-member-expression-to-functions@7.29.7':
     resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-imports@7.18.6':
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -5244,11 +5271,21 @@ packages:
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@8.0.0':
+    resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@8.0.1':
+    resolution: {integrity: sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
@@ -5258,15 +5295,31 @@ packages:
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-optimise-call-expression@8.0.0':
+    resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@8.0.1':
+    resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-remap-async-to-generator@7.29.7':
     resolution: {integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-remap-async-to-generator@8.0.1':
+    resolution: {integrity: sha512-baAKuLEMmu6BCSY3tuiU7qglM1qOZt6F1SrFScA241oNqksxkxfEZEKztlGRmoVns9AQ5UgArH7RsUEjxWnzgQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-replace-supers@7.28.6':
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
@@ -5280,6 +5333,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-replace-supers@8.0.1':
+    resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
@@ -5287,6 +5346,10 @@ packages:
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -5296,8 +5359,8 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0-rc.6':
-    resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -5308,6 +5371,10 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@8.0.0':
+    resolution: {integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@8.0.0-rc.6':
     resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -5316,13 +5383,25 @@ packages:
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-wrap-function@7.29.7':
     resolution: {integrity: sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-wrap-function@8.0.0':
+    resolution: {integrity: sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/highlight@7.25.9':
     resolution: {integrity: sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==}
@@ -5343,6 +5422,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@8.0.0':
+    resolution: {integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
   '@babel/parser@8.0.0-rc.6':
     resolution: {integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -5354,11 +5438,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@8.0.1':
+    resolution: {integrity: sha512-Ytgjjne4RnG3Oig7ik+NfY4ebRY30BPptVkkyu1f72eINJXRM3/bkU++tIc5aPvyLmo4KH20avq0xJ2o+9aEnw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7':
     resolution: {integrity: sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@8.0.1':
+    resolution: {integrity: sha512-X7pAMBhuKluA7UfwZNvKN0XVVu/AGeo84Z75eJl85rcb8J2aBzLK92btahM1X5h0oi0QIrbe0qIMA/0+4Buk7w==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7':
     resolution: {integrity: sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==}
@@ -5366,11 +5462,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@8.0.1':
+    resolution: {integrity: sha512-DJviKTxYfH0hFwnMiW4dnPyMGzS3Hrr4zUfXl1zwQ0QiGlGlNYklLoPSYEQr8S7nau0/K7NdQjTh0qbYuyFjCA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7':
     resolution: {integrity: sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@8.0.1':
+    resolution: {integrity: sha512-DmR/N+B9+4PbURFj4+zdnWj49/PFAnK2bn8+E4ZAmwn3J5QCxnbG7Ep6aRfz9M8Aw+rBro0kIJQycvzFpl4buQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7':
     resolution: {integrity: sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==}
@@ -5378,11 +5486,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.13.0
 
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@8.0.1':
+    resolution: {integrity: sha512-x8bi0LFVD2xkULjfNn+hCMg16yAFHAM9fS/ThSFeYBi+0MP9K6qcY2BZb4urUwC7PYtEy5wPe6TKjOEjXrCGFA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7':
     resolution: {integrity: sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@8.0.1':
+    resolution: {integrity: sha512-P8+RN2n7ts2s1vnE+lXdHYf+dhnmcGSen/kWzBsVluT9Sey5AqmcRXYWlHqgQxaNlKTD5YMa1tf5z4d1v8W88w==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-proposal-async-generator-functions@7.20.7':
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -5523,12 +5643,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-jsx@7.28.6':
-    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-jsx@7.29.7':
     resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
     engines: {node: '>=6.9.0'}
@@ -5601,11 +5715,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-arrow-functions@8.0.1':
+    resolution: {integrity: sha512-o/gr7kRlq3PKLLuYth4udOsrC7geBerti+QtwPeyxMOsEQO1d8kDHqk9r2PtMx2y9i8FG7tzyTerfv1yMLSMsQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-async-generator-functions@7.29.7':
     resolution: {integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-async-generator-functions@8.0.1':
+    resolution: {integrity: sha512-kqnSMF1YHBzuiQrl68675i5Ma1oljvo+SJsNEZFZVBu5BUrVIZm9KId3ui2PdtLK2sv2zM8sJnjPDfgLxQlEqQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-async-to-generator@7.29.7':
     resolution: {integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==}
@@ -5613,11 +5739,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-async-to-generator@8.0.1':
+    resolution: {integrity: sha512-e1jmmEU4p2Lx64sA1+EF8e8/RxPuegzbXcEbmFp5alDyLE+f2ViUpZ77bRWMXzihTwgVVmn/TOpqDbAuS5g1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-block-scoped-functions@7.29.7':
     resolution: {integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-block-scoped-functions@8.0.1':
+    resolution: {integrity: sha512-0V97/gcf7LIgPieEiK1YT0eXa18XJFSLOTZjzEZhA9SJIqZhD/IwGUrCitBzXSmnGCP7hchwC6svHtJ/Eidcpg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-block-scoping@7.29.7':
     resolution: {integrity: sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==}
@@ -5625,11 +5763,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-block-scoping@8.0.1':
+    resolution: {integrity: sha512-HxiQvKsSCs2jOmMhjDrooHaZYOy6W8bqwXp/zjdgPjsNrda6tK9/CH3a/cVIeg6ge3hSS02ALqvqgIo4rTsuSg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-class-properties@7.29.7':
     resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@8.0.1':
+    resolution: {integrity: sha512-tORnYiVhIHnKj90TgbSZXrO24f9oEpA6MgFxpIDSKKlHv7AzBIRhkMlYevanueLNYaQXqZWarfCgXM4bWTfNiw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-class-static-block@7.29.7':
     resolution: {integrity: sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==}
@@ -5637,11 +5787,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
 
+  '@babel/plugin-transform-class-static-block@8.0.1':
+    resolution: {integrity: sha512-NEVK+L0Le8h8tJ+IK0CGS5y9Yi1ZHxLj6M5PeanhMFuq9aSo0XI+Wtmbuyop6fTNukOm7ORNntf/kwid891vqQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-classes@7.29.7':
     resolution: {integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-classes@8.0.1':
+    resolution: {integrity: sha512-phwyCES8kIMAdVOFw25ztmgAvkl2G+TvUv7azUYyrlR1Qoo3eLJC/MU3MGUKFZ4BWtsJ1NTJM1lKRLzKbswg7w==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-computed-properties@7.29.7':
     resolution: {integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==}
@@ -5649,11 +5811,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-computed-properties@8.0.1':
+    resolution: {integrity: sha512-i4l3OGLO8DUDcwdnyraOvILbhqdUf4QgfzhVxSOSzRy49XKXrY7pwaSg9gDSKmhZfNPrEMciBSJSciQh/CjB1A==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-destructuring@7.29.7':
     resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-destructuring@8.0.1':
+    resolution: {integrity: sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-dotall-regex@7.29.7':
     resolution: {integrity: sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==}
@@ -5661,11 +5835,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-dotall-regex@8.0.1':
+    resolution: {integrity: sha512-czOUoSaZljJ92yu+bYlXqb/UBN8K9daNCob/B6/7nthSvfGP6YhCnfqD64XWfyb2dN4ypxALNplApoJrsMd4fw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-duplicate-keys@7.29.7':
     resolution: {integrity: sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-duplicate-keys@8.0.1':
+    resolution: {integrity: sha512-kNnVLkxFUEcTtCyB5PFVQ5Xoy88Bk1lU/ZgDu97CW8eNhRH2Wsiy8Sq5l5dFnwtIUYjzsXHU77jUy1W5AtGSIw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7':
     resolution: {integrity: sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==}
@@ -5673,11 +5859,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@8.0.1':
+    resolution: {integrity: sha512-Tv43P47o6fuHgBL7HLHQg3WKXohW9CEUGjLtnCDW27yJLK0zKUdTTqREbZbycNHA83hewMjde5tF6ekrHu9bAA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-dynamic-import@7.29.7':
     resolution: {integrity: sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-dynamic-import@8.0.1':
+    resolution: {integrity: sha512-AS9GlgKc43tJNRu7yOvLaTko4qmdOb+8M69uNS8i421WLO20eVez7LdG5khKdi8E0LIQpYzzzdGIrdXWnO753g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-explicit-resource-management@7.29.7':
     resolution: {integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==}
@@ -5685,17 +5883,35 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-explicit-resource-management@8.0.1':
+    resolution: {integrity: sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-exponentiation-operator@7.29.7':
     resolution: {integrity: sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-exponentiation-operator@8.0.1':
+    resolution: {integrity: sha512-DsZvUUklUmDQ7d2vp+VjqgUWD51mGxhZZ1FPdPP9Hcj0vsgGUKX+zEBGp/vzB1O5PZUxWT/Euq5fu39M9dm9wg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-export-namespace-from@7.29.7':
     resolution: {integrity: sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-export-namespace-from@8.0.1':
+    resolution: {integrity: sha512-bFzznm46bvWGaTYKle3iolbBJ+oPBfUjwCPesxlFE3SQ7DaY9EHf/8Y5ZzrodKJi8JDdcAyaVWaDUSVyhULh0g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-flow-strip-types@7.29.7':
     resolution: {integrity: sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==}
@@ -5709,11 +5925,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-for-of@8.0.1':
+    resolution: {integrity: sha512-rpeXtgELjpIBQH/+YmyFlD9timPEVCyqY+TNednzoeoTYvXSBEeUvYnYE+BK8rB8m6hHiNK7aL9QWKhGifEJCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-function-name@7.29.7':
     resolution: {integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-function-name@8.0.1':
+    resolution: {integrity: sha512-H1L/JfPf3CqmubuaiZaquXKQ8MRs4YWSsgRllkTviM8TafcCNnlvc4/fJZ3rXP8HmFM+/Bg+TlsPehUI9BtDFA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-json-strings@7.29.7':
     resolution: {integrity: sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==}
@@ -5721,11 +5949,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-json-strings@8.0.1':
+    resolution: {integrity: sha512-Mowp8X0J6p7ZehLU82B5e65te2uuSeDHyxrEROwEAS2VKXNXssfw5ZMqhY7k9iXTsOv1Xs/49G3lDCj9Vvw8qQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-literals@7.29.7':
     resolution: {integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-literals@8.0.1':
+    resolution: {integrity: sha512-ai7kfPRcfyUV1EszXoF1PvL3IuJoCuH08WSEPoRcJTWfZZ55VL/rcfvbVY16QLA3jjbzzSneQSoCtD3L6OyUjw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-logical-assignment-operators@7.29.7':
     resolution: {integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==}
@@ -5733,11 +5973,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-logical-assignment-operators@8.0.1':
+    resolution: {integrity: sha512-Emvtr5zkEGyCNAmt+qKD5EUh8G0RbxV9EZWrDdX0LuVy5tBq1B3fOIslvVF9aCJmpnwS/AvAT53b9LxAZyXlng==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-member-expression-literals@7.29.7':
     resolution: {integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-member-expression-literals@8.0.1':
+    resolution: {integrity: sha512-3Axi9abnyGsm/hh6DsKPZ1Cr9fTtKqS7w0Ig5g12mU269YclpH8pV3xMln2vPLexXgUp6S6L+I06d9/YOLfRKA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-modules-amd@7.29.7':
     resolution: {integrity: sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==}
@@ -5745,11 +5997,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-modules-amd@8.0.1':
+    resolution: {integrity: sha512-FDdhET8y1YFDNRuoynqSf23WTzbBBpbIB2oRrlFX7YYm9uWtFvJDSD1r/epBSjfPkOjeaaLgRW9xNnt3JGx46A==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-modules-commonjs@7.29.7':
     resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@8.0.1':
+    resolution: {integrity: sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-modules-systemjs@7.29.7':
     resolution: {integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==}
@@ -5757,11 +6021,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-modules-systemjs@8.0.1':
+    resolution: {integrity: sha512-0NEHanXmnFEnfT2dLKTXnu7m8GXFsnxRgteBC2aH21hYMBwAgxu5dcTdi/Eg+ToI1HbZe0CHwz4XRLgRNQhYoQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-modules-umd@7.29.7':
     resolution: {integrity: sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-umd@8.0.1':
+    resolution: {integrity: sha512-XKTa2J2MdkmbVEeChq9f7Or0VYcsF0NyVBgytRyeN9F+J+ETAB2SHhfkG4toz/ssuU0i+h/QgJ6ddo5YakSQcA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
     resolution: {integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==}
@@ -5769,11 +6045,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-transform-named-capturing-groups-regex@8.0.1':
+    resolution: {integrity: sha512-zCHu+Jr2gTdJE48lN9SV/kXueCW2M79mKtKJc/ttfzzr/jvgdQdCd17RADMqFRQc/25MLxdtjTmlD0HSAMOlIQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-new-target@7.29.7':
     resolution: {integrity: sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-new-target@8.0.1':
+    resolution: {integrity: sha512-QSQxVg1x4PuOuhWUs4Y9u+x9Y+ER8z6G3tC+bDLBzvoOrNLJrEBQLRnwrTP8e5klihAw6Z+e9X5RjdAKcAGapA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
     resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
@@ -5781,11 +6069,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-nullish-coalescing-operator@8.0.1':
+    resolution: {integrity: sha512-AgCJAmQLF7+PtsK79wJqr4xJ2StHCXlz7JL5CVFP4HejJx25Tk6yl1ZrXvi0cKh3VGDVnfVxefxnrpsBirgpyQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-numeric-separator@7.29.7':
     resolution: {integrity: sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-numeric-separator@8.0.1':
+    resolution: {integrity: sha512-it2DmUyLIA1GQUXlFDEnI+/G89mTgxndnAiZYpW8xYR6LboblfirMqiWJeTna5uypQJg7viTT4D1iEURRtFcfw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-object-rest-spread@7.29.7':
     resolution: {integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==}
@@ -5793,11 +6093,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-object-rest-spread@8.0.1':
+    resolution: {integrity: sha512-VmxkDu6bBdbxRzqn6E93hYucug4OVa6svSO19W//vVzNUGAmQzk3QRyHyyEtfcjSLR3NWfRsWwVM9zExLmd+2w==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-object-super@7.29.7':
     resolution: {integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-object-super@8.0.1':
+    resolution: {integrity: sha512-fDkPXRTRKGm25bAq01q82UM4ypPqdVXCwphUUm4t1dL01fGIG0v8KRvT+4BjhMAtRxtPuI34t5Vs7yjRgs3ZgQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-optional-catch-binding@7.29.7':
     resolution: {integrity: sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==}
@@ -5805,11 +6117,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-optional-catch-binding@8.0.1':
+    resolution: {integrity: sha512-b2OQ74uGliyATcasTjxGy2O/86UI/n+EN4juB4EMfEwTi9j9uq70PuP0L8fW77vfRY66gO/YoTo/WbIdQ/Si1g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-optional-chaining@7.29.7':
     resolution: {integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-optional-chaining@8.0.1':
+    resolution: {integrity: sha512-WtRS1c94lZGpGHxYLXMEWeoMVcuv8nkiyr8BTs6OYZv7N3Y9xVE8nbdFIl4lDJH6aH8/pLhqAQOL69d/WI9WdA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-parameters@7.29.7':
     resolution: {integrity: sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==}
@@ -5817,11 +6141,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-parameters@8.0.1':
+    resolution: {integrity: sha512-IIwRqroW0CYQwR6+3pnmu27z+H98poScWdnov8z6osumMeEsFxAFBBsDS2CFk2jFpPlGqVr89jK/HXO6i5DzxQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-private-methods@7.29.7':
     resolution: {integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-private-methods@8.0.1':
+    resolution: {integrity: sha512-TrFCGcXaVDh6S5IRhmLSRTY9H80VTCMQWnZtzBRg4RWg3KCLmdmsmj4M15kZAPZfoPkWL/SJb4em3Py/vOiX8g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-private-property-in-object@7.29.7':
     resolution: {integrity: sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==}
@@ -5829,11 +6165,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-private-property-in-object@8.0.1':
+    resolution: {integrity: sha512-e+yfOqSYBZaf3PARpiQkjZrpWYgmcFLhK+1tevh2CpHR1O9/36IdyPnAZusESX5nzVV/XZTDAtQBRLa8HPT5Dw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-property-literals@7.29.7':
     resolution: {integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-property-literals@8.0.1':
+    resolution: {integrity: sha512-Z/qx4cxUtYR1nt7XWRutObPxDks98fEYsjWbVeKEqZH6y3AGknmgzCqmHf2FHWZCl1DfoPeuJY+3hZ+35D+2tg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-react-constant-elements@7.27.1':
     resolution: {integrity: sha512-edoidOjl/ZxvYo4lSBOQGDSyToYVkTAwyVoa2tkuYTSmjrB1+uAedoL5iROVLXkxH+vRgA7uP4tMg2pUJpZ3Ug==}
@@ -5883,17 +6231,35 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-regenerator@8.0.1':
+    resolution: {integrity: sha512-1WjCi/45Mn5e0uvz26FdvRe6bTAvN6WAtkHgIjl0w/LkBvrv4Y5bDR+8YY72r7cefXBfwYUXIHSoxQkrIfnjXQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-regexp-modifiers@7.29.7':
     resolution: {integrity: sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-transform-regexp-modifiers@8.0.1':
+    resolution: {integrity: sha512-02ITRDBesPdTYU0oShAzERwEPzozOUQSXlz3qrt8JGuhalBJQv9z5NjgHJPC9sS3Fsam8gDtfAEpBnqZwUIdjQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-reserved-words@7.29.7':
     resolution: {integrity: sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-reserved-words@8.0.1':
+    resolution: {integrity: sha512-+aykZi7ZP3U84veqfJXm3HhPZGddWFi64g7jr0ni6tb1zel+1ey+SL+IRKPoZXFyFqvYEsoqrmx4PyEJRlHl/Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-runtime@7.29.7':
     resolution: {integrity: sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==}
@@ -5907,11 +6273,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-shorthand-properties@8.0.1':
+    resolution: {integrity: sha512-JddANd9yPVH8dYgVoNkqAH5BftnsDxFpG51Zas7sc6F3poz5QWcejHNGO8a/57IX5ByjGSzEmYk9Z7ZMa5MWaw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-spread@7.29.7':
     resolution: {integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-spread@8.0.1':
+    resolution: {integrity: sha512-O9Bw9FyxlSw1SlMg3S82/GKNZ0x77RPbHezotEy1JTlIM/vk6WO8jW1iF+iTiKLOXNvi+b+LZ9t77Gi+Q0FhGg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-sticky-regex@7.29.7':
     resolution: {integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==}
@@ -5919,17 +6297,35 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-sticky-regex@8.0.1':
+    resolution: {integrity: sha512-IsVP6WrZZQdaG2zLmeKwWiI+ua2NB5L1+f77C2/8z2NCDz7uxlIA/lnwocYOJk9PXcOC2sZgRls3LN4XpNduzQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-template-literals@7.29.7':
     resolution: {integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-template-literals@8.0.1':
+    resolution: {integrity: sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-typeof-symbol@7.29.7':
     resolution: {integrity: sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typeof-symbol@8.0.1':
+    resolution: {integrity: sha512-+wJoxgxP2gtey0UMUOMhzMMji2XHO/Uu6MXUh/r5Yhc2jngKzK/wFxY2WNe4UCaRcMvCb4gcnB8wIgFXJsocXg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-typescript@7.28.5':
     resolution: {integrity: sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==}
@@ -5949,11 +6345,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-unicode-escapes@8.0.1':
+    resolution: {integrity: sha512-TAXJepIJ6vZphytTwcf+LuXi2M2ZWI43VCqNw+1ZZLPP/38Z1A8j4Mahvg8kqDgMOSM/cakk+hedTJCiw3jQuQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-unicode-property-regex@7.29.7':
     resolution: {integrity: sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-unicode-property-regex@8.0.1':
+    resolution: {integrity: sha512-zjBN9tSMSuomNDfurL69Gf7+v4D2t5uI1mSZaYJDo88SKpbduhCXqtxH7Tx66iCF6caWYwnBzSM0tnCozmQq5Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-unicode-regex@7.29.7':
     resolution: {integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==}
@@ -5961,17 +6369,35 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-unicode-regex@8.0.1':
+    resolution: {integrity: sha512-v0oO83cvT5lwbcIVRShpx4vaHD8AvM9IBowsQuTeP+kGmhh3recJQs33Bl6dlo3/2g9amlznLbFGn4VJbPCJqA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-transform-unicode-sets-regex@7.29.7':
     resolution: {integrity: sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/plugin-transform-unicode-sets-regex@8.0.1':
+    resolution: {integrity: sha512-MlQeyS0K7gh0XNeLBMS/3Z07HjDOKhA7xm2L18GyxOXyiFHI9E+ZuQ4mFYmcLjluXsE/Wf6dABIqZvKpKw0Z3w==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/preset-env@7.29.7':
     resolution: {integrity: sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/preset-env@8.0.1':
+    resolution: {integrity: sha512-tiwl69ZQGIbPif28GK8vI/Nm1nYdP+UHXWRnqXl0fjfBS7DWmAs2XvlpVkZyZjVVDxcprcbzCnN93SbuSgz8WQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/preset-flow@7.29.7':
     resolution: {integrity: sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==}
@@ -6014,6 +6440,10 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
@@ -6021,6 +6451,10 @@ packages:
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@8.0.0':
+    resolution: {integrity: sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
@@ -6034,8 +6468,8 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@8.0.0-rc.6':
-    resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
+  '@babel/types@8.0.0':
+    resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bam.tech/react-native-image-resizer@3.0.11':
@@ -14357,6 +14791,9 @@ packages:
   '@types/fs-extra@8.1.5':
     resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
 
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -16432,11 +16869,6 @@ packages:
   babel-plugin-jsx-attributes-array-to-object@0.3.0:
     resolution: {integrity: sha512-XvbCsBFo/y4n2DzRtICQ60Kb3FWPIK359YsUkDPjC4UBCF/FMENKYzxarEhAD1GnrAuui5wOUvli89yqF1IzdA==}
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
   babel-plugin-polyfill-corejs2@0.4.15:
     resolution: {integrity: sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==}
     peerDependencies:
@@ -16452,10 +16884,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  babel-plugin-polyfill-regenerator@0.6.5:
-    resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
+  babel-plugin-polyfill-corejs3@1.0.0:
+    resolution: {integrity: sha512-yIkslVjbmml2Xjb6XhFW7lISXHsqk6cesxTdDsXoMom4Lnb99DbD3OQbSOoM5Z+ASh8YXYaLAsRQrU2Jeh3Qig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+      '@babel/core': ^7.4.0 || ^8.0.0
 
   babel-plugin-polyfill-regenerator@0.6.6:
     resolution: {integrity: sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==}
@@ -17814,12 +18247,6 @@ packages:
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.1.0
-
-  core-js-compat@3.47.0:
-    resolution: {integrity: sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==}
-
-  core-js-compat@3.48.0:
-    resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -31615,6 +32042,32 @@ snapshots:
       - supports-color
       - typescript
 
+  '@ant-design/react-native@5.0.0(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/slider@4.4.2)(@react-native-picker/picker@2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)':
+    dependencies:
+      '@ant-design/icons-react-native': 2.3.2(react@18.3.1)
+      '@bang88/react-native-ultimate-listview': 4.1.1
+      '@react-native-community/cameraroll': 4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-community/segmented-control': 2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-community/slider': 4.4.2
+      '@react-native-picker/picker': 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@types/shallowequal': 1.1.5
+      array-tree-filter: 2.1.0
+      babel-runtime: 6.26.0
+      normalize-css-color: 1.0.2
+      react-native-codegen: 0.0.7(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      react-native-collapsible: 1.6.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-gesture-handler: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-modal-popover: 2.1.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      shallowequal: 1.1.0
+      tslint: 6.1.3(typescript@6.0.3)
+      utility-types: 3.11.0
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - react
+      - react-native
+      - supports-color
+      - typescript
+
   '@antfu/eslint-config@9.0.0(@eslint-react/eslint-plugin@5.8.6(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@next/eslint-plugin-next@16.2.4)(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@unocss/eslint-plugin@66.6.8(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint-plugin-jsx-a11y@6.10.2(eslint@10.5.0(jiti@2.7.0)))(eslint-plugin-react-refresh@0.5.2(eslint@10.5.0(jiti@2.7.0)))(eslint-plugin-vuejs-accessibility@2.5.0(eslint@10.5.0(jiti@2.7.0))(globals@17.6.0))(eslint@10.5.0(jiti@2.7.0))(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
@@ -31718,21 +32171,22 @@ snapshots:
       '@babel/highlight': 7.25.9
       picocolors: 1.1.1
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.0
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.29.3': {}
 
   '@babel/compat-data@7.29.7': {}
+
+  '@babel/compat-data@8.0.0': {}
 
   '@babel/core@7.25.2':
     dependencies:
@@ -31742,10 +32196,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.25.2)
       '@babel/helpers': 7.29.7
-      '@babel/parser': 7.25.6
+      '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.25.6
+      '@babel/types': 7.29.7
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -31774,6 +32228,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@8.0.1':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.0
+      '@babel/types': 8.0.0
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      empathic: 2.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.3
+      semver: 7.8.4
+
   '@babel/eslint-parser@7.28.5(@babel/core@7.29.7)(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.7
@@ -31789,22 +32262,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 2.5.2
 
-  '@babel/generator@7.28.5':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -31813,10 +32270,19 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0-rc.6':
     dependencies:
-      '@babel/parser': 8.0.0-rc.6
-      '@babel/types': 8.0.0-rc.6
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
@@ -31829,6 +32295,10 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -31846,6 +32316,14 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-compilation-targets@8.0.0':
+    dependencies:
+      '@babel/compat-data': 8.0.0
+      '@babel/helper-validator-option': 8.0.0
+      browserslist: 4.28.2
+      lru-cache: 11.5.1
+      semver: 7.8.4
+
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -31858,6 +32336,20 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@8.0.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.25.2)':
     dependencies:
@@ -31885,12 +32377,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7)':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-annotate-as-pure': 7.29.7
-      regexpu-core: 6.4.0
-      semver: 6.3.1
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/helper-replace-supers': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+      '@babel/traverse': 8.0.0
+      semver: 7.8.4
 
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -31899,16 +32408,19 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.7)':
+  '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      regexpu-core: 6.4.0
+      semver: 6.3.1
+
+  '@babel/helper-create-regexp-features-plugin@8.0.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3
-      lodash.debounce: 4.0.8
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-annotate-as-pure': 8.0.0
+      regexpu-core: 6.4.0
+      semver: 7.8.4
 
   '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.7)':
     dependencies:
@@ -31921,13 +32433,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-define-polyfill-provider@1.0.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      lodash.debounce: 4.0.8
+
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/helper-globals@7.28.0': {}
-
   '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -31942,6 +32472,11 @@ snapshots:
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.0
+      '@babel/types': 8.0.0
 
   '@babel/helper-module-imports@7.18.6':
     dependencies:
@@ -31961,6 +32496,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.0
+      '@babel/types': 8.0.0
+
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -31979,6 +32519,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.0
+      '@babel/traverse': 8.0.0
+
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
       '@babel/types': 7.29.7
@@ -31987,7 +32543,15 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/helper-optimise-call-expression@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.0
+
   '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-plugin-utils@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
 
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -31998,6 +32562,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-wrap-function': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-remap-async-to-generator@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-wrap-function': 8.0.0
+      '@babel/traverse': 8.0.0
+
   '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32006,6 +32586,16 @@ snapshots:
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.25.2)':
     dependencies:
@@ -32025,6 +32615,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/traverse': 8.0.0
+
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.7
@@ -32039,19 +32645,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.0
+      '@babel/types': 8.0.0
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.6': {}
+  '@babel/helper-string-parser@8.0.0': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/helper-validator-identifier@8.0.0': {}
+
   '@babel/helper-validator-identifier@8.0.0-rc.6': {}
 
   '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helper-wrap-function@7.29.7':
     dependencies:
@@ -32061,10 +32676,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-wrap-function@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.0
+      '@babel/types': 8.0.0
+
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
+
+  '@babel/helpers@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.0
 
   '@babel/highlight@7.25.9':
     dependencies:
@@ -32075,7 +32701,7 @@ snapshots:
 
   '@babel/parser@7.25.6':
     dependencies:
-      '@babel/types': 7.25.6
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
@@ -32085,9 +32711,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.0
+
   '@babel/parser@8.0.0-rc.6':
     dependencies:
-      '@babel/types': 8.0.0-rc.6
+      '@babel/types': 8.0.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32097,15 +32727,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32114,6 +32777,20 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32124,6 +32801,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+      '@babel/plugin-transform-optional-chaining': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32131,6 +32824,19 @@ snapshots:
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.29.7)':
     dependencies:
@@ -32142,6 +32848,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32149,6 +32866,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32164,17 +32890,37 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
 
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.1)
+    optional: true
+
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.1)
+    optional: true
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.29.7)':
     dependencies:
@@ -32185,11 +32931,28 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
       '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
 
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 8.0.1
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@8.0.1)
+    optional: true
+
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.1)
+    optional: true
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.29.7)':
     dependencies:
@@ -32200,14 +32963,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
@@ -32234,19 +33017,42 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7)':
@@ -32257,6 +33063,11 @@ snapshots:
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2)':
@@ -32274,15 +33085,16 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
@@ -32294,25 +33106,55 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
@@ -32339,16 +33181,38 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-arrow-functions@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32359,6 +33223,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@8.0.1)
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-generator-functions@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-remap-async-to-generator': 8.0.1(@babel/core@7.29.7)
+      '@babel/traverse': 8.0.0
+
   '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32368,15 +33248,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-to-generator@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 8.0.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-remap-async-to-generator': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-block-scoped-functions@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-block-scoping@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32386,6 +33302,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-properties@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32393,6 +33323,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-static-block@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32406,11 +33350,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-classes@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@8.0.1)
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-replace-supers': 8.0.1(@babel/core@7.29.7)
+      '@babel/traverse': 8.0.0
+
   '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
+
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/template': 7.29.7
+
+  '@babel/plugin-transform-computed-properties@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32420,16 +33397,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-destructuring@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-destructuring@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-dotall-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-duplicate-keys@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32437,10 +33449,32 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-dynamic-import@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32450,21 +33484,62 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-explicit-resource-management@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-exponentiation-operator@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-export-namespace-from@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+
+  '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@8.0.1)
+    optional: true
 
   '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32473,6 +33548,20 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-for-of@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-for-of@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
 
   '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32483,25 +33572,80 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-function-name@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-json-strings@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-literals@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-logical-assignment-operators@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-member-expression-literals@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32511,6 +33655,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-amd@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32518,6 +33676,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32529,6 +33701,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-validator-identifier': 8.0.0
+
   '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32537,26 +33726,82 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-umd@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-named-capturing-groups-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-new-target@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-new-target@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-nullish-coalescing-operator@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-numeric-separator@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32569,6 +33814,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@8.0.1)
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-object-rest-spread@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32577,10 +33841,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-object-super@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-object-super@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-replace-supers': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-optional-catch-binding@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32590,10 +33878,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-optional-chaining@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-parameters@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-parameters@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32602,6 +33914,20 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-private-methods@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32612,10 +33938,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-property-literals@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.29.7)':
     dependencies:
@@ -32626,6 +33978,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32639,10 +33997,22 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
+
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32655,6 +34025,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@8.0.1)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32666,25 +34048,69 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-regenerator@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-regenerator@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-regexp-modifiers@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-reserved-words@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.7)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-runtime@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@8.0.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@8.0.1)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@8.0.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -32694,6 +34120,16 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-shorthand-properties@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -32702,20 +34138,64 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-spread@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-spread@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+
   '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-sticky-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-template-literals@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-typeof-symbol@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.29.7)':
     dependencies:
@@ -32750,10 +34230,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-escapes@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32761,17 +34263,53 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-property-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+
   '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@8.0.1)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-sets-regex@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
 
   '@babel/preset-env@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32845,10 +34383,156 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.7)
       babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.7)
       babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.7)
-      core-js-compat: 3.48.0
+      core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/preset-env@7.29.7(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 8.0.1
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@8.0.1)
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@8.0.1)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-regenerator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@8.0.1)
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@8.0.1)
+      babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@8.0.1)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@8.0.1)
+      core-js-compat: 3.49.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-env@8.0.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/compat-data': 8.0.0
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.29.7)
+      '@babel/helper-validator-option': 8.0.0
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-dotall-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-keys': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-dynamic-import': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-json-strings': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-systemjs': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-umd': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-new-target': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regexp-modifiers': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-reserved-words': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typeof-symbol': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-escapes': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-property-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-sets-regex': 8.0.1(@babel/core@7.29.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 1.0.0(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+      semver: 7.8.4
 
   '@babel/preset-flow@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -32860,6 +34544,13 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/types': 7.29.7
+      esutils: 2.0.3
+
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@8.0.1)':
+    dependencies:
+      '@babel/core': 8.0.1
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
       esutils: 2.0.3
@@ -32908,11 +34599,17 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/helper-globals': 7.28.0
+      '@babel/helper-globals': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
@@ -32932,6 +34629,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.0
+      obug: 2.1.3
+
   '@babel/types@7.25.6':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
@@ -32948,15 +34655,20 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@babel/types@8.0.0-rc.6':
+  '@babel/types@8.0.0':
     dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.6
-      '@babel/helper-validator-identifier': 8.0.0-rc.6
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.0
 
   '@bam.tech/react-native-image-resizer@3.0.11(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@bam.tech/react-native-image-resizer@3.0.11(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   '@bang88/react-native-ultimate-listview@4.1.1': {}
 
@@ -33274,7 +34986,7 @@ snapshots:
   '@commitlint/is-ignored@21.0.2':
     dependencies:
       '@commitlint/types': 21.0.1
-      semver: 7.8.3
+      semver: 7.8.4
 
   '@commitlint/lint@21.0.2':
     dependencies:
@@ -33346,7 +35058,7 @@ snapshots:
     dependencies:
       '@simple-libs/child-process-utils': 1.0.2
       '@simple-libs/stream-utils': 1.2.0
-      semver: 7.8.3
+      semver: 7.8.4
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
@@ -35623,7 +37335,7 @@ snapshots:
     dependencies:
       empathic: 2.0.1
       module-replacements: 3.0.0-beta.7
-      semver: 7.8.3
+      semver: 7.8.4
     optionalDependencies:
       eslint: 10.5.0(jiti@2.7.0)
 
@@ -36524,6 +38236,180 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@expo/cli@0.17.13(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(expo-modules-autolinking@1.10.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@expo/code-signing-certificates': 0.0.5
+      '@expo/config': 8.5.6
+      '@expo/config-plugins': 7.9.2
+      '@expo/devcert': 1.2.1
+      '@expo/env': 0.2.3
+      '@expo/image-utils': 0.4.2(encoding@0.1.13)
+      '@expo/json-file': 8.3.3
+      '@expo/metro-config': 0.17.8(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))
+      '@expo/osascript': 2.6.0
+      '@expo/package-manager': 1.12.1
+      '@expo/plist': 0.1.3
+      '@expo/prebuild-config': 6.8.1(encoding@0.1.13)(expo-modules-autolinking@1.10.3)
+      '@expo/rudder-sdk-node': 1.1.1(encoding@0.1.13)
+      '@expo/spawn-async': 1.5.0
+      '@expo/xcpretty': 4.4.4
+      '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
+      '@urql/core': 2.3.6(graphql@15.8.0)
+      '@urql/exchange-retry': 0.3.0(graphql@15.8.0)
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-parser: 0.3.2
+      cacache: 15.3.0(bluebird@3.7.2)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      connect: 3.7.0
+      debug: 4.4.3
+      env-editor: 0.4.2
+      find-yarn-workspace-root: 2.0.0
+      form-data: 3.0.4
+      freeport-async: 2.0.0
+      fs-extra: 8.1.0
+      getenv: 1.0.0
+      glob: 7.2.3
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
+      https-proxy-agent: 5.0.1
+      internal-ip: 4.3.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+      js-yaml: 3.14.2
+      json-schema-deref-sync: 0.13.0
+      lodash.debounce: 4.0.8
+      md5hex: 1.0.0
+      minimatch: 3.1.5
+      minipass: 3.3.6
+      node-fetch: 2.7.0(encoding@0.1.13)
+      node-forge: 1.3.3
+      npm-package-arg: 7.0.0
+      open: 8.4.2
+      ora: 3.4.0
+      picomatch: 3.0.2
+      pretty-bytes: 5.6.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      qrcode-terminal: 0.11.0
+      require-from-string: 2.0.2
+      requireg: 0.2.2
+      resolve: 1.22.12
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      semver: 7.8.4
+      send: 0.18.0
+      slugify: 1.6.9
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      tar: 6.2.1
+      temp-dir: 2.0.0
+      tempy: 0.7.1
+      terminal-link: 2.1.1
+      text-table: 0.2.0
+      url-join: 4.0.0
+      wrap-ansi: 7.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@react-native/babel-preset'
+      - bluebird
+      - bufferutil
+      - encoding
+      - expo-modules-autolinking
+      - supports-color
+      - utf-8-validate
+
+  '@expo/cli@0.17.13(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(expo-modules-autolinking@1.10.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@expo/code-signing-certificates': 0.0.5
+      '@expo/config': 8.5.6
+      '@expo/config-plugins': 7.9.2
+      '@expo/devcert': 1.2.1
+      '@expo/env': 0.2.3
+      '@expo/image-utils': 0.4.2(encoding@0.1.13)
+      '@expo/json-file': 8.3.3
+      '@expo/metro-config': 0.17.8(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))
+      '@expo/osascript': 2.6.0
+      '@expo/package-manager': 1.12.1
+      '@expo/plist': 0.1.3
+      '@expo/prebuild-config': 6.8.1(encoding@0.1.13)(expo-modules-autolinking@1.10.3)
+      '@expo/rudder-sdk-node': 1.1.1(encoding@0.1.13)
+      '@expo/spawn-async': 1.5.0
+      '@expo/xcpretty': 4.4.4
+      '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
+      '@urql/core': 2.3.6(graphql@15.8.0)
+      '@urql/exchange-retry': 0.3.0(graphql@15.8.0)
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-parser: 0.3.2
+      cacache: 15.3.0(bluebird@3.7.2)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      connect: 3.7.0
+      debug: 4.4.3
+      env-editor: 0.4.2
+      find-yarn-workspace-root: 2.0.0
+      form-data: 3.0.4
+      freeport-async: 2.0.0
+      fs-extra: 8.1.0
+      getenv: 1.0.0
+      glob: 7.2.3
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
+      https-proxy-agent: 5.0.1
+      internal-ip: 4.3.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+      js-yaml: 3.14.2
+      json-schema-deref-sync: 0.13.0
+      lodash.debounce: 4.0.8
+      md5hex: 1.0.0
+      minimatch: 3.1.5
+      minipass: 3.3.6
+      node-fetch: 2.7.0(encoding@0.1.13)
+      node-forge: 1.3.3
+      npm-package-arg: 7.0.0
+      open: 8.4.2
+      ora: 3.4.0
+      picomatch: 3.0.2
+      pretty-bytes: 5.6.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      qrcode-terminal: 0.11.0
+      require-from-string: 2.0.2
+      requireg: 0.2.2
+      resolve: 1.22.12
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      semver: 7.8.4
+      send: 0.18.0
+      slugify: 1.6.9
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      tar: 6.2.1
+      temp-dir: 2.0.0
+      tempy: 0.7.1
+      terminal-link: 2.1.1
+      text-table: 0.2.0
+      url-join: 4.0.0
+      wrap-ansi: 7.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@react-native/babel-preset'
+      - bluebird
+      - bufferutil
+      - encoding
+      - expo-modules-autolinking
+      - supports-color
+      - utf-8-validate
+
   '@expo/code-signing-certificates@0.0.5':
     dependencies:
       node-forge: 1.3.3
@@ -36650,6 +38536,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/metro-config@0.17.8(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@expo/config': 8.5.6
+      '@expo/env': 0.2.3
+      '@expo/json-file': 8.3.3
+      '@expo/spawn-async': 1.8.0
+      '@react-native/babel-preset': 0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      babel-preset-fbjs: 3.4.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      debug: 4.4.3
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 9.1.0
+      getenv: 1.0.0
+      glob: 7.2.3
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.19.0
+      postcss: 8.4.45
+      resolve-from: 5.0.0
+      sucrase: 3.34.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/osascript@2.6.0':
     dependencies:
       '@expo/spawn-async': 1.8.0
@@ -36721,6 +38633,12 @@ snapshots:
       expo-font: 11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@expo/vector-icons@14.1.0(expo-font@11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      expo-font: 11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   '@expo/xcpretty@4.4.4':
     dependencies:
@@ -38741,6 +40659,20 @@ snapshots:
       - debug
       - supports-color
 
+  '@mpxjs/api-proxy@2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@mpxjs/utils': 2.10.21(@mpxjs/core@2.10.24)
+      axios: 1.17.0(debug@4.4.3)
+    optionalDependencies:
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - '@mpxjs/core'
+      - debug
+      - supports-color
+
   '@mpxjs/babel-plugin-inject-page-events@2.10.21': {}
 
   '@mpxjs/cli-shared-utils@2.2.29':
@@ -38764,6 +40696,28 @@ snapshots:
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      vue: 2.7.16
+      vue-demi: 0.14.10(vue@2.7.16)
+      vue-i18n: 8.28.2(vue@2.7.16)
+      vue-i18n-bridge: 9.14.1(vue@2.7.16)
+
+  '@mpxjs/core@2.10.24(943114438cafe5180199c21b882cb5f0)':
+    dependencies:
+      '@mpxjs/api-proxy': 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      '@mpxjs/perf': 2.10.24
+      '@mpxjs/store': 2.10.22(@mpxjs/core@2.10.24)
+      '@mpxjs/utils': 2.10.21(@mpxjs/core@2.10.24)
+      lodash: 4.18.1
+      miniprogram-api-typings: 3.12.3
+    optionalDependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native-stack': 6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.14.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       vue: 2.7.16
       vue-demi: 0.14.10(vue@2.7.16)
       vue-i18n: 8.28.2(vue@2.7.16)
@@ -38810,6 +40764,25 @@ snapshots:
   '@mpxjs/fetch@2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@mpxjs/api-proxy': 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
+      '@mpxjs/utils': 2.10.21(@mpxjs/core@2.10.24)
+      json-bigint: 1.0.0
+      path-to-regexp: 6.3.0
+    transitivePeerDependencies:
+      - '@mpxjs/core'
+      - '@react-native-async-storage/async-storage'
+      - '@react-native-community/netinfo'
+      - debug
+      - react-native-ble-manager
+      - react-native-device-info
+      - react-native-get-location
+      - react-native-haptic-feedback
+      - react-native-safe-area-context
+      - react-native-wifi-reborn
+      - supports-color
+
+  '@mpxjs/fetch@2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@mpxjs/api-proxy': 2.10.21(@mpxjs/core@2.10.24)(@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(debug@4.4.3)(react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))
       '@mpxjs/utils': 2.10.21(@mpxjs/core@2.10.24)
       json-bigint: 1.0.0
       path-to-regexp: 6.3.0
@@ -39020,7 +40993,7 @@ snapshots:
 
   '@mpxjs/pinia@2.10.22(@mpxjs/core@2.10.24)(pinia@2.3.1(typescript@6.0.3)(vue@2.7.16))(vue-demi@0.14.10(vue@2.7.16))(vue@2.7.16)':
     dependencies:
-      '@mpxjs/core': 2.10.24(1c28718c96822fb4f4aaf85760dedccb)
+      '@mpxjs/core': 2.10.24(943114438cafe5180199c21b882cb5f0)
       '@mpxjs/utils': 2.10.21(@mpxjs/core@2.10.24)
       pinia: 2.3.1(typescript@6.0.3)(vue@2.7.16)
       vue: 2.7.16
@@ -39043,7 +41016,7 @@ snapshots:
 
   '@mpxjs/store@2.10.22(@mpxjs/core@2.10.24)':
     dependencies:
-      '@mpxjs/core': 2.10.24(1c28718c96822fb4f4aaf85760dedccb)
+      '@mpxjs/core': 2.10.24(943114438cafe5180199c21b882cb5f0)
       '@mpxjs/utils': 2.10.21(@mpxjs/core@2.10.24)
 
   '@mpxjs/template-engine@2.8.7(@mpxjs/core@2.10.24)(vue@2.7.16)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))':
@@ -39058,7 +41031,7 @@ snapshots:
 
   '@mpxjs/utils@2.10.21(@mpxjs/core@2.10.24)':
     dependencies:
-      '@mpxjs/core': 2.10.24(1c28718c96822fb4f4aaf85760dedccb)
+      '@mpxjs/core': 2.10.24(943114438cafe5180199c21b882cb5f0)
 
   '@mpxjs/vue-cli-plugin-mpx-e2e-test@2.2.29':
     dependencies:
@@ -39380,7 +41353,7 @@ snapshots:
 
   '@npmcli/fs@6.0.0':
     dependencies:
-      semver: 7.8.3
+      semver: 7.8.4
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -41126,19 +43099,44 @@ snapshots:
       merge-options: 3.0.4
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-native-async-storage/async-storage@1.21.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
   '@react-native-camera-roll/camera-roll@7.10.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))':
     dependencies:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-native-camera-roll/camera-roll@7.10.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   '@react-native-clipboard/clipboard@1.16.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-native-clipboard/clipboard@1.16.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
   '@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   '@react-native-community/cli-clean@12.3.7(encoding@0.1.13)':
     dependencies:
@@ -41286,6 +43284,11 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-native-community/geolocation@3.4.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
   '@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))':
     dependencies:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)
@@ -41295,10 +43298,24 @@ snapshots:
     dependencies:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-native-community/netinfo@11.1.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
   '@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   '@react-native-community/slider@4.4.2': {}
 
@@ -41307,11 +43324,31 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-native-picker/picker@2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
   '@react-native/assets-registry@0.73.1': {}
 
   '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
     dependencies:
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.29.7(@babel/core@8.0.1))':
+    dependencies:
+      '@react-native/codegen': 0.73.3(@babel/preset-env@7.29.7(@babel/core@8.0.1))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+    optional: true
+
+  '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@8.0.1(@babel/core@7.29.7))':
+    dependencies:
+      '@react-native/codegen': 0.73.3(@babel/preset-env@8.0.1(@babel/core@7.29.7))
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
@@ -41364,6 +43401,103 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
+      '@babel/template': 7.29.7
+      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-preset@0.73.21(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@8.0.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@8.0.1)
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@8.0.1)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@8.0.1)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@8.0.1)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@8.0.1)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@8.0.1)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@8.0.1)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@8.0.1)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-spread': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@8.0.1)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@8.0.1)
+      '@babel/template': 7.29.7
+      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.29.7(@babel/core@8.0.1))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@8.0.1)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+    optional: true
+
   '@react-native/codegen@0.73.3(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
     dependencies:
       '@babel/parser': 7.29.7
@@ -41372,6 +43506,33 @@ snapshots:
       glob: 7.2.3
       invariant: 2.2.4
       jscodeshift: 0.14.0(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/codegen@0.73.3(@babel/preset-env@7.29.7(@babel/core@8.0.1))':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/preset-env': 7.29.7(@babel/core@8.0.1)
+      flow-parser: 0.206.0
+      glob: 7.2.3
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.29.7(@babel/core@8.0.1))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@react-native/codegen@0.73.3(@babel/preset-env@8.0.1(@babel/core@7.29.7))':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/preset-env': 8.0.1(@babel/core@7.29.7)
+      flow-parser: 0.206.0
+      glob: 7.2.3
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       mkdirp: 0.5.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -41397,6 +43558,49 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  '@react-native/community-cli-plugin@0.73.18(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.12
+      metro-config: 0.80.12
+      metro-core: 0.80.12
+      node-fetch: 2.7.0(encoding@0.1.13)
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/community-cli-plugin@0.73.18(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.73.8(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.12
+      metro-config: 0.80.12
+      metro-core: 0.80.12
+      node-fetch: 2.7.0(encoding@0.1.13)
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   '@react-native/debugger-frontend@0.73.3': {}
 
@@ -41433,10 +43637,44 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@react-native/babel-preset': 0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      hermes-parser: 0.15.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/metro-babel-transformer@0.73.15(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))':
+    dependencies:
+      '@babel/core': 8.0.1
+      '@react-native/babel-preset': 0.73.21(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))
+      hermes-parser: 0.15.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+    optional: true
+
   '@react-native/metro-config@0.73.5(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))':
     dependencies:
       '@react-native/js-polyfills': 0.73.1
       '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      metro-config: 0.80.12
+      metro-runtime: 0.80.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/metro-config@0.73.5(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))':
+    dependencies:
+      '@react-native/js-polyfills': 0.73.1
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       metro-config: 0.80.12
       metro-runtime: 0.80.12
     transitivePeerDependencies:
@@ -41463,6 +43701,19 @@ snapshots:
       nullthrows: 1.1.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-native/virtualized-lists@0.73.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-native/virtualized-lists@0.73.4(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
   '@react-navigation/bottom-tabs@6.6.1(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -41472,6 +43723,17 @@ snapshots:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      warn-once: 0.1.1
+
+  '@react-navigation/bottom-tabs@6.6.1(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      color: 4.2.3
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       warn-once: 0.1.1
 
   '@react-navigation/core@6.4.17(react@18.2.0)':
@@ -41510,6 +43772,21 @@ snapshots:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    optional: true
+
   '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
@@ -41531,6 +43808,27 @@ snapshots:
       react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       warn-once: 0.1.1
 
+  '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      warn-once: 0.1.1
+
+  '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+    optional: true
+
   '@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@react-navigation/core': 6.4.17(react@18.2.0)
@@ -41550,6 +43848,25 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  '@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-navigation/core': 6.4.17(react@18.3.1)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.12
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  '@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/core': 6.4.17(react@18.2.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.12
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
   '@react-navigation/routers@6.1.9':
     dependencies:
       nanoid: 3.3.12
@@ -41564,6 +43881,18 @@ snapshots:
       react-native-gesture-handler: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      warn-once: 0.1.1
+
+  '@react-navigation/stack@6.4.1(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      color: 4.2.3
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-gesture-handler: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       warn-once: 0.1.1
 
   '@react-spring/animated@9.6.1(react@18.3.1)':
@@ -41643,6 +43972,19 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@react-native/babel-preset': 0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      metro-react-native-babel-preset: 0.77.0(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rnx-kit/babel-preset-metro-react-native@1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@rnx-kit/console': 1.1.0
+      babel-plugin-const-enum: 1.2.0(@babel/core@7.29.7)
+    optionalDependencies:
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@react-native/babel-preset': 0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       metro-react-native-babel-preset: 0.77.0(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
@@ -42800,23 +45142,23 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components-rn@4.2.0(01e3613fcfd3dc8d10a39ce95a709b5e)':
+  '@tarojs/components-rn@4.2.0(5d19abdb0cedecd019055f97364ca9b0)':
     dependencies:
-      '@ant-design/react-native': 5.0.0(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/slider@4.4.2)(@react-native-picker/picker@2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+      '@ant-design/react-native': 5.0.0(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/slider@4.4.2)(@react-native-picker/picker@2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       '@react-native-community/slider': 4.4.2
-      '@react-native-picker/picker': 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      '@tarojs/components': 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
-      '@tarojs/router-rn': 4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      expo-av: 13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-camera: 14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      '@react-native-picker/picker': 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@tarojs/components': 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@tarojs/router-rn': 4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo-av: 13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-camera: 14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
       prop-types: 15.8.1
       react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
-      react-native-maps: 1.3.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      react-native-pager-view: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      react-native-svg: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-maps: 1.3.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-pager-view: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-svg: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - '@react-native-community/cameraroll'
@@ -42891,6 +45233,43 @@ snapshots:
       react-native-pager-view: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-svg: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@tarojs/helper'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-web
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/components-rn@4.2.0(f596fa1c086a07bd829d944f980b353c)':
+    dependencies:
+      '@ant-design/react-native': 5.0.0(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(@react-native-community/slider@4.4.2)(@react-native-picker/picker@2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+      '@react-native-community/slider': 4.4.2
+      '@react-native-picker/picker': 2.6.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@tarojs/components': 4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
+      '@tarojs/router-rn': 4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo-av: 13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-camera: 14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-maps: 1.3.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-pager-view: 6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-svg: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - '@react-native-community/cameraroll'
@@ -42986,7 +45365,7 @@ snapshots:
   '@tarojs/helper@4.2.0(@swc/helpers@0.5.19)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/parser': 7.29.3
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -43427,6 +45806,94 @@ snapshots:
       react: 18.3.1
       react-reconciler: 0.29.0(react@18.3.1)
 
+  '@tarojs/rn-runner@4.2.0(27f7ef473c1321482f55865b541990cb)':
+    dependencies:
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@3.30.0)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@3.30.0)
+      '@rollup/plugin-json': 6.1.0(rollup@3.30.0)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@3.30.0)
+      '@rollup/plugin-replace': 5.0.7(rollup@3.30.0)
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
+      '@tarojs/rn-supporter': 4.2.0(9f23edbaa304bf6a12500d33cca0180c)
+      '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      babel-preset-taro: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      fs-extra: 11.3.5
+      lodash: 4.18.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      rollup-plugin-image-file: 1.0.2
+      stylelint-config-taro-rn: 4.2.0(stylelint-taro-rn@4.2.0(stylelint@17.13.0(typescript@6.0.3)))(stylelint@17.13.0(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - '@swc/helpers'
+      - '@tarojs/components'
+      - '@types/babel__core'
+      - '@types/react'
+      - bufferutil
+      - encoding
+      - html-webpack-plugin
+      - postcss
+      - react-native-svg
+      - rollup
+      - stylelint
+      - stylelint-taro-rn
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/rn-runner@4.2.0(2d70dadc451ebdff11a7f444e36f8275)':
+    dependencies:
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@3.30.0)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@3.30.0)
+      '@rollup/plugin-json': 6.1.0(rollup@3.30.0)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@3.30.0)
+      '@rollup/plugin-replace': 5.0.7(rollup@3.30.0)
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
+      '@tarojs/rn-supporter': 4.2.0(9f23edbaa304bf6a12500d33cca0180c)
+      '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      babel-preset-taro: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      fs-extra: 11.3.5
+      lodash: 4.18.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      rollup-plugin-image-file: 1.0.2
+      stylelint-config-taro-rn: 4.2.0(stylelint-taro-rn@4.2.0(stylelint@17.13.0(typescript@6.0.3)))(stylelint@17.13.0(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - '@swc/helpers'
+      - '@tarojs/components'
+      - '@types/babel__core'
+      - '@types/react'
+      - bufferutil
+      - encoding
+      - html-webpack-plugin
+      - postcss
+      - react-native-svg
+      - rollup
+      - stylelint
+      - stylelint-taro-rn
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
   '@tarojs/rn-runner@4.2.0(2eabfd8e94e725d09fb5ac3484257417)':
     dependencies:
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@3.30.0)
@@ -43559,7 +46026,7 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-runner@4.2.0(96f3cee50afd4140743c19fb1b0f85df)':
+  '@tarojs/rn-runner@4.2.0(d477c65f58c9794e581f6aa6353a13f4)':
     dependencies:
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@3.30.0)
       '@rollup/plugin-commonjs': 25.0.8(rollup@3.30.0)
@@ -43567,17 +46034,17 @@ snapshots:
       '@rollup/plugin-node-resolve': 15.3.1(rollup@3.30.0)
       '@rollup/plugin-replace': 5.0.7(rollup@3.30.0)
       '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
-      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
-      '@tarojs/rn-supporter': 4.2.0(1d99dd92e5d7a9dcb1d2231b8060c1c5)
+      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
+      '@tarojs/rn-supporter': 4.2.0(03579dbe1158965bf8c74103816c7bb3)
       '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
-      babel-preset-taro: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
-      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      babel-preset-taro: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2)
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.5
       lodash: 4.18.1
       react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       rollup-plugin-image-file: 1.0.2
       stylelint-config-taro-rn: 4.2.0(stylelint-taro-rn@4.2.0(stylelint@17.13.0(typescript@6.0.3)))(stylelint@17.13.0(typescript@6.0.3))
     transitivePeerDependencies:
@@ -43603,7 +46070,7 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-runner@4.2.0(cf87f2eaad1e013c79aebf03eed5b4fb)':
+  '@tarojs/rn-runner@4.2.0(fe45314d9f8100a219923db20b5c08db)':
     dependencies:
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@3.30.0)
       '@rollup/plugin-commonjs': 25.0.8(rollup@3.30.0)
@@ -43611,17 +46078,17 @@ snapshots:
       '@rollup/plugin-node-resolve': 15.3.1(rollup@3.30.0)
       '@rollup/plugin-replace': 5.0.7(rollup@3.30.0)
       '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
-      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
-      '@tarojs/rn-supporter': 4.2.0(1d99dd92e5d7a9dcb1d2231b8060c1c5)
+      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
+      '@tarojs/rn-supporter': 4.2.0(03579dbe1158965bf8c74103816c7bb3)
       '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
-      babel-preset-taro: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
-      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      babel-preset-taro: 4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0)
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.5
       lodash: 4.18.1
       react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       rollup-plugin-image-file: 1.0.2
       stylelint-config-taro-rn: 4.2.0(stylelint-taro-rn@4.2.0(stylelint@17.13.0(typescript@6.0.3)))(stylelint@17.13.0(typescript@6.0.3))
     transitivePeerDependencies:
@@ -43674,13 +46141,40 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tarojs/rn-supporter@4.2.0(1d3ca1f77c2c55ce3e9bf3db252933f8)':
+  '@tarojs/rn-style-transformer@4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)':
+    dependencies:
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      fbjs: 3.0.5(encoding@0.1.13)
+      less: 4.6.6
+      postcss: 8.5.15
+      postcss-css-variables: 0.19.0(postcss@8.5.15)
+      postcss-import: 16.1.1(postcss@8.5.15)
+      postcss-pxtransform: 4.2.0(postcss@8.5.15)
+      postcss-reporter: 7.1.0(postcss@8.5.15)
+      prop-types: 15.8.1
+      resolve: 1.22.12
+      sass: 1.101.0
+      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint-config-taro-rn: 4.2.0(stylelint-taro-rn@4.2.0(stylelint@16.26.1(typescript@6.0.3)))(stylelint@16.26.1(typescript@6.0.3))
+      stylelint-taro-rn: 4.2.0(stylelint@16.26.1(typescript@6.0.3))
+      stylus: 0.63.0
+      taro-css-to-react-native: 4.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - '@swc/helpers'
+      - encoding
+      - supports-color
+      - typescript
+
+  '@tarojs/rn-supporter@4.2.0(03579dbe1158965bf8c74103816c7bb3)':
     dependencies:
       '@react-native-community/cli-config': 12.3.7(encoding@0.1.13)
       '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
-      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
       '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
-      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
+      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
       '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
       '@tarojs/service': 4.2.0(@swc/helpers@0.5.19)
       '@tarojs/shared': 4.2.0
@@ -43696,8 +46190,8 @@ snapshots:
       mime-types: 2.1.35
       qrcode: 1.5.4
       react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
-      react-native-svg-transformer: 1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(typescript@6.0.3)
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-svg-transformer: 1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(typescript@6.0.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -43718,7 +46212,7 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-supporter@4.2.0(1d99dd92e5d7a9dcb1d2231b8060c1c5)':
+  '@tarojs/rn-supporter@4.2.0(1d3ca1f77c2c55ce3e9bf3db252933f8)':
     dependencies:
       '@react-native-community/cli-config': 12.3.7(encoding@0.1.13)
       '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
@@ -43728,7 +46222,7 @@ snapshots:
       '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
       '@tarojs/service': 4.2.0(@swc/helpers@0.5.19)
       '@tarojs/shared': 4.2.0
-      '@tarojs/taro': 4.2.0(@tarojs/components@4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
+      '@tarojs/taro': 4.2.0(0b217e27bdf5fc98ed45c080699d2a21)
       babel-plugin-global-define: 1.0.3
       babel-plugin-jsx-attributes-array-to-object: 0.3.0
       babel-plugin-transform-react-jsx-to-rn-stylesheet: 4.2.0(@babel/core@7.29.7)
@@ -43806,6 +46300,50 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
+  '@tarojs/rn-supporter@4.2.0(9f23edbaa304bf6a12500d33cca0180c)':
+    dependencies:
+      '@react-native-community/cli-config': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      '@tarojs/rn-style-transformer': 4.2.0(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(@swc/helpers@0.5.19)(encoding@0.1.13)(postcss@8.5.15)(typescript@6.0.3)
+      '@tarojs/rn-transformer': 4.2.0(@swc/helpers@0.5.19)
+      '@tarojs/service': 4.2.0(@swc/helpers@0.5.19)
+      '@tarojs/shared': 4.2.0
+      '@tarojs/taro': 4.2.0(@tarojs/components@4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
+      babel-plugin-global-define: 1.0.3
+      babel-plugin-jsx-attributes-array-to-object: 0.3.0
+      babel-plugin-transform-react-jsx-to-rn-stylesheet: 4.2.0(@babel/core@7.29.7)
+      lodash: 4.18.1
+      metro: 0.80.12
+      metro-cache: 0.80.12
+      metro-core: 0.80.12
+      metro-resolver: 0.80.12
+      mime-types: 2.1.35
+      qrcode: 1.5.4
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-svg-transformer: 1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - '@swc/helpers'
+      - '@tarojs/components'
+      - '@types/react'
+      - bufferutil
+      - encoding
+      - html-webpack-plugin
+      - postcss
+      - react-native-svg
+      - rollup
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
   '@tarojs/rn-transformer@4.2.0(@swc/helpers@0.5.19)':
     dependencies:
       '@babel/core': 7.29.7
@@ -43835,6 +46373,21 @@ snapshots:
       react-native-gesture-handler: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  '@tarojs/router-rn@4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-navigation/bottom-tabs': 6.6.1(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native-stack': 6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-navigation/routers': 6.1.9
+      '@react-navigation/stack': 6.4.1(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      lodash: 4.18.1
+      query-string: 9.3.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-gesture-handler: 2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-screens: 3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   '@tarojs/router@4.2.0(@tarojs/runtime@4.2.0)(@tarojs/shared@4.2.0)(@tarojs/taro@4.2.0(0b217e27bdf5fc98ed45c080699d2a21))':
     dependencies:
@@ -43881,14 +46434,14 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@tarojs/runtime-rn@4.2.0(8fd588555cd6cf0b65d4ad6cbf334e96)':
+  '@tarojs/runtime-rn@4.2.0(9fecfe1428b37a46dcdd1c048606c7be)':
     dependencies:
-      '@tarojs/components-rn': 4.2.0(01e3613fcfd3dc8d10a39ce95a709b5e)
-      '@tarojs/router-rn': 4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@tarojs/components-rn': 4.2.0(f596fa1c086a07bd829d944f980b353c)
+      '@tarojs/router-rn': 4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@tarojs/shared': 4.2.0
       react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
-      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
       react-native-root-siblings: 5.0.1
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -43963,6 +46516,43 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      react-native-root-siblings: 5.0.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/helper'
+      - '@types/react'
+      - expo
+      - expo-av
+      - expo-camera
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/runtime-rn@4.2.0(cb1511c2bff512ce7b248f11fd1dedcd)':
+    dependencies:
+      '@tarojs/components-rn': 4.2.0(5d19abdb0cedecd019055f97364ca9b0)
+      '@tarojs/router-rn': 4.2.0(react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@tarojs/shared': 4.2.0
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
       react-native-root-siblings: 5.0.1
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -44092,35 +46682,90 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f)':
+  '@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d)':
     dependencies:
-      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
-      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
-      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
-      '@tarojs/runtime-rn': 4.2.0(8fd588555cd6cf0b65d4ad6cbf334e96)
+      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      '@tarojs/runtime-rn': 4.2.0(9fecfe1428b37a46dcdd1c048606c7be)
       '@tarojs/taro': 4.2.0(@tarojs/components@4.2.0(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(@tarojs/helper@4.2.0(@swc/helpers@0.5.19))(@tarojs/shared@4.2.0)(@types/react@19.2.17)(html-webpack-plugin@5.6.7(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(postcss@8.5.15)(rollup@3.30.0)(vue@3.5.38(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2(debug@4.4.3)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)))(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1))
       base64-js: 1.5.1
       deprecated-react-native-prop-types: 5.0.0
-      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
-      expo-av: 13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-barcode-scanner: 12.9.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-brightness: 11.8.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-camera: 14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-file-system: 16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-image-picker: 14.7.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-keep-awake: 12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-location: 16.5.5(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
-      expo-sensors: 12.9.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo-av: 13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-barcode-scanner: 12.9.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-brightness: 11.8.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-camera: 14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-file-system: 16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-image-picker: 14.7.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-keep-awake: 12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-location: 16.5.5(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-sensors: 12.9.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
       prop-types: 15.8.1
       react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
-      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
-      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-root-siblings: 5.0.1
-      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/components'
+      - '@tarojs/helper'
+      - '@tarojs/shared'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b)':
+    dependencies:
+      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      '@tarojs/runtime-rn': 4.2.0(cb1511c2bff512ce7b248f11fd1dedcd)
+      '@tarojs/taro': 4.2.0(0b217e27bdf5fc98ed45c080699d2a21)
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 5.0.0
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo-av: 13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-barcode-scanner: 12.9.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-brightness: 11.8.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-camera: 14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-file-system: 16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-image-picker: 14.7.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-keep-awake: 12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-location: 16.5.5(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-sensors: 12.9.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-root-siblings: 5.0.1
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - '@react-native-community/cameraroll'
@@ -44858,6 +47503,8 @@ snapshots:
   '@types/fs-extra@8.1.5':
     dependencies:
       '@types/node': 25.9.3
+
+  '@types/gensync@1.0.5': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -46115,7 +48762,7 @@ snapshots:
     dependencies:
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
@@ -46442,7 +49089,7 @@ snapshots:
 
   '@vue/compiler-core@3.4.21':
     dependencies:
-      '@babel/parser': 7.25.6
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.4.21
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -46489,7 +49136,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.21':
     dependencies:
-      '@babel/parser': 7.25.6
+      '@babel/parser': 7.29.7
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-ssr': 3.4.21
@@ -47220,7 +49867,7 @@ snapshots:
 
   android-versions@1.9.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.8.4
 
   anser@1.4.10: {}
 
@@ -47523,7 +50170,7 @@ snapshots:
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.6
+      '@babel/parser': 8.0.0
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -47705,9 +50352,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)):
+  babel-loader@10.1.1(@babel/core@8.0.1)(webpack@5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 8.0.1
       find-up: 5.0.0
     optionalDependencies:
       webpack: 5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)
@@ -47808,15 +50455,6 @@ snapshots:
 
   babel-plugin-jsx-attributes-array-to-object@0.3.0: {}
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.7):
-    dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -47826,11 +50464,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs2@0.4.15(@babel/core@8.0.1):
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 8.0.1
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@8.0.1)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
-      core-js-compat: 3.47.0
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@8.0.1)
+      core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
@@ -47838,21 +50493,35 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
-      core-js-compat: 3.48.0
+      core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs3@0.14.0(@babel/core@8.0.1):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
+      '@babel/core': 8.0.1
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@8.0.1)
+      core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-polyfill-corejs3@1.0.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 1.0.0(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
 
   babel-plugin-polyfill-regenerator@0.6.6(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.6(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@8.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -47865,6 +50534,13 @@ snapshots:
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
+
+  babel-plugin-transform-flow-enums@0.0.2(@babel/core@8.0.1):
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@8.0.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+    optional: true
 
   babel-plugin-transform-imports-api@1.0.0:
     dependencies:
@@ -47879,7 +50555,7 @@ snapshots:
   babel-plugin-transform-solid-jsx@4.2.0(@babel/core@7.29.7):
     dependencies:
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       html-entities: 2.3.3
       validate-html-nesting: 1.2.4
     transitivePeerDependencies:
@@ -47990,64 +50666,6 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
-  babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@babel/runtime': 7.29.7
-      '@babel/runtime-corejs3': 7.29.7
-      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))
-      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
-      babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-transform-imports-api: 1.0.0
-      babel-plugin-transform-solid-jsx: 4.2.0(@babel/core@7.29.7)
-      core-js: 3.49.0
-    optionalDependencies:
-      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
-      '@tarojs/taro-rn': 4.2.0(c1dd6512e74c927e0feb00cd304be06f)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - '@babel/plugin-transform-typescript'
-      - '@react-native/babel-preset'
-      - '@swc/helpers'
-      - metro-react-native-babel-preset
-      - supports-color
-
-  babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c1dd6512e74c927e0feb00cd304be06f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@babel/runtime': 7.29.7
-      '@babel/runtime-corejs3': 7.29.7
-      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))
-      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
-      babel-plugin-dynamic-import-node: 2.3.3
-      babel-plugin-transform-imports-api: 1.0.0
-      babel-plugin-transform-solid-jsx: 4.2.0(@babel/core@7.29.7)
-      core-js: 3.49.0
-    optionalDependencies:
-      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
-      '@tarojs/taro-rn': 4.2.0(c1dd6512e74c927e0feb00cd304be06f)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
-      react-refresh: 0.18.0
-    transitivePeerDependencies:
-      - '@babel/plugin-transform-typescript'
-      - '@react-native/babel-preset'
-      - '@swc/helpers'
-      - metro-react-native-babel-preset
-      - supports-color
-
   babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(c496c45218d176d4b969ca34f767b88b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0):
     dependencies:
       '@babel/core': 7.29.7
@@ -48126,6 +50744,122 @@ snapshots:
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
       '@tarojs/taro-rn': 4.2.0(e2eee54289cde632d8e6d7ecd8dbecd9)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
+      react-refresh: 0.18.0
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-typescript'
+      - '@react-native/babel-preset'
+      - '@swc/helpers'
+      - metro-react-native-babel-preset
+      - supports-color
+
+  babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-transform-imports-api: 1.0.0
+      babel-plugin-transform-solid-jsx: 4.2.0(@babel/core@7.29.7)
+      core-js: 3.49.0
+    optionalDependencies:
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@tarojs/taro-rn': 4.2.0(a42b1aa98d4cd7caaca566459cf5855d)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-typescript'
+      - '@react-native/babel-preset'
+      - '@swc/helpers'
+      - metro-react-native-babel-preset
+      - supports-color
+
+  babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(a42b1aa98d4cd7caaca566459cf5855d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-transform-imports-api: 1.0.0
+      babel-plugin-transform-solid-jsx: 4.2.0(@babel/core@7.29.7)
+      core-js: 3.49.0
+    optionalDependencies:
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@tarojs/taro-rn': 4.2.0(a42b1aa98d4cd7caaca566459cf5855d)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
+      react-refresh: 0.18.0
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-typescript'
+      - '@react-native/babel-preset'
+      - '@swc/helpers'
+      - metro-react-native-babel-preset
+      - supports-color
+
+  babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.14.2):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-transform-imports-api: 1.0.0
+      babel-plugin-transform-solid-jsx: 4.2.0(@babel/core@7.29.7)
+      core-js: 3.49.0
+    optionalDependencies:
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@tarojs/taro-rn': 4.2.0(b49a683095d54d19e88acf05a985216b)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-typescript'
+      - '@react-native/babel-preset'
+      - '@swc/helpers'
+      - metro-react-native-babel-preset
+      - supports-color
+
+  babel-preset-taro@4.2.0(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/preset-react@7.29.7(@babel/core@7.29.7))(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(@swc/helpers@0.5.19)(@tarojs/taro-rn@4.2.0(b49a683095d54d19e88acf05a985216b))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))(react-refresh@0.18.0):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7)(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7))
+      '@tarojs/helper': 4.2.0(@swc/helpers@0.5.19)
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-transform-imports-api: 1.0.0
+      babel-plugin-transform-solid-jsx: 4.2.0(@babel/core@7.29.7)
+      core-js: 3.49.0
+    optionalDependencies:
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@tarojs/taro-rn': 4.2.0(b49a683095d54d19e88acf05a985216b)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -49468,14 +52202,6 @@ snapshots:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       webpack: 5.105.4(@swc/core@1.15.41(@swc/helpers@0.5.19))(esbuild@0.28.1)
-
-  core-js-compat@3.47.0:
-    dependencies:
-      browserslist: 4.28.2
-
-  core-js-compat@3.48.0:
-    dependencies:
-      browserslist: 4.28.2
 
   core-js-compat@3.49.0:
     dependencies:
@@ -51304,7 +54030,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.5.0(jiti@2.7.0)
-      semver: 7.8.3
+      semver: 7.8.4
 
   eslint-config-flat-gitignore@2.3.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
@@ -51586,7 +54312,7 @@ snapshots:
       html-entities: 2.6.0
       object-deep-merge: 2.0.1
       parse-imports-exports: 0.2.4
-      semver: 7.8.3
+      semver: 7.8.4
       spdx-expression-parse: 4.0.0
       to-valid-identifier: 1.0.0
     transitivePeerDependencies:
@@ -51659,7 +54385,7 @@ snapshots:
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
-      semver: 7.8.3
+      semver: 7.8.4
     optionalDependencies:
       ts-declaration-location: 1.0.7(typescript@6.0.3)
       typescript: 6.0.3
@@ -51868,7 +54594,7 @@ snapshots:
       pluralize: 8.0.0
       regexp-tree: 0.1.27
       regjsparser: 0.13.1
-      semver: 7.8.3
+      semver: 7.8.4
       strip-indent: 4.1.1
 
   eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
@@ -52279,6 +55005,18 @@ snapshots:
       - expo
       - supports-color
 
+  expo-asset@9.0.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      '@react-native/assets-registry': 0.73.1
+      blueimp-md5: 2.19.0
+      expo-constants: 15.4.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-file-system: 16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      invariant: 2.2.4
+      md5-file: 3.2.3
+    transitivePeerDependencies:
+      - expo
+      - supports-color
+
   expo-av@13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -52286,6 +55024,10 @@ snapshots:
   expo-av@13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  expo-av@13.10.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   expo-barcode-scanner@12.9.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -52297,6 +55039,11 @@ snapshots:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       expo-image-loader: 4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
 
+  expo-barcode-scanner@12.9.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo-image-loader: 4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+
   expo-brightness@11.8.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -52304,6 +55051,10 @@ snapshots:
   expo-brightness@11.8.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  expo-brightness@11.8.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   expo-camera@14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -52313,6 +55064,11 @@ snapshots:
   expo-camera@14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      invariant: 2.2.4
+
+  expo-camera@14.1.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       invariant: 2.2.4
 
   expo-constants@15.4.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
@@ -52329,6 +55085,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@15.4.6(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      '@expo/config': 8.5.6
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-file-system@16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -52336,6 +55099,10 @@ snapshots:
   expo-file-system@16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  expo-file-system@16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   expo-font@11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -52347,6 +55114,11 @@ snapshots:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       fontfaceobserver: 2.3.0
 
+  expo-font@11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      fontfaceobserver: 2.3.0
+
   expo-image-loader@4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -52354,6 +55126,10 @@ snapshots:
   expo-image-loader@4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  expo-image-loader@4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   expo-image-picker@14.7.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -52365,6 +55141,11 @@ snapshots:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       expo-image-loader: 4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
 
+  expo-image-picker@14.7.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      expo-image-loader: 4.6.0(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+
   expo-keep-awake@12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -52373,6 +55154,10 @@ snapshots:
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
+  expo-keep-awake@12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
   expo-location@16.5.5(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -52380,6 +55165,10 @@ snapshots:
   expo-location@16.5.5(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  expo-location@16.5.5(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   expo-modules-autolinking@1.10.3:
     dependencies:
@@ -52404,6 +55193,11 @@ snapshots:
   expo-sensors@12.9.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      invariant: 2.2.4
+
+  expo-sensors@12.9.1(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       invariant: 2.2.4
 
   expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
@@ -52437,7 +55231,7 @@ snapshots:
   expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 0.17.13(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(bluebird@3.7.2)(encoding@0.1.13)(expo-modules-autolinking@1.10.3)
+      '@expo/cli': 0.17.13(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(expo-modules-autolinking@1.10.3)
       '@expo/config': 8.5.6
       '@expo/config-plugins': 7.9.2
       '@expo/metro-config': 0.17.8(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))
@@ -52447,6 +55241,34 @@ snapshots:
       expo-file-system: 16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
       expo-font: 11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
       expo-keep-awake: 12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-modules-autolinking: 1.10.3
+      expo-modules-core: 1.11.14
+      fbemitter: 3.0.0(encoding@0.1.13)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native/babel-preset'
+      - bluebird
+      - bufferutil
+      - encoding
+      - react
+      - react-native
+      - supports-color
+      - utf-8-validate
+
+  expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@expo/cli': 0.17.13(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(expo-modules-autolinking@1.10.3)
+      '@expo/config': 8.5.6
+      '@expo/config-plugins': 7.9.2
+      '@expo/metro-config': 0.17.8(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))
+      '@expo/vector-icons': 14.1.0(expo-font@11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      babel-preset-expo: 10.0.2(@babel/core@7.29.7)
+      expo-asset: 9.0.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-file-system: 16.0.9(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-font: 11.10.3(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
+      expo-keep-awake: 12.8.2(expo@50.0.21(@babel/core@7.29.7)(@react-native/babel-preset@0.73.21(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7)))(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))
       expo-modules-autolinking: 1.10.3
       expo-modules-core: 1.11.14
       fbemitter: 3.0.0(encoding@0.1.13)
@@ -55499,7 +58321,7 @@ snapshots:
 
   jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -56005,6 +58827,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jscodeshift@0.11.0(@babel/preset-env@8.0.1(@babel/core@7.29.7)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 8.0.1(@babel/core@7.29.7)
+      '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.29.7)
+      colors: 1.4.0
+      flow-parser: 0.206.0
+      graceful-fs: 4.2.11
+      micromatch: 3.1.10
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.20.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   jscodeshift@0.14.0(@babel/preset-env@7.29.7(@babel/core@7.29.7)):
     dependencies:
       '@babel/core': 7.29.7
@@ -56014,6 +58861,57 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      flow-parser: 0.206.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.21.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  jscodeshift@0.14.0(@babel/preset-env@7.29.7(@babel/core@8.0.1)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@8.0.1)
+      '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      flow-parser: 0.206.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.21.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  jscodeshift@0.14.0(@babel/preset-env@8.0.1(@babel/core@7.29.7)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 8.0.1(@babel/core@7.29.7)
       '@babel/preset-flow': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/register': 7.29.7(@babel/core@7.29.7)
@@ -56175,7 +59073,7 @@ snapshots:
     dependencies:
       acorn: 8.16.0
       eslint-visitor-keys: 5.0.1
-      semver: 7.8.3
+      semver: 7.8.4
 
   jsonc-parser@3.3.1: {}
 
@@ -56905,7 +59803,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.3
+      semver: 7.8.4
 
   make-dir@5.1.0:
     optional: true
@@ -58450,7 +61348,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.8.3
+      semver: 7.8.4
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.1:
@@ -59236,7 +62134,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -61066,10 +63964,24 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
+  react-native-codegen@0.0.7(@babel/preset-env@8.0.1(@babel/core@7.29.7)):
+    dependencies:
+      flow-parser: 0.121.0
+      jscodeshift: 0.11.0(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
   react-native-collapsible@1.6.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-collapsible@1.6.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0)):
     dependencies:
@@ -61079,6 +63991,15 @@ snapshots:
   react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)):
     dependencies:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)):
+    dependencies:
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-device-info@14.1.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
 
   react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -61101,16 +64022,48 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      lodash: 4.18.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      lodash: 4.18.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
+
   react-native-image-pan-zoom@2.1.12(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-image-pan-zoom@2.1.12(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   react-native-image-zoom-viewer@3.0.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       react-native-image-pan-zoom: 2.1.12(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+
+  react-native-image-zoom-viewer@3.0.1(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-image-pan-zoom: 2.1.12(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
 
   react-native-known-styling-properties@1.3.0: {}
 
@@ -61120,6 +64073,12 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  react-native-maps@1.3.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@types/geojson': 7946.0.16
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
   react-native-modal-popover@2.1.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       lodash: 4.18.1
@@ -61127,10 +64086,22 @@ snapshots:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
+  react-native-modal-popover@2.1.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      lodash: 4.18.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
   react-native-pager-view@6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-pager-view@6.2.3(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   react-native-root-siblings@5.0.1: {}
 
@@ -61144,6 +64115,17 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
 
   react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -61160,6 +64142,21 @@ snapshots:
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
       warn-once: 0.1.1
 
+  react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-freeze: 1.0.4(react@18.3.1)
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      warn-once: 0.1.1
+
+  react-native-screens@3.29.0(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-freeze: 1.0.4(react@18.2.0)
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+      warn-once: 0.1.1
+    optional: true
+
   react-native-svg-transformer@1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(typescript@6.0.3):
     dependencies:
       '@svgr/core': 8.1.0(typescript@6.0.3)
@@ -61172,12 +64169,31 @@ snapshots:
       - supports-color
       - typescript
 
+  react-native-svg-transformer@1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(typescript@6.0.3):
+    dependencies:
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
+      path-dirname: 1.0.2
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+      react-native-svg: 14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
 
   react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -61193,6 +64209,21 @@ snapshots:
       invariant: 2.2.4
       react: 18.3.1
       react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      escape-string-regexp: 2.0.0
+      invariant: 2.2.4
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1)
+
+  react-native-webview@13.6.4(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      escape-string-regexp: 2.0.0
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0)
+    optional: true
 
   react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@7.29.7(@babel/core@7.29.7))(encoding@0.1.13)(react@18.2.0):
     dependencies:
@@ -61292,6 +64323,105 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 12.3.7(encoding@0.1.13)
+      '@react-native/assets-registry': 0.73.1
+      '@react-native/codegen': 0.73.3(@babel/preset-env@8.0.1(@babel/core@7.29.7))
+      '@react-native/community-cli-plugin': 0.73.18(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)
+      '@react-native/gradle-plugin': 0.73.5
+      '@react-native/js-polyfills': 0.73.1
+      '@react-native/normalize-colors': 0.73.2
+      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.11(@babel/core@7.29.7)(@babel/preset-env@8.0.1(@babel/core@7.29.7))(encoding@0.1.13)(react@18.3.1))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      deprecated-react-native-prop-types: 5.0.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.12
+      metro-source-map: 0.80.12
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.3.1
+      react-devtools-core: 4.28.5
+      react-refresh: 0.14.2
+      react-shallow-renderer: 16.15.0(react@18.3.1)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 6.2.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 12.3.7(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 12.3.7(encoding@0.1.13)
+      '@react-native/assets-registry': 0.73.1
+      '@react-native/codegen': 0.73.3(@babel/preset-env@7.29.7(@babel/core@8.0.1))
+      '@react-native/community-cli-plugin': 0.73.18(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)
+      '@react-native/gradle-plugin': 0.73.5
+      '@react-native/js-polyfills': 0.73.1
+      '@react-native/normalize-colors': 0.73.2
+      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.11(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1))(encoding@0.1.13)(react@18.2.0))
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      deprecated-react-native-prop-types: 5.0.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.12
+      metro-source-map: 0.80.12
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 4.28.5
+      react-refresh: 0.14.2
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 6.2.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   react-reconciler@0.29.0(react@18.3.1):
     dependencies:
@@ -62781,7 +65911,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.3
+      semver: 7.8.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -65113,7 +68243,7 @@ snapshots:
 
   unplugin-vue-router@0.19.2(@vue/compiler-sfc@3.5.35)(vue-router@4.6.4(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.7
       '@vue-macros/common': 3.1.1(vue@3.5.38(typescript@6.0.3))
       '@vue/compiler-sfc': 3.5.35
       '@vue/language-core': 3.2.1
@@ -65916,7 +69046,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
       esquery: 1.7.0
-      semver: 7.8.3
+      semver: 7.8.4
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,12 +44,18 @@ catalogs:
     autoprefixer: ^10.5.0
   babelCore7285:
     '@babel/core': ^7.29.7
+  babelCore8:
+    '@babel/core': ^8.0.1
   babelPresetReact7285:
     '@babel/preset-react': ^7.29.7
+  babelPresetReact8:
+    '@babel/preset-react': ^8.0.1
   babelRuntime7284:
     '@babel/runtime': ^7.29.7
   babelRuntime7284tilde:
     '@babel/runtime': ^7.29.2
+  babelRuntime8:
+    '@babel/runtime': ^8.0.0
   baselineBrowserMapping:
     baseline-browser-mapping: ^2.10.37
   classVarianceAuthority:


### PR DESCRIPTION
## 变更内容

- 将核心 Babel 链路升级到 Babel 8：`@babel/core`、`@babel/generator`、`@babel/parser`、`@babel/traverse`、`@babel/types`。
- 仅调整 `weapp-tailwindcss` 与 `@weapp-tailwindcss/babel` 相关依赖；uni-app、Taro、MPX、templates、website 仍保留 Babel 7。
- 适配 Babel 8 的 ESM-only 与同步 transform API 变化。
- 将相关包 Node engine 调整为 Babel 8 要求的 `^22.18.0 || >=24.11.0`。
- 添加中文 changeset，按 major 记录 Node 支持范围变化。

## 验证

- `pnpm install`
- `pnpm --filter @weapp-tailwindcss/babel test`
- `pnpm vitest run --project=weapp-tailwindcss packages/weapp-tailwindcss/test/babel/index.test.ts packages/weapp-tailwindcss/test/js/babel-utils.test.ts packages/weapp-tailwindcss/test/js/babel-branches.test.ts --coverage.enabled=false`
- `pnpm vitest run --project=@weapp-tailwindcss/minify-preserve packages/minify-preserve/test/bundler-config.test.ts --coverage.enabled=false`
- `pnpm typecheck`
- `pnpm build:pkgs`

## 兼容性记录

- HBuilderX 5.07.2026041006 内置 Node 为 `v18.20.0`，低于 Babel 8 的 engine 要求。
- HBuilderX `dev:mp-weixin` 目前会在加载 `vite.config.ts` 时遇到 Babel 8 ESM / Node API 兼容问题，例如 `require() of ES Module @babel/traverse` 和 `node:util.styleText` 不存在。
- 普通外部 `uni` CLI 在当前 Node v25 环境下，H5 和 mp-weixin 构建/启动路径已验证可用。

## 已知非本次改动失败

`pnpm --filter weapp-tailwindcss test -- --coverage.enabled=false` 仍有 3 个文件 6 个失败，集中在 CI workflow 断言和 Vite/Webpack watch/cache 用例，和本次 Babel 8 适配路径不重合。