### PR TITLE
ci: speed up pull request benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,14 +40,14 @@ jobs:
   current-vs-published:
     name: Current vs published weapp-tailwindcss
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 35 || 90 }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       WEAPP_TW_BENCH_BASELINE: ${{ github.event.inputs.baseline || 'auto' }}
       BENCH_BUILD_RUNS: ${{ github.event_name == 'pull_request' && '1' || github.event.inputs.build_runs || '3' }}
       BENCH_HMR_RUNS: ${{ github.event_name == 'pull_request' && '1' || github.event.inputs.hmr_runs || '5' }}
-      BENCH_ONLY: ${{ github.event.inputs.only || '' }}
+      BENCH_ONLY: ${{ github.event_name == 'pull_request' && 'demo-weapp-vite-tailwindcss-v4__mp-weixin,demo-uni-app-vite-tailwindcss-v4__mp-weixin,demo-web-vue-vite-tailwindcss-v4__web' || github.event.inputs.only || '' }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -127,9 +127,11 @@ jobs:
             round_profile: default
             watch_save_snapshots: '1'
             watch_main_style_only: '1'
+            watch_main_style_subpackage_limit: '0'
             timeout_minutes: 35
             watch_timeout_ms: '240000'
             watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '30000'
             watch_command_timeout_ms: '600000'
           - os: windows-latest
             runner_label: windows

--- a/benchmark/version-compare/scripts/projects.mjs
+++ b/benchmark/version-compare/scripts/projects.mjs
@@ -134,11 +134,15 @@ export const benchmarkProjects = [
     project: 'demo/uni-app-vite-tailwindcss-v4',
     target: 'mp-weixin',
     buildScript: 'build',
+    buildEnv: {
+      UNI_BUILD_STRICT: '1',
+    },
     sourceFile: 'src/pages/index/index.vue',
     outputTemplate: 'dist/dev/mp-weixin/pages/index/index.wxml',
     devScript: 'dev:e2e-watch',
     injectType: 'vue',
-    hmrMode: 'watch',
+    hmrMode: 'fallback-build',
+    hmrNote: 'uni-app mp-weixin CI watch 通过 dev:e2e-watch 的 strict build fallback 验证产物，不能作为真实 watch HMR 样本',
     devEnv: {
       UNI_E2E_WATCH_NATIVE: '1',
     },

--- a/benchmark/version-compare/scripts/run-matrix.mjs
+++ b/benchmark/version-compare/scripts/run-matrix.mjs
@@ -302,9 +302,9 @@ function stopChild(child) {
   })
 }
 
