### PR TITLE
test: 修复 MPX Benchmark watch 预热

### DIFF
--- a/benchmark/version-compare/scripts/run-matrix.mjs
+++ b/benchmark/version-compare/scripts/run-matrix.mjs
@@ -108,6 +108,7 @@ function spawnPnpmWithEnv(cwd, args, env = {}, stdio = 'pipe') {
 }
 
 const localUrlRE = /(?:Local|Loopback|Listening at):\s*(https?:\/\/\S+)/i
+const devReadyLogRE = /compiled successfully|Compiled successfully|built in [\d.]+m?s?|Build complete|Watching for changes|ready in \d+/i
 
 async function readText(file) {
   try {
@@ -218,6 +219,10 @@ function resolveLoggedBaseUrls(logs, fallbackUrl) {
     }
   }
   return Array.from(urls)
+}
+
+function hasDevReadyLog(logs) {
+  return logs.some(line => devReadyLogRE.test(line))
 }
 
 async function fetchProbeText(url) {
@@ -407,7 +412,7 @@ async function runHmrRounds({
       if (!(await exists(outputPath))) {
         return false
       }
-      if (await statMtimeMs(outputPath) <= initialOutputMtime) {
+      if ((await statMtimeMs(outputPath) <= initialOutputMtime) && !hasDevReadyLog(logs)) {
         return false
       }
       const text = await readText(outputPath)


### PR DESCRIPTION
## 背景

#943 合并后的 Benchmark 中，MPX watch 初始构建会输出 `[compared for emit]`，产物 mtime 不变，导致 runner 误以为 dev 还没 ready，一直等到 180s timeout。

## 变更

- watch 预热阶段同时接受启动后的 compiled successfully 等 ready 日志。
- 保留产物存在检查，避免读取完全不存在的旧产物。

## 验证

- `node benchmark/version-compare/scripts/run-matrix.mjs --versions-file /tmp/bench-current-only.json --build-runs 1 --hmr-runs 1 --timeout 180000 --poll-interval 120 --only demo-mpx-tailwindcss-v4__mp-weixin --out /tmp/bench-mpx-mp.json`
- `pnpm --filter weapp-tailwindcss exec vitest run test/ci/benchmark-report.test.ts test/ci/workflows.test.ts`