### PR TITLE
fix: collect custom template attributes in source candidates

### DIFF
--- a/.changeset/soft-cups-juggle.md
+++ b/.changeset/soft-cups-juggle.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 Tailwind CSS v4 `@source` 扫描路径未复用 `customAttributes` 的问题，使 `t-class` 等自定义模板类名属性中的工具类可以参与 CSS 生成。

--- a/packages/weapp-tailwindcss/src/bundlers/gulp/shared/create-native-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/gulp/shared/create-native-framework-plugins.ts
@@ -246,6 +246,8 @@ export function createNativeGulpPlugins(options: UserDefinedOptions = {}) {
     }
     const collector = createSourceCandidateCollector({
       bareArbitraryValues: opts.arbitraryValues?.bareArbitraryValues,
+      customAttributesEntities: opts.customAttributesEntities,
+      disabledDefaultTemplateHandler: opts.disabledDefaultTemplateHandler,
     })
     await collector.scanRoot({
       entries: sourceScan?.entries,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
@@ -420,6 +420,8 @@ export function createViteFrameworkPlugins(
   let recordedGeneratorCandidates: Set<string> | undefined
   const sourceCandidateCollector = createSourceCandidateCollector({
     bareArbitraryValues: opts.arbitraryValues?.bareArbitraryValues,
+    customAttributesEntities,
+    disabledDefaultTemplateHandler,
   })
   const sourceCandidateScanCache = new LRUCache<string, SourceCandidateCollectorSnapshot>({
     max: SOURCE_CANDIDATE_SCAN_CACHE_MAX,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/source-candidates.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/source-candidates.ts
@@ -1,4 +1,5 @@
 import type { TailwindInlineSourceCandidates, TailwindSourceEntry } from '@/tailwindcss/source-scan'
+import type { ICustomAttributesEntities } from '@/types'
 import type { IArbitraryValues } from '@/types/shared'
 import { readFile } from 'node:fs/promises'
 import { LRUCache } from 'lru-cache'
@@ -70,6 +71,8 @@ export interface SourceCandidateCollectorOptions {
    * 是否补充 UnoCSS 风格裸任意值候选。
    */
   bareArbitraryValues?: IArbitraryValues['bareArbitraryValues'] | undefined
+  customAttributesEntities?: ICustomAttributesEntities | undefined
+  disabledDefaultTemplateHandler?: boolean | undefined
   extractor?: ((source: string, extension: string) => Promise<Iterable<string>> | Iterable<string>) | undefined
 }
 
@@ -93,9 +96,35 @@ function createSourceCandidateContentCacheKey(
   extension: string,
   source: string,
   bareArbitraryValues: IArbitraryValues['bareArbitraryValues'] | undefined,
+  customAttributesEntities: ICustomAttributesEntities | undefined,
+  disabledDefaultTemplateHandler: boolean | undefined,
   extractor: SourceCandidateCollectorOptions['extractor'],
 ) {
-  return `${extension}\0${JSON.stringify(bareArbitraryValues ?? false)}\0${extractor ? 'custom' : 'default'}\0${md5Hash(source)}`
+  return [
+    extension,
+    JSON.stringify(bareArbitraryValues ?? false),
+    createCustomAttributesCacheSignature(customAttributesEntities),
+    disabledDefaultTemplateHandler === true ? 'default-template:off' : 'default-template:on',
+    extractor ? 'custom' : 'default',
+    md5Hash(source),
+  ].join('\0')
+}
+
+function createCustomAttributesCacheSignature(customAttributesEntities: ICustomAttributesEntities | undefined) {
+  return JSON.stringify(
+    (customAttributesEntities ?? []).map(([selector, props]) => [
+      stringifyCustomAttributeToken(selector),
+      Array.isArray(props)
+        ? props.map(stringifyCustomAttributeToken)
+        : stringifyCustomAttributeToken(props),
+    ]),
+  )
+}
+
+function stringifyCustomAttributeToken(token: string | RegExp) {
+  return typeof token === 'string'
+    ? `s:${token}`
+    : `r:${token.source}/${token.flags}`
 }
 
 async function extractCandidates(
@@ -171,7 +200,14 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     const normalizedId = cleanUrl(id)
     scanSourceById.set(normalizedId, source)
     const extension = resolveSourceCandidateExtension(normalizedId)
-    const contentCacheKey = createSourceCandidateContentCacheKey(extension, source, options.bareArbitraryValues, options.extractor)
+    const contentCacheKey = createSourceCandidateContentCacheKey(
+      extension,
+      source,
+      options.bareArbitraryValues,
+      options.customAttributesEntities,
+      options.disabledDefaultTemplateHandler,
+      options.extractor,
+    )
     const cachedCandidates = sourceCandidateContentCache.get(contentCacheKey)
     if (cachedCandidates) {
       replaceScanLayer(normalizedId, new Set(cachedCandidates))
@@ -187,7 +223,14 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
   async function syncCss(id: string, source: string) {
     const normalizedId = cleanUrl(id)
     cssSourceById.set(normalizedId, source)
-    const contentCacheKey = createSourceCandidateContentCacheKey('css', source, options.bareArbitraryValues, options.extractor)
+    const contentCacheKey = createSourceCandidateContentCacheKey(
+      'css',
+      source,
+      options.bareArbitraryValues,
+      options.customAttributesEntities,
+      options.disabledDefaultTemplateHandler,
+      options.extractor,
+    )
     const cachedCandidates = sourceCandidateContentCache.get(contentCacheKey)
     if (cachedCandidates) {
       replaceCssLayer(normalizedId, new Set(cachedCandidates))
@@ -204,7 +247,14 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     const normalizedId = cleanUrl(id)
     transformSourceById.set(normalizedId, source)
     const extension = resolveSourceCandidateExtension(normalizedId)
-    const contentCacheKey = createSourceCandidateContentCacheKey(extension, source, options.bareArbitraryValues, options.extractor)
+    const contentCacheKey = createSourceCandidateContentCacheKey(
+      extension,
+      source,
+      options.bareArbitraryValues,
+      options.customAttributesEntities,
+      options.disabledDefaultTemplateHandler,
+      options.extractor,
+    )
     const cachedCandidates = sourceCandidateContentCache.get(contentCacheKey)
     const extractedCandidates = cachedCandidates
       ? new Set(cachedCandidates)

--- a/packages/weapp-tailwindcss/src/bundlers/webpack/BaseUnifiedPlugin/v5-assets/source-candidate-refresh.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/webpack/BaseUnifiedPlugin/v5-assets/source-candidate-refresh.ts
@@ -32,6 +32,8 @@ export async function refreshWebpackSourceCandidates(options: {
     changedFiles: options.watchChangedFiles,
     collector: createSourceCandidateStore({
       bareArbitraryValues: options.compilerOptions.arbitraryValues?.bareArbitraryValues,
+      customAttributesEntities: options.compilerOptions.customAttributesEntities,
+      disabledDefaultTemplateHandler: options.compilerOptions.disabledDefaultTemplateHandler,
     }),
     outDir: options.outputDir,
     root,

--- a/packages/weapp-tailwindcss/src/tailwindcss/candidates.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/candidates.ts
@@ -1,7 +1,10 @@
+import type { ICustomAttributesEntities } from '@/types'
 import type { IArbitraryValues } from '@/types/shared'
 import { extractSourceCandidates } from '@tailwindcss-mangle/engine'
+import { Parser } from 'htmlparser2'
 import { traverse } from '@/babel'
 import { babelParse } from '@/js/babel'
+import { createAttributeMatcher } from '@/wxml/custom-attributes'
 
 const SCRIPT_SOURCE_CANDIDATE_EXTENSIONS = new Set([
   'js',
@@ -14,8 +17,27 @@ const SCRIPT_SOURCE_CANDIDATE_EXTENSIONS = new Set([
   'cts',
 ])
 
+const TEMPLATE_SOURCE_CANDIDATE_EXTENSIONS = new Set([
+  'html',
+  'wxml',
+  'axml',
+  'jxml',
+  'ksml',
+  'ttml',
+  'qml',
+  'tyml',
+  'xhsml',
+  'swan',
+  'vue',
+  'uvue',
+  'nvue',
+  'mpx',
+])
+
 export interface SourceCandidateExtractionOptions {
   bareArbitraryValues?: IArbitraryValues['bareArbitraryValues'] | undefined
+  customAttributesEntities?: ICustomAttributesEntities | undefined
+  disabledDefaultTemplateHandler?: boolean | undefined
   extractor?: ((source: string, extension: string) => Promise<Iterable<string>> | Iterable<string>) | undefined
 }
 
@@ -33,6 +55,85 @@ export async function extractCandidatesFromSource(
   for (const candidate of scriptCandidates) {
     candidates.add(candidate)
   }
+  const templateAttributeCandidates = await extractTemplateAttributeCandidates(source, extension, options)
+  for (const candidate of templateAttributeCandidates) {
+    candidates.add(candidate)
+  }
+  return candidates
+}
+
+function isDefaultTemplateAttribute(name: string) {
+  if (name === 'class' || name === 'hover-class' || name === 'virtualhostclass') {
+    return true
+  }
+  const lowerName = name.toLowerCase()
+  return lowerName === 'class' || lowerName === 'hover-class' || lowerName === 'virtualhostclass'
+}
+
+async function extractCandidateTokensFromTemplateAttributeValue(
+  value: string,
+  options: SourceCandidateExtractionOptions,
+) {
+  return options.extractor
+    ? await options.extractor(value, 'html')
+    : await extractSourceCandidates(value, 'html', {
+        ...(options.bareArbitraryValues === undefined ? {} : { bareArbitraryValues: options.bareArbitraryValues }),
+      })
+}
+
+export async function extractTemplateAttributeCandidates(
+  source: string,
+  extension: string,
+  options: SourceCandidateExtractionOptions,
+) {
+  if (!TEMPLATE_SOURCE_CANDIDATE_EXTENSIONS.has(extension)) {
+    return []
+  }
+
+  if (!options.customAttributesEntities?.length) {
+    return []
+  }
+
+  const candidates = new Set<string>()
+  const matchCustomAttribute = createAttributeMatcher(options.customAttributesEntities)
+  const defaultTemplateHandlerEnabled = !options.disabledDefaultTemplateHandler
+  let tag = ''
+  const tasks: Array<Promise<void>> = []
+
+  const parser = new Parser(
+    {
+      onopentagname(name) {
+        tag = name
+      },
+      onattribute(name, value) {
+        if (!value) {
+          return
+        }
+        const shouldHandleDefault = defaultTemplateHandlerEnabled && isDefaultTemplateAttribute(name)
+        const shouldHandleCustom = matchCustomAttribute?.(tag, name) ?? false
+        if (!shouldHandleDefault && !shouldHandleCustom) {
+          return
+        }
+
+        tasks.push((async () => {
+          for (const candidate of await extractCandidateTokensFromTemplateAttributeValue(value, options)) {
+            candidates.add(candidate)
+          }
+        })())
+      },
+      onclosetag() {
+        tag = ''
+      },
+    },
+    {
+      xmlMode: true,
+    },
+  )
+
+  parser.write(source)
+  parser.end()
+  await Promise.all(tasks)
+
   return candidates
 }
 

--- a/packages/weapp-tailwindcss/test/bundlers/vite-source-candidates.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-source-candidates.unit.test.ts
@@ -50,6 +50,47 @@ describe('bundlers/vite source candidates', () => {
     expect(store.source('/project/pages/index.wxml')).toBe('<view class="text-[24rpx]"></view>')
   })
 
+  it('collects configured custom template attributes as Tailwind v4 source candidates', async () => {
+    const { createSourceCandidateCollector } = await import('@/bundlers/vite/source-candidates')
+    const collector = createSourceCandidateCollector({
+      customAttributesEntities: [['*', [/^t-class(?:-.+)?$/]]],
+    })
+
+    await collector.sync('/project/pages/index.wxml', [
+      '<t-button',
+      '  t-class="bg-[#1677ff] text-[28rpx]"',
+      '  t-class-content="px-[24rpx]"',
+      '  data-other="ignored-token"',
+      '></t-button>',
+    ].join('\n'))
+
+    const values = collector.values()
+    expect(values.has('bg-[#1677ff]')).toBe(true)
+    expect(values.has('text-[28rpx]')).toBe(true)
+    expect(values.has('px-[24rpx]')).toBe(true)
+  })
+
+  it('separates source candidate cache entries by custom template attributes', async () => {
+    const { createSourceCandidateCollector } = await import('@/bundlers/vite/source-candidates')
+    const source = '<t-button t-class="issue-977-token" data-other="ignored-token"></t-button>'
+    const extractor = (value: string) => value === 'issue-977-token' || value === 'ignored-token'
+      ? [value]
+      : []
+    const defaultCollector = createSourceCandidateCollector({
+      extractor,
+    })
+    const customCollector = createSourceCandidateCollector({
+      customAttributesEntities: [['*', ['t-class']]],
+      extractor,
+    })
+
+    await defaultCollector.sync('/project/pages/index.wxml', source)
+    await customCollector.sync('/project/pages/index.wxml', source)
+
+    expect(defaultCollector.values()).toEqual(new Set())
+    expect(customCollector.values()).toEqual(new Set(['issue-977-token']))
+  })
+
   it('bounds extracted candidate cache without retaining full hmr source text in keys', async () => {
     const {
       clearSourceCandidateContentCacheForTest,


### PR DESCRIPTION
## Summary

- Fix Tailwind CSS v4 `@source` source-candidate collection to reuse configured `customAttributes`, so component props such as `t-class` and `t-class-*` can generate CSS.
- Pass custom template attribute settings into Vite, Gulp, and Webpack source candidate collectors.
- Include custom attribute settings in the source candidate content cache key to avoid stale cross-config reuse.
- Add a Chinese patch changeset for `weapp-tailwindcss`.

Fixes #977.

## Tests

- `pnpm --filter weapp-tailwindcss exec vitest run test/bundlers/vite-source-candidates.unit.test.ts`
- `pnpm --filter weapp-tailwindcss exec vitest run test/bundlers/vite-source-candidates.unit.test.ts test/bundlers/webpack.v5.unit/source-candidate-cache.test.ts`
- `git diff --check`

## Notes

- `pnpm --filter weapp-tailwindcss run build:tsc` was attempted, but the current workspace fails on existing `e2e`/`tools` files outside the package `rootDir` and unrelated exact-optional-property type errors before reaching this change.