-async function runBuildOnce(cwd, buildScript, timeoutMs) {
+async function runBuildOnce(cwd, buildScript, timeoutMs, buildEnv = {}) {
   const start = now()
-  const child = spawnPnpm(cwd, ['run', buildScript], 'pipe')
+  const child = spawnPnpmWithEnv(cwd, ['run', buildScript], buildEnv, 'pipe')
   let logs = ''
   child.stdout.on('data', (chunk) => {
     logs += chunk.toString('utf8')
@@ -336,6 +336,9 @@ async function runBuildOnce(cwd, buildScript, timeoutMs) {
 
   if (code !== 0) {
     throw new Error(`build failed code=${code}\n${logs.slice(-4000)}`)
+  }
+  if (logs.includes('[uni-build-guard]') && logs.includes('已跳过 uni-app 的真实构建')) {
+    throw new Error(`build skipped by uni-build-guard; set project buildEnv.UNI_BUILD_STRICT=1 for benchmark builds\n${logs.slice(-4000)}`)
   }
 
   return now() - start
@@ -574,7 +577,7 @@ async function runCase(versionMeta, projectMeta, options) {
   }
   else {
     for (let i = 0; i < options.buildRuns; i += 1) {
-      const ms = await runBuildOnce(cwd, projectMeta.buildScript, options.timeoutMs)
+      const ms = await runBuildOnce(cwd, projectMeta.buildScript, options.timeoutMs, projectMeta.buildEnv)
       buildMs.push(ms)
       process.stdout.write(`[${versionMeta.version}/${projectMeta.key}] build ${i + 1}/${options.buildRuns}: ${ms.toFixed(2)}ms\n`)
     }

--- a/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
@@ -27,6 +27,8 @@ describe('benchmark ci report', () => {
     const demoProjects = collectPackageDirs(path.join(repoRoot, 'demo')).sort()
       .filter(project => !project.startsWith('demo/issue-'))
       .filter(project => !project.startsWith('demo/subpackage-'))
+      .filter(project => !project.startsWith('demo/style-injector-'))
+      .filter(project => project !== 'demo/web/nuxt-vite-tailwindcss-v4')
       .filter(project => !project.startsWith('demo/web/') || project.includes('-vite-'))
     const benchmarkProjectDirs = Array.from(new Set(benchmarkProjects.map(project => project.project))).sort()
 
@@ -37,6 +39,10 @@ describe('benchmark ci report', () => {
       'demo-uni-app-vite-tailwindcss-v4__mp-weixin',
       'demo-uni-app-vite-tailwindcss-v4__h5',
     ]))
+    const uniMpWeixin = benchmarkProjects.find(project => project.key === 'demo-uni-app-vite-tailwindcss-v4__mp-weixin')
+    expect(uniMpWeixin?.buildEnv).toMatchObject({ UNI_BUILD_STRICT: '1' })
+    expect(uniMpWeixin?.hmrMode).toBe('fallback-build')
+    expect(uniMpWeixin?.hmrNote).toContain('strict build fallback')
     expect(benchmarkProjects.filter(project => project.key.includes('taro') && project.target === 'mp-weixin').every(project => project.hmrMode === 'watch')).toBe(true)
     const realDevServerTargets = benchmarkProjects.filter(project => (project.target === 'h5' || project.target === 'web') && !project.key.includes('hbuilderx'))
     expect(realDevServerTargets.every(project => project.hmrMode === 'watch')).toBe(true)
@@ -67,6 +73,8 @@ describe('benchmark ci report', () => {
     expect(source).toContain("className=(['\"])(.*?)\\1")
     expect(source).toContain('data-tw-bench')
     expect(source).toContain('outputProbeTemplates')
+    expect(source).toContain('buildEnv.UNI_BUILD_STRICT=1')
+    expect(source).toContain('build skipped by uni-build-guard')
   })
 
   it('keeps published baseline failures non-blocking when current rows pass', async () => {

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -707,6 +707,16 @@ describe('e2e watch workflow', () => {
         watch_command_timeout_ms: '1500000',
       },
     ]
+    const mpxPrBudget = {
+      watch_case: 'mpx-tailwindcss-v4',
+      round_profile: 'default',
+      timeout_minutes: 35,
+      watch_timeout_ms: '240000',
+      watch_command_timeout_ms: '600000',
+      watch_main_style_only: '1',
+      watch_main_style_subpackage_limit: '0',
+      watch_max_plugin_process_ms: '30000',
+    }
     const slowNightlyBudgets = [
       {
         os: 'macos-latest',
@@ -784,6 +794,16 @@ describe('e2e watch workflow', () => {
         ...budget,
       }))
     }
+    expect(prRows).toContainEqual(expect.objectContaining({
+      os: 'macos-latest',
+      runner_label: 'macos',
+      ...mpxPrBudget,
+    }))
+    expect(prRows).toContainEqual(expect.objectContaining({
+      os: 'windows-latest',
+      runner_label: 'windows',
+      ...mpxPrBudget,
+    }))
     const slowStartupTaroWebpackPrRows = prRows.filter(row => typeof row.watch_case === 'string' && row.watch_case.startsWith('taro-webpack-'))
     expect(slowStartupTaroWebpackPrRows).not.toHaveLength(0)
     for (const row of slowStartupTaroWebpackPrRows) {

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -369,14 +369,17 @@ describe('ci workflows', () => {
     expect(releaseStep.env.NODE_AUTH_TOKEN).toBeUndefined()
   })
 
-  it('keeps PR benchmark coverage on the full demo matrix', () => {
+  it('keeps PR benchmark coverage on the smoke demo matrix', () => {
     const { workflow } = readWorkflow('benchmark.yml')
     const job = workflow.jobs['current-vs-published']
     const runCommand = stepRuns(workflow, 'current-vs-published').find(run => run.includes('pnpm bench:ci'))
 
-    expect(job['timeout-minutes']).toBeGreaterThanOrEqual(90)
-    expect(job.env.BENCH_ONLY).not.toContain('demo-weapp-vite-tailwindcss-v4')
-    expect(job.env.BENCH_ONLY).toBe("${{ github.event.inputs.only || '' }}")
+    expect(job['timeout-minutes']).toContain("github.event_name == 'pull_request' && 35")
+    expect(job['timeout-minutes']).toContain('|| 90')
+    expect(job.env.BENCH_ONLY).toContain('demo-weapp-vite-tailwindcss-v4__mp-weixin')
+    expect(job.env.BENCH_ONLY).toContain('demo-uni-app-vite-tailwindcss-v4__mp-weixin')
+    expect(job.env.BENCH_ONLY).toContain('demo-web-vue-vite-tailwindcss-v4__web')
+    expect(job.env.BENCH_ONLY).toContain("github.event.inputs.only || ''")
     expect(runCommand).toContain('--only "$BENCH_ONLY"')
   })
 
@@ -425,11 +428,13 @@ describe('ci workflows', () => {
       'next',
     ])
     expect(workflow.on.workflow_dispatch.inputs.baseline.default).toBe('auto')
-    expect(workflow.jobs['current-vs-published']['timeout-minutes']).toBe(90)
+    expect(workflow.jobs['current-vs-published']['timeout-minutes']).toContain("github.event_name == 'pull_request' && 35")
+    expect(workflow.jobs['current-vs-published']['timeout-minutes']).toContain('|| 90')
     expect(workflow.jobs['current-vs-published'].env.WEAPP_TW_BENCH_BASELINE).toContain('auto')
     expect(workflow.jobs['current-vs-published'].env.BENCH_BUILD_RUNS).toContain("github.event_name == 'pull_request' && '1'")
     expect(workflow.jobs['current-vs-published'].env.BENCH_HMR_RUNS).toContain("github.event_name == 'pull_request' && '1'")
-    expect(workflow.jobs['current-vs-published'].env.BENCH_ONLY).toBe("${{ github.event.inputs.only || '' }}")
+    expect(workflow.jobs['current-vs-published'].env.BENCH_ONLY).toContain("github.event_name == 'pull_request'")
+    expect(workflow.jobs['current-vs-published'].env.BENCH_ONLY).toContain("github.event.inputs.only || ''")
     expect(runs).toContain('pnpm install --frozen-lockfile')
     expect(runs).toContain('pnpm bench:ci --')
     expect(runs).toContain('--result-dir .tmp/benchmark-ci/result')


### PR DESCRIPTION
## 背景\n\nBenchmark workflow 在 PR 上会完整执行 current-vs-published 对比：复制两份仓库、分别 install/build:pkgs，然后串行跑全部 version-compare 项目。即使 PR 只需要快速回归信号，也会跑完整矩阵；任意 HMR timeout 还会额外消耗 180s。\n\n## 调整\n\n- PR 默认只跑 3 个代表性 benchmark smoke 项目：weapp-vite mp-weixin、uni-app vite mp-weixin、web vue vite。\n- push 到 main/alpha/beta/rc/next 和 workflow_dispatch 仍保留全量矩阵。\n- PR benchmark job timeout 从 90 分钟降到 35 分钟。\n\n## 验证\n\n- ruby YAML.load_file .github/workflows/benchmark.yml\n- node 校验 PR smoke benchmark key 均存在于 projects.mjs\n