### PR TITLE
fix: preserve uni-app root style shell during hmr

### DIFF
--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -378,6 +378,46 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  root-style-import-shell-hmr:
+    name: root-style-shell-hmr (${{ matrix.project }})
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - uni-app-vite-tailwindcss-v4
+          - subpackage-uni-app-vite-tailwindcss-v4
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build weapp-tailwindcss
+        run: pnpm --filter weapp-tailwindcss build
+
+      - name: Run root style import shell HMR regression
+        env:
+          E2E_ROOT_STYLE_SHELL_CASE: ${{ matrix.project }}
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: pnpm e2e:root-style-shell-hmr
+
   nightly-full-regression:
     name: e2e-watch-nightly (${{ matrix.runner_label }}-node${{ matrix['node-version'] || 22 }}-${{ matrix.watch_case }}-${{ matrix.round_profile }})
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_pr_quick_gate != true)

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -409,8 +409,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build weapp-tailwindcss
-        run: pnpm --filter weapp-tailwindcss build
+      - name: Build watch suite package dependencies
+        run: pnpm --filter weapp-tailwindcss... --filter "./packages-runtime/*" run build
 
       - name: Run root style import shell HMR regression
         env:

--- a/e2e/demoCoverageMatrix.ts
+++ b/e2e/demoCoverageMatrix.ts
@@ -27,6 +27,7 @@ export interface DemoPlatformCoverage {
   devScript?: string
   staticCoverage: DemoCoverageStatus
   hmrCoverage: DemoCoverageStatus
+  devHmrSnapshotCoverage: DemoCoverageStatus
   rootStyleShellHmrCoverage?: DemoCoverageStatus
   evidence: string
   command: string
@@ -57,6 +58,7 @@ function automated(platform: string, options: {
     platform,
     staticCoverage: 'automated',
     hmrCoverage: 'automated',
+    devHmrSnapshotCoverage: 'automated',
     ...(options.buildScript ? { buildScript: options.buildScript } : {}),
     ...(options.devScript ? { devScript: options.devScript } : {}),
     evidence: options.evidence,
@@ -77,6 +79,7 @@ function local(platform: string, options: {
     platform,
     staticCoverage: options.staticCoverage ?? 'local',
     hmrCoverage: options.hmrCoverage ?? 'local',
+    devHmrSnapshotCoverage: options.hmrCoverage ?? 'local',
     ...(options.buildScript ? { buildScript: options.buildScript } : {}),
     ...(options.devScript ? { devScript: options.devScript } : {}),
     evidence: options.evidence,

--- a/e2e/demoCoverageMatrix.ts
+++ b/e2e/demoCoverageMatrix.ts
@@ -27,6 +27,7 @@ export interface DemoPlatformCoverage {
   devScript?: string
   staticCoverage: DemoCoverageStatus
   hmrCoverage: DemoCoverageStatus
+  rootStyleShellHmrCoverage?: DemoCoverageStatus
   evidence: string
   command: string
   reason?: string
@@ -226,12 +227,15 @@ function uniAppPlatforms(name: string, platforms: string[]): DemoPlatformCoverag
     const buildScript = `build:${platform}`
     const devScript = `dev:${platform}`
     if (platform === 'mp-weixin' || platform === 'mp-alipay' || platform === 'mp-qq' || platform === 'mp-toutiao') {
-      return automated(platform, {
-        buildScript,
-        devScript,
-        evidence: 'watch-HMR mini-program platform case',
-        command: `E2E_WATCH_CASE=${name}:${platform} pnpm e2e:watch`,
-      })
+      return {
+        ...automated(platform, {
+          buildScript,
+          devScript,
+          evidence: 'watch-HMR mini-program platform case',
+          command: `E2E_WATCH_CASE=${name}:${platform} pnpm e2e:watch`,
+        }),
+        rootStyleShellHmrCoverage: 'automated',
+      }
     }
     if (platform === 'h5') {
       return automated(platform, {
@@ -280,7 +284,7 @@ function subpackageUniAppPlatforms(name: string): DemoPlatformCoverage[] {
         hmrCoverage: 'exempt',
       })
     }
-    return local(platform, {
+    const coverage = local(platform, {
       buildScript,
       devScript,
       evidence: 'multiplatform build output',
@@ -289,6 +293,15 @@ function subpackageUniAppPlatforms(name: string): DemoPlatformCoverage[] {
       staticCoverage: 'automated',
       hmrCoverage: 'exempt',
     })
+    if (platform === 'mp-weixin' || platform === 'mp-alipay' || platform === 'mp-toutiao') {
+      return {
+        ...coverage,
+        rootStyleShellHmrCoverage: 'automated',
+        evidence: 'multiplatform build output + root style import shell HMR matrix',
+        command: `E2E_ROOT_STYLE_SHELL_CASE=${name}:${platform} pnpm e2e:root-style-shell-hmr`,
+      }
+    }
+    return coverage
   })
 }
 

--- a/e2e/e2e-matrix.test.ts
+++ b/e2e/e2e-matrix.test.ts
@@ -342,6 +342,10 @@ describe('e2e matrix', () => {
       for (const platform of entry.platforms) {
         expect(platform.command.length, `${entry.name} ${platform.platform} should document a validation command`).toBeGreaterThan(0)
         expect(platform.evidence.length, `${entry.name} ${platform.platform} should document validation evidence`).toBeGreaterThan(0)
+        expect(
+          platform.devHmrSnapshotCoverage,
+          `${entry.name} ${platform.platform} dev/HMR snapshot coverage should match its HMR execution status`,
+        ).toBe(platform.hmrCoverage)
         if (platform.buildScript) {
           expect(
             pkg.scripts?.[scriptName(platform.buildScript)],

--- a/e2e/e2e-matrix.test.ts
+++ b/e2e/e2e-matrix.test.ts
@@ -20,6 +20,10 @@ import { miniProgramCases, uniAppAppCases, uniAppXAppCases, webCases } from './h
 import { MULTIPLATFORM_BUILD_OUTPUT_CASES } from './multiplatform-build-output/cases'
 import { MULTIPLATFORM_TARGETS } from './multiplatform-build-output/targets'
 import { E2E_PROJECTS } from './projectEntries'
+import {
+  createRootStyleImportShellHmrCases,
+  ROOT_STYLE_IMPORT_SHELL_HMR_EXEMPTIONS,
+} from './rootStyleImportShellHmr'
 import { taroWebHmrCaseNames } from './taro-web-demo-hmr-cases'
 import { webViteHmrCoverageCaseNames } from './web-vite-demo-hmr-cases'
 
@@ -254,6 +258,49 @@ function hasBuildOutputEvidence(name: string, platform: string, cases: Map<strin
 }
 
 describe('e2e matrix', () => {
+  it('covers every CI-compatible uni-app Vite root import shell demo and platform', () => {
+    const cases = createRootStyleImportShellHmrCases('/repo')
+    const casesByProject = new Map<string, typeof cases>()
+    for (const item of cases) {
+      const projectCases = casesByProject.get(item.project) ?? []
+      projectCases.push(item)
+      casesByProject.set(item.project, projectCases)
+    }
+
+    expect([...casesByProject.keys()].sort()).toEqual([
+      'subpackage-uni-app-vite-tailwindcss-v4',
+      'uni-app-vite-tailwindcss-v4',
+    ])
+    expect(casesByProject.get('uni-app-vite-tailwindcss-v4')?.map(item => item.platform)).toEqual([
+      'mp-weixin',
+      'mp-alipay',
+      'mp-qq',
+      'mp-toutiao',
+    ])
+    expect(casesByProject.get('subpackage-uni-app-vite-tailwindcss-v4')?.map(item => item.platform)).toEqual([
+      'mp-weixin',
+      'mp-alipay',
+      'mp-toutiao',
+    ])
+    for (const project of ['uni-app-vite-tailwindcss-v4', 'subpackage-uni-app-vite-tailwindcss-v4']) {
+      const entry = DEMO_COVERAGE_MATRIX.find(item => item.name === project)
+      for (const testCase of casesByProject.get(project) ?? []) {
+        expect(
+          entry?.platforms.find(item => item.platform === testCase.platform)?.rootStyleShellHmrCoverage,
+          `${testCase.name} should declare root style shell HMR coverage`,
+        ).toBe('automated')
+      }
+    }
+
+    expect(ROOT_STYLE_IMPORT_SHELL_HMR_EXEMPTIONS.map(item => item.project)).toEqual(expect.arrayContaining([
+      'taro-vite-react-tailwindcss-v4',
+      'taro-vite-vue3-tailwindcss-v4',
+      'issue-uview-plus-cssentries',
+      'uni-app-vite-vue3-hbuilderx-tailwindcss-v4',
+      'uni-app-x-hbuilderx-tailwindcss-v4',
+    ]))
+  })
+
   it('keeps every demo package explicit in the demo coverage matrix', () => {
     expect(DEMO_COVERAGE_MATRIX.map(item => item.name).sort()).toEqual(discoverDemoPackageNames())
   })

--- a/e2e/rootStyleImportShellHmr.ts
+++ b/e2e/rootStyleImportShellHmr.ts
@@ -1,0 +1,98 @@
+import path from 'pathe'
+
+export type RootStyleImportShellPlatform = 'mp-alipay' | 'mp-qq' | 'mp-toutiao' | 'mp-weixin'
+
+export interface RootStyleImportShellHmrCase {
+  name: string
+  project: string
+  projectRoot: string
+  platform: RootStyleImportShellPlatform
+  devScript: string
+  sourceFile: string
+  rootStyleFile: string
+  probeClass: string
+  probeValue: string
+}
+
+const styleExtensions: Record<RootStyleImportShellPlatform, string> = {
+  'mp-alipay': 'acss',
+  'mp-qq': 'qss',
+  'mp-toutiao': 'ttss',
+  'mp-weixin': 'wxss',
+}
+
+const projectConfigs = [
+  {
+    project: 'uni-app-vite-tailwindcss-v4',
+    platforms: ['mp-weixin', 'mp-alipay', 'mp-qq', 'mp-toutiao'],
+    sourceFile: 'src/App.vue',
+  },
+  {
+    project: 'subpackage-uni-app-vite-tailwindcss-v4',
+    platforms: ['mp-weixin', 'mp-alipay', 'mp-toutiao'],
+    sourceFile: 'src/pages/index/index.vue',
+  },
+] as const satisfies ReadonlyArray<{
+  project: string
+  platforms: readonly RootStyleImportShellPlatform[]
+  sourceFile?: string
+}>
+
+export const ROOT_STYLE_IMPORT_SHELL_HMR_EXEMPTIONS = [
+  {
+    project: 'uni-app-vite-vue3-hbuilderx-tailwindcss-v4',
+    reason: '小程序 dev 编译依赖本机 HBuilderX，不进入托管 CI 的 uni CLI watch 矩阵。',
+  },
+  {
+    project: 'uni-app-x-hbuilderx-tailwindcss-v4',
+    reason: 'uni-app x 小程序产物依赖本机 HBuilderX，不能由普通 Vite CI runner 生成。',
+  },
+  {
+    project: 'taro-vite-react-tailwindcss-v4',
+    reason: 'Taro app 样式是 import 与生成 CSS 合并产物，不是纯本地 import shell。',
+  },
+  {
+    project: 'taro-vite-vue3-tailwindcss-v4',
+    reason: 'Taro app 样式是 import 与生成 CSS 合并产物，不是纯本地 import shell。',
+  },
+  {
+    project: 'issue-uview-plus-cssentries',
+    reason: '该 demo 禁用 styleInjector，app 样式为空，Tailwind 输出位于 styles/tailwindcss.*。',
+  },
+] as const
+
+export function createRootStyleImportShellHmrCases(repositoryRoot: string): RootStyleImportShellHmrCase[] {
+  let probeIndex = 0
+
+  return projectConfigs.flatMap(({ project, platforms, sourceFile }) => {
+    const projectRoot = path.resolve(repositoryRoot, `demo/${project}`)
+    return platforms.map((platform) => {
+      probeIndex += 1
+      const probeValue = `${198 + probeIndex}.31rpx`
+      const extension = styleExtensions[platform]
+      return {
+        name: `${project}:${platform}`,
+        project,
+        projectRoot,
+        platform,
+        devScript: `dev:${platform}`,
+        sourceFile: path.resolve(projectRoot, sourceFile),
+        rootStyleFile: path.resolve(projectRoot, `dist/dev/${platform}/app.${extension}`),
+        probeClass: `text-[${probeValue}]`,
+        probeValue,
+      }
+    })
+  })
+}
+
+export function selectRootStyleImportShellHmrCases(
+  cases: RootStyleImportShellHmrCase[],
+  selection: string | undefined,
+) {
+  if (!selection || selection === 'ci' || selection === 'all') {
+    return cases
+  }
+
+  const selected = new Set(selection.split(',').map(item => item.trim()).filter(Boolean))
+  return cases.filter(item => selected.has(item.name) || selected.has(item.project))
+}

--- a/e2e/watch-artifact-snapshot-gate.test.ts
+++ b/e2e/watch-artifact-snapshot-gate.test.ts
@@ -1,0 +1,69 @@
+import type { WatchArtifactEntry, WatchCaseArtifacts } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { diffWatchArtifactSnapshots } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/artifacts'
+import { assertDevHmrArtifactSnapshotGate } from './watchArtifactSnapshotGate'
+
+function entry(file: string, content: string): WatchArtifactEntry {
+  return {
+    file,
+    absoluteFile: `/repo/${file}`,
+    exists: true,
+    size: Buffer.byteLength(content),
+    sha256: createHash('sha256').update(content).digest('hex'),
+    kind: 'text',
+    content,
+  }
+}
+
+function artifacts(options: {
+  devApp?: string
+  devMain?: string
+  hmrApp?: string
+  hmrMain?: string
+} = {}): WatchCaseArtifacts {
+  const dev = {
+    phase: 'dev' as const,
+    capturedAt: '2026-07-10T00:00:00.000Z',
+    files: [
+      entry('dist/mp/app.wxss', options.devApp ?? '@import "./main.wxss";\n'),
+      entry('dist/mp/main.wxss', options.devMain ?? '.dev-tailwind{display:block}\n'),
+    ],
+  }
+  const hmr = {
+    phase: 'hmr' as const,
+    capturedAt: '2026-07-10T00:00:01.000Z',
+    requestedHmrCount: 5,
+    capturedAfterHmrCount: 6,
+    files: [
+      entry('dist/mp/app.wxss', options.hmrApp ?? '@import "./main.wxss";\n'),
+      entry('dist/mp/main.wxss', options.hmrMain ?? '.hmr-tailwind{display:block}\n'),
+    ],
+  }
+  return {
+    requestedHmrCount: 5,
+    capturedAfterHmrCount: 6,
+    dev,
+    hmr,
+    diff: diffWatchArtifactSnapshots(dev, hmr, 5, 6),
+  }
+}
+
+describe('dev/HMR artifact snapshot gate', () => {
+  it('accepts a preserved import shell and non-empty generated target', () => {
+    expect(() => assertDevHmrArtifactSnapshotGate('uni-app', artifacts())).not.toThrow()
+  })
+
+  it('rejects an import shell overwritten by generated css after HMR', () => {
+    expect(() => assertDevHmrArtifactSnapshotGate('uni-app', artifacts({
+      hmrApp: '.hmr-tailwind{display:block}\n',
+    }))).toThrow('HMR replaced local import shell output')
+  })
+
+  it('rejects an empty imported style target after HMR', () => {
+    expect(() => assertDevHmrArtifactSnapshotGate('uni-app', artifacts({
+      hmrMain: '',
+    }))).toThrow('HMR import shell target is missing or empty')
+  })
+})

--- a/e2e/watch/hot-update/demo/uni-app-vite-tailwindcss-v4.test.ts
+++ b/e2e/watch/hot-update/demo/uni-app-vite-tailwindcss-v4.test.ts
@@ -1,5 +1,89 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { describe, it } from 'vitest'
+import { createWatchSession } from '../../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/session'
+import { readFileIfExists, waitFor, writeFilePreserveEol } from '../../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/text'
 import { resolveCaseName, runHotUpdateTarget, shouldRunTarget } from '../shared'
+
+const ROOT_STYLE_HMR_TIMEOUT_MS = 240000
+const ROOT_STYLE_HMR_PROBE = 'text-[198.31rpx]'
+
+async function runRootStyleImportShellHmr(options: {
+  devScript: string
+  extension: 'acss' | 'wxss'
+  platform: 'mp-alipay' | 'mp-weixin'
+}) {
+  const projectRoot = path.resolve(import.meta.dirname, '../../../../demo/uni-app-vite-tailwindcss-v4')
+  const appSourceFile = path.join(projectRoot, 'src/App.vue')
+  const outputRoot = path.join(projectRoot, 'dist/dev', options.platform)
+  const appStyleFile = path.join(outputRoot, `app.${options.extension}`)
+  const mainStyleFile = path.join(outputRoot, `main.${options.extension}`)
+  const importShell = `@import "./main.${options.extension}";`
+  const originalSource = await fs.readFile(appSourceFile, 'utf8')
+  const updatedSource = originalSource.replace(
+    '</script>',
+    `const rootStyleHmrProbe = '${ROOT_STYLE_HMR_PROBE}'\n</script>`,
+  )
+  if (updatedSource === originalSource) {
+    throw new Error(`[${options.platform}] App.vue script fixture is missing`)
+  }
+
+  const assertOutputs = async (hasProbe: boolean) => {
+    const [appStyle, mainStyle] = await Promise.all([
+      readFileIfExists(appStyleFile),
+      readFileIfExists(mainStyleFile),
+    ])
+    if (appStyle?.trim() !== importShell || !mainStyle?.includes('--tw-')) {
+      return false
+    }
+    return mainStyle.includes('198.31rpx') === hasProbe
+  }
+
+  const sessionStartedAt = Date.now()
+  const session = createWatchSession(projectRoot, options.devScript, { quietSass: true })
+  try {
+    await waitFor(
+      async () => session.lastCompileSuccessAt() > sessionStartedAt && await assertOutputs(false),
+      {
+        timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
+        pollMs: 50,
+        message: `[${options.platform}] initial root style import shell was not generated`,
+        onTick: session.ensureRunning,
+      },
+      sessionStartedAt,
+    )
+
+    const updateStartedAt = Date.now()
+    await writeFilePreserveEol(appSourceFile, updatedSource, originalSource)
+    await waitFor(
+      async () => session.lastCompileSuccessAt() > updateStartedAt && await assertOutputs(true),
+      {
+        timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
+        pollMs: 50,
+        message: `[${options.platform}] root style import shell was not preserved after App.vue update`,
+        onTick: session.ensureRunning,
+      },
+      updateStartedAt,
+    )
+
+    const rollbackStartedAt = Date.now()
+    await writeFilePreserveEol(appSourceFile, originalSource, updatedSource)
+    await waitFor(
+      async () => session.lastCompileSuccessAt() > rollbackStartedAt && await assertOutputs(false),
+      {
+        timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
+        pollMs: 50,
+        message: `[${options.platform}] root style import shell was not preserved after App.vue rollback`,
+        onTick: session.ensureRunning,
+      },
+      rollbackStartedAt,
+    )
+  }
+  finally {
+    await writeFilePreserveEol(appSourceFile, originalSource, originalSource).catch(() => undefined)
+    await session.stop()
+  }
+}
 
 describe('e2e watch hot-update uni-app-vite-tailwindcss-v4', () => {
   const caseName = resolveCaseName()
@@ -13,4 +97,11 @@ describe('e2e watch hot-update uni-app-vite-tailwindcss-v4', () => {
   it('should verify template/script/style hot updates and project report for uni-app-vite-tailwindcss-v4', async () => {
     await runHotUpdateTarget(target)
   })
+
+  it.each([
+    { devScript: 'dev:mp-weixin', extension: 'wxss', platform: 'mp-weixin' },
+    { devScript: 'dev:mp-alipay', extension: 'acss', platform: 'mp-alipay' },
+  ] as const)('should preserve the uni-app root $extension import shell during App.vue HMR', async (options) => {
+    await runRootStyleImportShellHmr(options)
+  }, ROOT_STYLE_HMR_TIMEOUT_MS)
 })

--- a/e2e/watch/hot-update/demo/uni-app-vite-tailwindcss-v4.test.ts
+++ b/e2e/watch/hot-update/demo/uni-app-vite-tailwindcss-v4.test.ts
@@ -1,89 +1,5 @@
-import fs from 'node:fs/promises'
-import path from 'node:path'
 import { describe, it } from 'vitest'
-import { createWatchSession } from '../../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/session'
-import { readFileIfExists, waitFor, writeFilePreserveEol } from '../../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/text'
 import { resolveCaseName, runHotUpdateTarget, shouldRunTarget } from '../shared'
-
-const ROOT_STYLE_HMR_TIMEOUT_MS = 240000
-const ROOT_STYLE_HMR_PROBE = 'text-[198.31rpx]'
-
-async function runRootStyleImportShellHmr(options: {
-  devScript: string
-  extension: 'acss' | 'wxss'
-  platform: 'mp-alipay' | 'mp-weixin'
-}) {
-  const projectRoot = path.resolve(import.meta.dirname, '../../../../demo/uni-app-vite-tailwindcss-v4')
-  const appSourceFile = path.join(projectRoot, 'src/App.vue')
-  const outputRoot = path.join(projectRoot, 'dist/dev', options.platform)
-  const appStyleFile = path.join(outputRoot, `app.${options.extension}`)
-  const mainStyleFile = path.join(outputRoot, `main.${options.extension}`)
-  const importShell = `@import "./main.${options.extension}";`
-  const originalSource = await fs.readFile(appSourceFile, 'utf8')
-  const updatedSource = originalSource.replace(
-    '</script>',
-    `const rootStyleHmrProbe = '${ROOT_STYLE_HMR_PROBE}'\n</script>`,
-  )
-  if (updatedSource === originalSource) {
-    throw new Error(`[${options.platform}] App.vue script fixture is missing`)
-  }
-
-  const assertOutputs = async (hasProbe: boolean) => {
-    const [appStyle, mainStyle] = await Promise.all([
-      readFileIfExists(appStyleFile),
-      readFileIfExists(mainStyleFile),
-    ])
-    if (appStyle?.trim() !== importShell || !mainStyle?.includes('--tw-')) {
-      return false
-    }
-    return mainStyle.includes('198.31rpx') === hasProbe
-  }
-
-  const sessionStartedAt = Date.now()
-  const session = createWatchSession(projectRoot, options.devScript, { quietSass: true })
-  try {
-    await waitFor(
-      async () => session.lastCompileSuccessAt() > sessionStartedAt && await assertOutputs(false),
-      {
-        timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
-        pollMs: 50,
-        message: `[${options.platform}] initial root style import shell was not generated`,
-        onTick: session.ensureRunning,
-      },
-      sessionStartedAt,
-    )
-
-    const updateStartedAt = Date.now()
-    await writeFilePreserveEol(appSourceFile, updatedSource, originalSource)
-    await waitFor(
-      async () => session.lastCompileSuccessAt() > updateStartedAt && await assertOutputs(true),
-      {
-        timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
-        pollMs: 50,
-        message: `[${options.platform}] root style import shell was not preserved after App.vue update`,
-        onTick: session.ensureRunning,
-      },
-      updateStartedAt,
-    )
-
-    const rollbackStartedAt = Date.now()
-    await writeFilePreserveEol(appSourceFile, originalSource, updatedSource)
-    await waitFor(
-      async () => session.lastCompileSuccessAt() > rollbackStartedAt && await assertOutputs(false),
-      {
-        timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
-        pollMs: 50,
-        message: `[${options.platform}] root style import shell was not preserved after App.vue rollback`,
-        onTick: session.ensureRunning,
-      },
-      rollbackStartedAt,
-    )
-  }
-  finally {
-    await writeFilePreserveEol(appSourceFile, originalSource, originalSource).catch(() => undefined)
-    await session.stop()
-  }
-}
 
 describe('e2e watch hot-update uni-app-vite-tailwindcss-v4', () => {
   const caseName = resolveCaseName()
@@ -97,11 +13,4 @@ describe('e2e watch hot-update uni-app-vite-tailwindcss-v4', () => {
   it('should verify template/script/style hot updates and project report for uni-app-vite-tailwindcss-v4', async () => {
     await runHotUpdateTarget(target)
   })
-
-  it.each([
-    { devScript: 'dev:mp-weixin', extension: 'wxss', platform: 'mp-weixin' },
-    { devScript: 'dev:mp-alipay', extension: 'acss', platform: 'mp-alipay' },
-  ] as const)('should preserve the uni-app root $extension import shell during App.vue HMR', async (options) => {
-    await runRootStyleImportShellHmr(options)
-  }, ROOT_STYLE_HMR_TIMEOUT_MS)
 })

--- a/e2e/watch/hot-update/shared.ts
+++ b/e2e/watch/hot-update/shared.ts
@@ -1,4 +1,4 @@
-import type { ConcreteOrPlatformWatchCaseName } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
+import type { ConcreteOrPlatformWatchCaseName, WatchCaseArtifacts } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
 import fs from 'node:fs/promises'
 import process from 'node:process'
 import { execa } from 'execa'
@@ -6,6 +6,7 @@ import path from 'pathe'
 import { expect } from 'vitest'
 import { buildCases, demoWatchShardCases, getBaseWatchCaseName, isDemoWatchShardName, isLocalOnlyWatchCase } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases'
 import { DEFAULT_PLUGIN_PROCESS_BUDGET_MS } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
+import { assertDevHmrArtifactSnapshotGate } from '../../watchArtifactSnapshotGate'
 
 export type WatchProjectGroup = 'demo'
 export type DemoWatchShardName
@@ -339,6 +340,7 @@ interface HotUpdateCaseReport {
   rollbackOutputMs: number
   rollbackEffectiveMs: number
   totalMs: number
+  artifacts?: WatchCaseArtifacts
 }
 
 interface HmrDurationTiming {
@@ -1122,6 +1124,7 @@ export function assertHotUpdateReport(report: HotUpdateReport, target: WatchCase
     expect(item.hotUpdateEffectiveMs).toBeGreaterThan(0)
     expect(item.hotUpdateEffectiveMs).toBeLessThanOrEqual(maxHotUpdateMs)
     expect(item.rollbackEffectiveMs).toBeGreaterThan(0)
+    assertDevHmrArtifactSnapshotGate(item.project, item.artifacts)
     expect(item.classTokens.length).toBeGreaterThan(0)
     expect(item.escapedClasses.length).toBe(item.classTokens.length)
     expect(item.rounds.length).toBeGreaterThanOrEqual(requiredMutationRounds.length)

--- a/e2e/watch/root-style-import-shell-hmr.test.ts
+++ b/e2e/watch/root-style-import-shell-hmr.test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs/promises'
+import path from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { createWatchSession } from '../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/session'
+import { readFileIfExists, waitFor, writeFilePreserveEol } from '../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/text'
+import {
+  createRootStyleImportShellHmrCases,
+  selectRootStyleImportShellHmrCases,
+} from '../rootStyleImportShellHmr'
+
+const ROOT_STYLE_HMR_TIMEOUT_MS = 180_000
+const ROOT_STYLE_HMR_TEST_TIMEOUT_MS = ROOT_STYLE_HMR_TIMEOUT_MS + 30_000
+const PURE_LOCAL_IMPORT_RE = /^@import (['"])(\.[^'"]+)\1;$/
+
+function mutateAppSource(source: string, probeClass: string) {
+  if (source.includes('</script>')) {
+    return source.replace(
+      '</script>',
+      `const rootStyleImportShellHmrProbe = '${probeClass}'\n</script>`,
+    )
+  }
+  if (source.includes('</template>')) {
+    return source.replace(
+      '</template>',
+      `  <view hidden class="${probeClass}">root-style-import-shell-hmr</view>\n</template>`,
+    )
+  }
+  throw new Error('Mutation source is missing a script or template closing tag')
+}
+
+async function inspectRootStyle(rootStyleFile: string) {
+  const rootStyle = await readFileIfExists(rootStyleFile)
+  const match = rootStyle?.trim().match(PURE_LOCAL_IMPORT_RE)
+  if (!rootStyle || !match) {
+    return undefined
+  }
+
+  const importRequest = match[2]
+  const generatedStyleFile = path.resolve(path.dirname(rootStyleFile), importRequest)
+  const generatedStyle = await readFileIfExists(generatedStyleFile)
+  if (!generatedStyle) {
+    return undefined
+  }
+
+  return {
+    rootStyle,
+    importRequest,
+    generatedStyle,
+    generatedStyleFile,
+  }
+}
+
+const enabled = process.env.E2E_ROOT_STYLE_SHELL_HMR === '1'
+const repositoryRoot = path.resolve(import.meta.dirname, '../..')
+const cases = selectRootStyleImportShellHmrCases(
+  createRootStyleImportShellHmrCases(repositoryRoot),
+  process.env.E2E_ROOT_STYLE_SHELL_CASE,
+)
+
+if (enabled && cases.length === 0) {
+  throw new Error(`No root style import shell HMR cases matched: ${process.env.E2E_ROOT_STYLE_SHELL_CASE ?? ''}`)
+}
+
+describe.skipIf(!enabled)('root style pure import shell HMR', () => {
+  it.each(cases)('$name keeps the root wrapper and replays generated CSS', async (testCase) => {
+    const originalSource = await fs.readFile(testCase.sourceFile, 'utf8')
+    const updatedSource = mutateAppSource(originalSource, testCase.probeClass)
+    const sessionStartedAt = Date.now()
+    const session = createWatchSession(testCase.projectRoot, testCase.devScript, { quietSass: true })
+    let initialRootStyle = ''
+    let initialImportRequest = ''
+
+    try {
+      await waitFor(
+        async () => {
+          const output = await inspectRootStyle(testCase.rootStyleFile)
+          if (session.lastCompileSuccessAt() <= sessionStartedAt || !output?.generatedStyle.includes('--tw-')) {
+            return false
+          }
+          initialRootStyle = output.rootStyle
+          initialImportRequest = output.importRequest
+          return !output.generatedStyle.includes(testCase.probeValue)
+        },
+        {
+          timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
+          pollMs: 50,
+          message: `[${testCase.name}] initial pure root style import shell was not generated`,
+          onTick: session.ensureRunning,
+        },
+        sessionStartedAt,
+      )
+
+      const updateStartedAt = Date.now()
+      await writeFilePreserveEol(testCase.sourceFile, updatedSource, originalSource)
+      await waitFor(
+        async () => {
+          const output = await inspectRootStyle(testCase.rootStyleFile)
+          return session.lastCompileSuccessAt() > updateStartedAt
+            && output?.rootStyle === initialRootStyle
+            && output.importRequest === initialImportRequest
+            && output.generatedStyle.includes('--tw-')
+            && output.generatedStyle.includes(testCase.probeValue)
+        },
+        {
+          timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
+          pollMs: 50,
+          message: `[${testCase.name}] root import shell was not preserved after candidate update`,
+          onTick: session.ensureRunning,
+        },
+        updateStartedAt,
+      )
+
+      const rollbackStartedAt = Date.now()
+      await writeFilePreserveEol(testCase.sourceFile, originalSource, updatedSource)
+      await waitFor(
+        async () => {
+          const output = await inspectRootStyle(testCase.rootStyleFile)
+          return session.lastCompileSuccessAt() > rollbackStartedAt
+            && output?.rootStyle === initialRootStyle
+            && output.importRequest === initialImportRequest
+            && output.generatedStyle.includes('--tw-')
+            && !output.generatedStyle.includes(testCase.probeValue)
+        },
+        {
+          timeoutMs: ROOT_STYLE_HMR_TIMEOUT_MS,
+          pollMs: 50,
+          message: `[${testCase.name}] root import shell was not preserved after candidate rollback`,
+          onTick: session.ensureRunning,
+        },
+        rollbackStartedAt,
+      )
+
+      const finalOutput = await inspectRootStyle(testCase.rootStyleFile)
+      expect(finalOutput?.generatedStyleFile).toBe(path.resolve(path.dirname(testCase.rootStyleFile), initialImportRequest))
+    }
+    finally {
+      await writeFilePreserveEol(testCase.sourceFile, originalSource, originalSource).catch(() => undefined)
+      await session.stop()
+    }
+  }, ROOT_STYLE_HMR_TEST_TIMEOUT_MS)
+})

--- a/e2e/watchArtifactSnapshotGate.ts
+++ b/e2e/watchArtifactSnapshotGate.ts
@@ -1,0 +1,136 @@
+import type { WatchArtifactEntry, WatchArtifactSnapshot, WatchCaseArtifacts } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
+import { Buffer } from 'node:buffer'
+import { createHash } from 'node:crypto'
+import path from 'node:path'
+import {
+  collectCssImportRequestsRoot,
+  isLocalCssImportRequest,
+  isPureLocalCssImportWrapper,
+  postcss,
+} from '../packages/postcss/src/index'
+import { diffWatchArtifactSnapshots } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/artifacts'
+
+const SHA256_RE = /^[a-f0-9]{64}$/
+
+function fail(label: string, message: string): never {
+  throw new Error(`[${label}] dev/HMR artifact snapshot gate: ${message}`)
+}
+
+function sha256(content: string) {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+function assertSnapshotEntry(label: string, phase: WatchArtifactSnapshot['phase'], entry: WatchArtifactEntry) {
+  if (!entry.file || path.isAbsolute(entry.file)) {
+    fail(label, `${phase} snapshot has an invalid relative file: ${entry.file}`)
+  }
+  if (!entry.exists) {
+    if (entry.size !== 0 || entry.sha256 != null || entry.content != null) {
+      fail(label, `${phase} snapshot missing file carries content metadata: ${entry.file}`)
+    }
+    return
+  }
+  if (!entry.sha256 || !SHA256_RE.test(entry.sha256)) {
+    fail(label, `${phase} snapshot file has no valid sha256: ${entry.file}`)
+  }
+  if (entry.size < 0) {
+    fail(label, `${phase} snapshot file has an invalid size: ${entry.file}`)
+  }
+  if (entry.content != null) {
+    if (Buffer.byteLength(entry.content) !== entry.size) {
+      fail(label, `${phase} snapshot content size mismatch: ${entry.file}`)
+    }
+    if (sha256(entry.content) !== entry.sha256) {
+      fail(label, `${phase} snapshot content hash mismatch: ${entry.file}`)
+    }
+  }
+}
+
+function snapshotByFile(label: string, snapshot: WatchArtifactSnapshot) {
+  const entries = new Map<string, WatchArtifactEntry>()
+  for (const entry of snapshot.files) {
+    assertSnapshotEntry(label, snapshot.phase, entry)
+    if (entries.has(entry.file)) {
+      fail(label, `${snapshot.phase} snapshot contains duplicate file: ${entry.file}`)
+    }
+    entries.set(entry.file, entry)
+  }
+  if (entries.size === 0) {
+    fail(label, `${snapshot.phase} snapshot contains no output files`)
+  }
+  return entries
+}
+
+function resolveImportTargets(file: string, css: string) {
+  const root = postcss.parse(css)
+  const baseDir = path.posix.dirname(file)
+  return [...collectCssImportRequestsRoot(root)]
+    .filter(isLocalCssImportRequest)
+    .map(request => request.replace(/[?#].*$/, ''))
+    .map(request => path.posix.normalize(path.posix.join(baseDir === '.' ? '' : baseDir, request)))
+    .sort()
+}
+
+function assertImportShellSnapshots(
+  label: string,
+  devByFile: ReadonlyMap<string, WatchArtifactEntry>,
+  hmrByFile: ReadonlyMap<string, WatchArtifactEntry>,
+) {
+  for (const [file, devEntry] of devByFile) {
+    if (devEntry.content == null || !isPureLocalCssImportWrapper(devEntry.content)) {
+      continue
+    }
+    const hmrEntry = hmrByFile.get(file)
+    if (!hmrEntry?.exists || hmrEntry.content == null || !isPureLocalCssImportWrapper(hmrEntry.content)) {
+      fail(label, `HMR replaced local import shell output: ${file}`)
+    }
+    const devTargets = resolveImportTargets(file, devEntry.content)
+    const hmrTargets = resolveImportTargets(file, hmrEntry.content)
+    if (JSON.stringify(hmrTargets) !== JSON.stringify(devTargets)) {
+      fail(label, `HMR changed local import shell targets: ${file}`)
+    }
+    for (const target of devTargets) {
+      const devTarget = devByFile.get(target)
+      const hmrTarget = hmrByFile.get(target)
+      if (!devTarget?.exists || devTarget.size === 0) {
+        fail(label, `dev import shell target is missing or empty: ${file} -> ${target}`)
+      }
+      if (!hmrTarget?.exists || hmrTarget.size === 0) {
+        fail(label, `HMR import shell target is missing or empty: ${file} -> ${target}`)
+      }
+    }
+  }
+}
+
+export function assertDevHmrArtifactSnapshotGate(label: string, artifacts: WatchCaseArtifacts | undefined) {
+  if (!artifacts) {
+    fail(label, 'report is missing artifacts.dev and artifacts.hmr')
+  }
+  if (artifacts.requestedHmrCount < 1 || artifacts.capturedAfterHmrCount < artifacts.requestedHmrCount) {
+    fail(label, `HMR snapshot was captured too early: ${artifacts.capturedAfterHmrCount}/${artifacts.requestedHmrCount}`)
+  }
+  if (artifacts.dev.phase !== 'dev' || artifacts.hmr.phase !== 'hmr') {
+    fail(label, `snapshot phases are invalid: ${artifacts.dev.phase}/${artifacts.hmr.phase}`)
+  }
+  const devByFile = snapshotByFile(label, artifacts.dev)
+  const hmrByFile = snapshotByFile(label, artifacts.hmr)
+  assertImportShellSnapshots(label, devByFile, hmrByFile)
+
+  const recomputed = diffWatchArtifactSnapshots(
+    artifacts.dev,
+    artifacts.hmr,
+    artifacts.requestedHmrCount,
+    artifacts.capturedAfterHmrCount,
+  )
+  if (
+    artifacts.diff.from !== 'dev'
+    || artifacts.diff.to !== 'hmr'
+    || artifacts.diff.requestedHmrCount !== artifacts.requestedHmrCount
+    || artifacts.diff.capturedAfterHmrCount !== artifacts.capturedAfterHmrCount
+    || artifacts.diff.changedFileCount !== recomputed.changedFileCount
+    || JSON.stringify(artifacts.diff.files) !== JSON.stringify(recomputed.files)
+    || artifacts.diff.text !== recomputed.text
+  ) {
+    fail(label, 'dev/HMR artifact diff does not match the captured snapshots')
+  }
+}

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "e2e:hot-update:demo": "cross-env E2E_HOT_UPDATE_TARGET=demo pnpm e2e:hot-update",
     "e2e:hot-update:apps": "echo \"apps hot-update target has moved to demo\"",
     "e2e:watch": "vitest run -c ./e2e/vitest.e2e.watch.config.ts",
+    "e2e:root-style-shell-hmr": "cross-env E2E_ROOT_STYLE_SHELL_HMR=1 vitest run --bail=1 -c ./e2e/vitest.e2e.watch.config.ts e2e/watch/root-style-import-shell-hmr.test.ts",
     "e2e:watch:full": "cross-env E2E_WATCH_SKIP_BUILD=0 pnpm e2e:watch",
     "e2e:watch:dev": "vitest -c ./e2e/vitest.e2e.watch.config.ts",
     "e2e:watch:demo": "cross-env E2E_WATCH_CASE=demo pnpm e2e:watch",

--- a/packages/weapp-tailwindcss/src/bundlers/vite/css-finalizer.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/css-finalizer.ts
@@ -23,6 +23,7 @@ import { normalizeMiniProgramGeneratorCssSource } from '../shared/generator-css/
 import { generateTailwindV4Css } from '../shared/v4-generation-core'
 import { resolveMiniProgramStyleOutputExtension, resolveViteCssPipelineOutputFile } from './generate-bundle'
 import { normalizeRootMiniProgramImportShellAssets } from './generate-bundle/finalize'
+import { restoreFrameworkRootMiniProgramImportShellAssets } from './generate-bundle/root-style-output'
 import { collectViteProcessedCssAssetResults, injectViteProcessedCssIntoMainCssAssets } from './processed-css-assets'
 import { isHTMLRequest } from './utils'
 import { resolveSourceRootFromBundleGraph, resolveWeappViteSourceRoot } from './weapp-vite-config'
@@ -56,6 +57,7 @@ interface CssFinalizerContext {
   rememberMainCssSource?: (file: string, rawSource: string) => void
   getRememberedMainCssSource?: (file: string) => RememberedMainCssSource | undefined
   isViteProcessedCssAsset?: (asset: OutputAsset, file?: string) => boolean
+  frameworkRootImportShellTargetByFile?: ReadonlyMap<string, string> | undefined
 }
 
 interface CssFinalizerThis {
@@ -220,6 +222,7 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
           rememberMainCssSource,
           getRememberedMainCssSource,
           isViteProcessedCssAsset,
+          frameworkRootImportShellTargetByFile,
         } = context
         const resolvedConfig = getResolvedConfig()
         const uniUtsPlatform = resolveUniUtsPlatform()
@@ -260,6 +263,19 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
           : rootDir
         const sourceRoot = resolveWeappViteSourceRoot(resolvedConfig, opts.appType)
           ?? resolveSourceRootFromBundleGraph(resolvedConfig, bundle)
+        restoreFrameworkRootMiniProgramImportShellAssets(bundle, {
+          debug,
+          isWebGeneratorTarget,
+          matchesCss: opts.cssMatcher,
+          onUpdate: opts.onUpdate,
+          recordCssAssetResult,
+          shouldKeep: (file, css) => cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+            ...createCssPipelineContext(file),
+            css,
+            file,
+          }),
+          targetByFile: frameworkRootImportShellTargetByFile ?? new Map(),
+        })
         const sourceTraceTokenSources = getSourceCandidateSourcesForEntries
           ? createCssTokenSourceMap(getSourceCandidateSourcesForEntries(undefined), opts)
           : undefined

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
@@ -25,7 +25,7 @@ import { collectConfiguredTailwindV4CssSourceEntries } from './generate-bundle/c
 import { createCssAssetEmitter, resolveAssetSourceFile } from './generate-bundle/css-assets'
 import { normalizeRelativeCssConfigDirectives } from './generate-bundle/css-config-directives'
 import { createCssHandlerOptionsCache, resolveViteCssHandlerExtraOptions } from './generate-bundle/css-handler-options'
-import { normalizeCssSourceForCompare, resolveMiniProgramStyleOutputExtension, resolveViteCssPipelineOutputFile } from './generate-bundle/css-output'
+import { normalizeCssSourceForCompare, resolveMiniProgramStyleOutputExtension, resolveReplayCssOutputFile, resolveViteCssPipelineOutputFile } from './generate-bundle/css-output'
 import { applyCssResultToBundle, createMatchedCssSourceOutputResolver, hasViteProcessedCssResultForSource, resolveCssBundleOutputFile, resolveOutputFileFromMatchedCssSource, shouldSkipRawSourceStyleAsset } from './generate-bundle/css-output-helpers'
 import { createCssRuntimeSignature, createCssTransformShareScopeKey } from './generate-bundle/css-share-scope'
 import { hasOmittedKnownBundleFiles } from './generate-bundle/dirty-state'
@@ -41,7 +41,7 @@ import { logBundleProcessPlan } from './generate-bundle/process-plan'
 import { createRememberedCssRuntimeSignature, findRememberedCssSources, mergeRememberedCssSources } from './generate-bundle/remembered-css'
 import { processRememberedCssReplay } from './generate-bundle/remembered-css-replay'
 import { registerGeneratorDependencies } from './generate-bundle/rollup-assets'
-import { shouldKeepRootMiniProgramStyleAsImportShell } from './generate-bundle/root-style-output'
+import { isRootMiniProgramStyleOutputFile, resolveSingleCssImportOutputFile, shouldKeepRootMiniProgramStyleAsImportShell, shouldPreserveFrameworkRootMiniProgramImportShell } from './generate-bundle/root-style-output'
 import { collectCssExtensionByStem, collectJsImportedCssFiles, collectRuntimeLinkedCssFiles } from './generate-bundle/runtime-linked-css'
 import { rememberRuntimeLinkedCssSources } from './generate-bundle/runtime-linked-source-memory'
 import { createScopedGeneratorCandidateSignature, createScopedGeneratorSourceTraceMap, createScopedGeneratorRuntime as resolveScopedGeneratorRuntime } from './generate-bundle/scoped-generator'
@@ -95,6 +95,7 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
   const lastCssResultByFile = new Map<string, string>()
   const lastCssSourceHashByFile = new Map<string, string>()
   const lastCssRawSourceHashByFile = new Map<string, string>()
+  const frameworkRootImportShellTargetByFile = context.frameworkRootImportShellTargetByFile ?? new Map<string, string>()
   let currentOutDir: string | undefined
   let currentSubpackageRoots: Set<string> | undefined
   const createInitialCssPipelineContext = (file: string) => {
@@ -824,6 +825,83 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
           ...createInitialCssPipelineContext(file),
           bundle,
         }
+        const rootImportShellOutputFile = resolveReplayCssOutputFile(
+          outDir,
+          originalSource.fileName || file,
+        )
+        let rememberedFrameworkRootImportTarget = frameworkRootImportShellTargetByFile.get(rootImportShellOutputFile)
+        const isCurrentFrameworkRootImportShell = shouldPreserveFrameworkRootMiniProgramImportShell({
+          css: rawSource,
+          file: rootImportShellOutputFile,
+          isWebGeneratorTarget,
+          matchesCss: opts.cssMatcher(rootImportShellOutputFile) || opts.cssMatcher(file),
+          shouldKeep: () => context.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+            ...cssPipelineContext,
+            css: rawSource,
+            file: rootImportShellOutputFile,
+          }),
+        })
+        if (isCurrentFrameworkRootImportShell) {
+          const importedFile = resolveSingleCssImportOutputFile(rootImportShellOutputFile, rawSource)
+          if (importedFile && isRootMiniProgramStyleOutputFile(importedFile)) {
+            frameworkRootImportShellTargetByFile.set(rootImportShellOutputFile, importedFile)
+          }
+        }
+        if (
+          !rememberedFrameworkRootImportTarget
+          && !isCurrentFrameworkRootImportShell
+          && !isWebGeneratorTarget
+          && isRootMiniProgramStyleOutputFile(rootImportShellOutputFile)
+          && normalizeOutputPathKey(assetSourceFile) === normalizeOutputPathKey(file)
+          && shouldKeepRootMiniProgramStyleAsImportShell(
+            context.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+              ...cssPipelineContext,
+              css: rawSource,
+              file: rootImportShellOutputFile,
+            }),
+          )
+        ) {
+          const rootGeneratedTargets = new Set<string>()
+          for (const entry of getConfiguredTailwindV4CssSourceEntries()) {
+            const targetFile = resolveMatchedCssSourceOutputFile(entry.file)
+            if (
+              targetFile
+              && isRootMiniProgramStyleOutputFile(targetFile)
+              && normalizeOutputPathKey(targetFile) !== normalizeOutputPathKey(rootImportShellOutputFile)
+            ) {
+              rootGeneratedTargets.add(targetFile)
+            }
+          }
+          for (const [, record] of getViteProcessedCssAssetResults?.() ?? []) {
+            if (typeof record === 'string' || record.injectIntoMain !== true || !record.outputFile) {
+              continue
+            }
+            const targetFile = resolveViteCssPipelineOutputFile(
+              record.outputFile,
+              opts,
+              rootDir,
+              isWebGeneratorTarget,
+              shouldPreserveAppCssExtension,
+              sourceRoot,
+              defaultStyleOutputExtension,
+              bundleFiles,
+            )
+            if (
+              isRootMiniProgramStyleOutputFile(targetFile)
+              && normalizeOutputPathKey(targetFile) !== normalizeOutputPathKey(rootImportShellOutputFile)
+            ) {
+              rootGeneratedTargets.add(targetFile)
+            }
+          }
+          if (rootGeneratedTargets.size === 1) {
+            const [targetFile] = rootGeneratedTargets
+            if (targetFile) {
+              rememberedFrameworkRootImportTarget = targetFile
+              frameworkRootImportShellTargetByFile.set(rootImportShellOutputFile, targetFile)
+              debug('css remember framework root generated target: %s -> %s', rootImportShellOutputFile, targetFile)
+            }
+          }
+        }
         let outputFile = resolveCssBundleOutputFile({
           bundleFiles,
           cssPipelineStrategy: context.cssPipelineStrategy,
@@ -834,6 +912,21 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
           pipelineContext: cssPipelineContext,
           shouldPreserveAppCssExtension,
         })
+        if (
+          rememberedFrameworkRootImportTarget
+          && !isWebGeneratorTarget
+          && (opts.cssMatcher(rootImportShellOutputFile) || opts.cssMatcher(file))
+          && shouldKeepRootMiniProgramStyleAsImportShell(
+            context.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+              ...cssPipelineContext,
+              css: rawSource,
+              file: rootImportShellOutputFile,
+            }),
+          )
+        ) {
+          outputFile = rememberedFrameworkRootImportTarget
+          debug('css reuse framework root import shell target: %s -> %s', rootImportShellOutputFile, outputFile)
+        }
         const resolveMatchedOutputFileForCurrentAsset = createMatchedCssSourceOutputResolver({
           assetSourceFile,
           file,
@@ -1159,6 +1252,22 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
               outputFile,
             }
           }
+        }
+        if (
+          !isWebGeneratorTarget
+          && isRootMiniProgramStyleOutputFile(rootImportShellOutputFile)
+          && isRootMiniProgramStyleOutputFile(outputFile)
+          && normalizeOutputPathKey(rootImportShellOutputFile) !== normalizeOutputPathKey(outputFile)
+          && shouldKeepRootMiniProgramStyleAsImportShell(
+            context.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+              ...cssPipelineContext,
+              css: rawSource,
+              file: rootImportShellOutputFile,
+            }),
+          )
+        ) {
+          frameworkRootImportShellTargetByFile.set(rootImportShellOutputFile, outputFile)
+          debug('css remember framework root import shell target: %s -> %s', rootImportShellOutputFile, outputFile)
         }
         const shouldKeepImportedCssShell = isCssImportOnlyBundleAsset(bundle, file, rawSource)
         const useRememberedCssSource = !shouldKeepImportedCssShell
@@ -1599,6 +1708,8 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
         cache,
         changedCssFiles: snapshot.changedByType.css,
         cssTaskFactories,
+        cssPipelineContext,
+        cssPipelineStrategy: context.cssPipelineStrategy,
         createScopedGeneratorRuntime,
         createScopedSourceCandidateGetter,
         createScopedSourceCandidateSourceGetter,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
@@ -41,7 +41,7 @@ import { logBundleProcessPlan } from './generate-bundle/process-plan'
 import { createRememberedCssRuntimeSignature, findRememberedCssSources, mergeRememberedCssSources } from './generate-bundle/remembered-css'
 import { processRememberedCssReplay } from './generate-bundle/remembered-css-replay'
 import { registerGeneratorDependencies } from './generate-bundle/rollup-assets'
-import { isRootMiniProgramStyleOutputFile, resolveSingleCssImportOutputFile, shouldKeepRootMiniProgramStyleAsImportShell, shouldPreserveFrameworkRootMiniProgramImportShell } from './generate-bundle/root-style-output'
+import { isRootMiniProgramStyleOutputFile, resolveSingleCssImportOutputFile, shouldKeepRootMiniProgramStyleAsImportShell, shouldMoveRootMiniProgramStyleToImportShellOrigin, shouldPreserveFrameworkRootMiniProgramImportShell } from './generate-bundle/root-style-output'
 import { collectCssExtensionByStem, collectJsImportedCssFiles, collectRuntimeLinkedCssFiles } from './generate-bundle/runtime-linked-css'
 import { rememberRuntimeLinkedCssSources } from './generate-bundle/runtime-linked-source-memory'
 import { createScopedGeneratorCandidateSignature, createScopedGeneratorSourceTraceMap, createScopedGeneratorRuntime as resolveScopedGeneratorRuntime } from './generate-bundle/scoped-generator'
@@ -853,10 +853,17 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
           && !isWebGeneratorTarget
           && isRootMiniProgramStyleOutputFile(rootImportShellOutputFile)
           && normalizeOutputPathKey(assetSourceFile) === normalizeOutputPathKey(file)
+          && opts.mainCssChunkMatcher(rootImportShellOutputFile, opts.appType)
           && shouldKeepRootMiniProgramStyleAsImportShell(
             context.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
               ...cssPipelineContext,
               css: rawSource,
+              file: rootImportShellOutputFile,
+            }),
+          )
+          && !shouldMoveRootMiniProgramStyleToImportShellOrigin(
+            context.cssPipelineStrategy?.shouldMoveRootMiniProgramStyleToImportShellOrigin?.({
+              ...cssPipelineContext,
               file: rootImportShellOutputFile,
             }),
           )
@@ -1262,6 +1269,12 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
             context.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
               ...cssPipelineContext,
               css: rawSource,
+              file: rootImportShellOutputFile,
+            }),
+          )
+          && !shouldMoveRootMiniProgramStyleToImportShellOrigin(
+            context.cssPipelineStrategy?.shouldMoveRootMiniProgramStyleToImportShellOrigin?.({
+              ...cssPipelineContext,
               file: rootImportShellOutputFile,
             }),
           )

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/finalize.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/finalize.ts
@@ -4,10 +4,9 @@ import type { ViteFrameworkCssPipelineContext, ViteFrameworkCssPipelineStrategy 
 import type { BundleMetrics } from './metrics'
 import type { GenerateBundleContext } from './types'
 import path from 'node:path'
-import { postcss, transformWebCssCompat, transformWebCssSafeSelectors } from '@weapp-tailwindcss/postcss'
+import { transformWebCssCompat, transformWebCssSafeSelectors } from '@weapp-tailwindcss/postcss'
 import { normalizeWeappTailwindcssGeneratorOptions } from '@/generator'
 import { injectUniAppXHarmonyBundleStyles } from '@/uni-app-x/style-asset'
-import { parseImportRequest } from '../../shared/generator-css/directives'
 import { isPureLocalCssImportWrapper } from '../../shared/generator-css/local-imports'
 import { normalizeOutputPathKey } from '../../shared/module-graph'
 import { runWithConcurrency } from '../../shared/run-tasks'
@@ -18,6 +17,7 @@ import { resolveViteCssPipelineOutputFile } from './css-output'
 import { finalizeMiniProgramCssAssets } from './final-css-assets'
 import { resolveViteMemoryDebugStats } from './memory-debug'
 import { formatCacheHitRate, formatMs } from './metrics'
+import { resolveSingleCssImportOutputFile } from './root-style-output'
 import { collectMiniProgramSubpackageRoots } from './subpackages'
 import { handleUniAppXPostCssTasks } from './uni-app-x-postprocess'
 import { pruneLastCssResults, resolveViteCssTaskConcurrency } from './vite-css-cache'
@@ -150,31 +150,6 @@ function resolveRootMiniProgramOriginStyleFile(file: string) {
     return
   }
   return normalized.replace(/(\.[^.]+)$/, '-origin$1')
-}
-
-function resolveSingleCssImportOutputFile(targetFile: string, css: string) {
-  let importedFile: string | undefined
-  try {
-    const root = postcss.parse(css)
-    root.walkAtRules('import', (atRule) => {
-      if (importedFile !== undefined) {
-        return
-      }
-      const request = parseImportRequest(atRule.params)
-      if (!request || /^(?:https?:)?\/\//i.test(request) || request.startsWith('data:')) {
-        return
-      }
-      const cleanRequest = request.replace(/[?#].*$/, '')
-      if (!/\.(?:css|wxss|acss|ttss|qss|jxss|tyss)$/i.test(cleanRequest)) {
-        return
-      }
-      const targetDir = path.posix.dirname(normalizeOutputPathKey(targetFile))
-      importedFile = normalizeOutputPathKey(path.posix.join(targetDir === '.' ? '' : targetDir, cleanRequest))
-    })
-  }
-  catch {
-  }
-  return importedFile
 }
 
 export function normalizeRootMiniProgramImportShellAssets(

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/remembered-css-replay.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/remembered-css-replay.ts
@@ -1,4 +1,5 @@
 import type { OutputAsset, OutputChunk } from 'rollup'
+import type { ViteFrameworkCssPipelineContext, ViteFrameworkCssPipelineStrategy } from '../shared/framework-strategy'
 import type { BundleMetrics } from './metrics'
 import type { GenerateBundleContext, RememberedCssSource } from './types'
 import { annotateCssSourceTrace, createCssTokenSourceMap } from '../../shared/css-source-trace'
@@ -11,6 +12,7 @@ import { createCssRuntimeSignature } from './css-share-scope'
 import { measureElapsed } from './metrics'
 import { collectRememberedCssReplayGroups, createRememberedCssRuntimeSignature, mergeRememberedCssSources } from './remembered-css'
 import { registerGeneratorDependencies } from './rollup-assets'
+import { isRootMiniProgramStyleOutputFile, shouldPreserveFrameworkRootMiniProgramImportShell } from './root-style-output'
 import { createScopedGeneratorCandidateSignature, createScopedGeneratorSourceTraceMap } from './scoped-generator'
 import { createCandidateSignature } from './signatures'
 import { getLastCssResult, getLastCssSourceHash, rememberLastCssResult } from './vite-css-cache'
@@ -37,6 +39,8 @@ interface ProcessRememberedCssReplayOptions {
     cssHandlerOptions: { isMainChunk?: boolean | undefined },
   ) => GenerateBundleContext['getSourceCandidateSourcesForEntries']
   cssTaskFactories: Array<() => Promise<void>>
+  cssPipelineContext: ViteFrameworkCssPipelineContext
+  cssPipelineStrategy?: ViteFrameworkCssPipelineStrategy | undefined
   debug: GenerateBundleContext['debug']
   defaultStyleOutputExtension: string
   emitOrReplayCssAsset: (fileName: string, source: string) => OutputAsset | undefined
@@ -86,6 +90,8 @@ export async function processRememberedCssReplay(options: ProcessRememberedCssRe
     createScopedSourceCandidateGetter,
     createScopedSourceCandidateSourceGetter,
     cssTaskFactories,
+    cssPipelineContext,
+    cssPipelineStrategy,
     debug,
     defaultStyleOutputExtension,
     emitOrReplayCssAsset,
@@ -201,7 +207,20 @@ export async function processRememberedCssReplay(options: ProcessRememberedCssRe
     if (!shouldRecordRememberedReplayCss) {
       continue
     }
-    if (!isWebGeneratorTarget && isPureLocalCssImportWrapper(rawSource)) {
+    const shouldPreserveFrameworkRootImportShell = shouldPreserveFrameworkRootMiniProgramImportShell({
+      css: rawSource,
+      file: outputFile,
+      isWebGeneratorTarget,
+      matchesCss: opts.cssMatcher(outputFile),
+      shouldKeep: () => cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+        ...cssPipelineContext,
+        css: rawSource,
+        file: outputFile,
+      }),
+    })
+    const shouldPreserveLocalImportWrapper = shouldPreserveFrameworkRootImportShell
+      || (!isRootMiniProgramStyleOutputFile(outputFile) && !isWebGeneratorTarget && isPureLocalCssImportWrapper(rawSource))
+    if (shouldPreserveLocalImportWrapper) {
       cssTaskFactories.push(() => timeTask('css.replay', async () => {
         const start = performance.now()
         const css = annotateCss(normalizeMiniProgramImportShell(rawSource))

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/root-style-output.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/root-style-output.ts
@@ -1,5 +1,9 @@
+import type { OutputBundle } from 'rollup'
 import path from 'node:path'
+import { postcss } from '@weapp-tailwindcss/postcss'
 import { normalizeOutputPathKey } from '@/bundlers/shared/module-graph'
+import { parseImportRequest } from '../../shared/generator-css/directives'
+import { isPureLocalCssImportWrapper } from '../../shared/generator-css/local-imports'
 
 export function isRootMiniProgramStyleOutputFile(file: string) {
   const normalized = normalizeOutputPathKey(file.replace(/[?#].*$/, ''))
@@ -20,6 +24,31 @@ export function createCssImportShell(targetFile: string, importedFile: string) {
   return `@import "${createRelativeCssImportRequest(targetFile, importedFile)}";\n`
 }
 
+export function resolveSingleCssImportOutputFile(targetFile: string, css: string) {
+  let importedFile: string | undefined
+  try {
+    const root = postcss.parse(css)
+    root.walkAtRules('import', (atRule) => {
+      if (importedFile !== undefined) {
+        return
+      }
+      const request = parseImportRequest(atRule.params)
+      if (!request || /^(?:https?:)?\/\//i.test(request) || request.startsWith('data:')) {
+        return
+      }
+      const cleanRequest = request.replace(/[?#].*$/, '')
+      if (!/\.(?:css|wxss|acss|ttss|qss|jxss|tyss)$/i.test(cleanRequest)) {
+        return
+      }
+      const targetDir = path.posix.dirname(normalizeOutputPathKey(targetFile))
+      importedFile = normalizeOutputPathKey(path.posix.join(targetDir === '.' ? '' : targetDir, cleanRequest))
+    })
+  }
+  catch {
+  }
+  return importedFile
+}
+
 export function createRootMiniProgramOriginStyleOutputFile(file: string) {
   const normalized = normalizeOutputPathKey(file.replace(/[?#].*$/, ''))
   if (/(?:^|\/)[^/]+-origin\.[^.]+$/i.test(normalized)) {
@@ -30,6 +59,70 @@ export function createRootMiniProgramOriginStyleOutputFile(file: string) {
 
 export function shouldKeepRootMiniProgramStyleAsImportShell(enabled: boolean | undefined) {
   return enabled === true
+}
+
+export function shouldPreserveFrameworkRootMiniProgramImportShell(options: {
+  css: string
+  file: string
+  isWebGeneratorTarget: boolean
+  matchesCss: boolean
+  shouldKeep: () => boolean | undefined
+}) {
+  return !options.isWebGeneratorTarget
+    && options.matchesCss
+    && isRootMiniProgramStyleOutputFile(options.file)
+    && isPureLocalCssImportWrapper(options.css)
+    && shouldKeepRootMiniProgramStyleAsImportShell(options.shouldKeep())
+}
+
+export function restoreFrameworkRootMiniProgramImportShellAssets(
+  bundle: OutputBundle,
+  options: {
+    debug?: ((format: string, ...args: unknown[]) => void) | undefined
+    isWebGeneratorTarget: boolean
+    matchesCss: (file: string) => boolean
+    onUpdate?: ((file: string, oldVal: string, newVal: string) => void) | undefined
+    recordCssAssetResult?: ((file: string, css: string) => void) | undefined
+    shouldKeep: (file: string, css: string) => boolean | undefined
+    targetByFile: ReadonlyMap<string, string>
+  },
+) {
+  if (options.isWebGeneratorTarget || options.targetByFile.size === 0) {
+    return 0
+  }
+  let restored = 0
+  for (const [sourceFile, targetFile] of options.targetByFile) {
+    if (
+      !options.matchesCss(sourceFile)
+      || !options.matchesCss(targetFile)
+      || !isRootMiniProgramStyleOutputFile(sourceFile)
+      || !isRootMiniProgramStyleOutputFile(targetFile)
+      || normalizeOutputPathKey(sourceFile) === normalizeOutputPathKey(targetFile)
+    ) {
+      continue
+    }
+    const output = Object.entries(bundle).find(([bundleFile, candidate]) =>
+      candidate.type === 'asset'
+      && normalizeOutputPathKey(candidate.fileName || bundleFile) === normalizeOutputPathKey(sourceFile),
+    )?.[1]
+    if (output?.type !== 'asset') {
+      continue
+    }
+    const rawSource = output.source.toString()
+    if (!shouldKeepRootMiniProgramStyleAsImportShell(options.shouldKeep(sourceFile, rawSource))) {
+      continue
+    }
+    const nextSource = createCssImportShell(sourceFile, targetFile)
+    if (rawSource === nextSource) {
+      continue
+    }
+    output.source = nextSource
+    options.recordCssAssetResult?.(sourceFile, nextSource)
+    options.onUpdate?.(sourceFile, rawSource, nextSource)
+    options.debug?.('restore framework root css import shell: %s -> %s', sourceFile, targetFile)
+    restored++
+  }
+  return restored
 }
 
 export function shouldMoveRootMiniProgramStyleToImportShellOrigin(enabled: boolean | undefined) {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/types.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/types.ts
@@ -54,6 +54,7 @@ export interface GenerateBundleContext {
   getViteCssCacheStats?: () => Record<string, unknown>
   hmrTimingRecorder?: HmrTimingRecorder
   cssPipelineStrategy?: ViteFrameworkCssPipelineStrategy | undefined
+  frameworkRootImportShellTargetByFile?: Map<string, string> | undefined
 }
 
 export interface RememberedCssSource {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets.ts
@@ -17,10 +17,10 @@ import {
 import path from 'pathe'
 import { parseBundlerGeneratedCssMarkerBlocks, stripBundlerGeneratedCssMarkers } from '../shared/generated-css-marker'
 import { removeTailwindSourceDirectives } from '../shared/generator-css/directives'
-import { isPureLocalCssImportWrapper } from '../shared/generator-css/local-imports'
 import { stripGeneratorPlaceholderMarkers } from '../shared/generator-css/markers'
 import { extractMarkedUserLayerComponentsCss, mergeMarkedUserLayerComponentsCss } from '../shared/generator-css/user-layer-order'
 import { normalizeOutputPathKey } from '../shared/module-graph'
+import { shouldPreserveFrameworkRootMiniProgramImportShell } from './generate-bundle/root-style-output'
 import { isSubpackageOutputFile } from './generate-bundle/subpackages'
 
 interface CssAssetMarkerMatcher {
@@ -891,14 +891,17 @@ function shouldPreserveMiniProgramImportShell(
 ) {
   const context = createCssAssetPipelineContext(options, file, bundle)
   return context !== undefined
-    && options.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
-      ...context,
+    && shouldPreserveFrameworkRootMiniProgramImportShell({
       css,
       file,
-    }) === true
-    && isMiniProgramStyleOutputFile(file)
-    && options.opts.cssMatcher(file)
-    && isPureLocalCssImportWrapper(css)
+      isWebGeneratorTarget: context.currentGeneratorBranch?.isWeb === true,
+      matchesCss: options.opts.cssMatcher(file),
+      shouldKeep: () => options.cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+        ...context,
+        css,
+        file,
+      }),
+    })
 }
 
 function resolvePreservedImportShellInjectionTarget(

--- a/packages/weapp-tailwindcss/src/bundlers/vite/serve-root-import-shell.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/serve-root-import-shell.ts
@@ -1,7 +1,6 @@
 import type { ViteFrameworkCssPipelineContext, ViteFrameworkCssPipelineStrategy } from './shared/framework-strategy'
-import { isPureLocalCssImportWrapper } from '../shared/generator-css/local-imports'
 import { normalizeMiniProgramImportShell } from '../shared/generator-css/output-import-shell'
-import { isRootMiniProgramStyleOutputFile, shouldKeepRootMiniProgramStyleAsImportShell } from './generate-bundle/root-style-output'
+import { shouldPreserveFrameworkRootMiniProgramImportShell } from './generate-bundle/root-style-output'
 
 export function resolveViteServeRootMiniProgramImportShell(options: {
   css: string
@@ -17,20 +16,17 @@ export function resolveViteServeRootMiniProgramImportShell(options: {
     isWebGeneratorTarget,
     outputFile,
   } = options
-  if (
-    isWebGeneratorTarget
-    || !isRootMiniProgramStyleOutputFile(outputFile)
-    || !isPureLocalCssImportWrapper(css)
-  ) {
-    return undefined
-  }
-  const shouldPreserve = shouldKeepRootMiniProgramStyleAsImportShell(
-    cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
+  const shouldPreserve = shouldPreserveFrameworkRootMiniProgramImportShell({
+    css,
+    file: outputFile,
+    isWebGeneratorTarget,
+    matchesCss: cssPipelineContext.opts?.cssMatcher?.(outputFile) ?? true,
+    shouldKeep: () => cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
       ...cssPipelineContext,
       css,
       file: outputFile,
     }),
-  )
+  })
   return shouldPreserve
     ? normalizeMiniProgramImportShell(css)
     : undefined

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
@@ -304,6 +304,7 @@ export function createViteFrameworkPlugins(
     cssEntries: opts.cssEntries ?? rawOptions.cssEntries,
   })
   const autoCssSourceContent = new Map<string, string>()
+  const frameworkRootImportShellTargetByFile = new Map<string, string>()
   const transientAutoCssSources = new Map<string, { file: string, base: string, css: string, dependencies: string[] }>()
   let refreshRuntimeStateForAutoCssSources: ((force: boolean) => Promise<void>) | undefined
   let autoCssSourcesRefresh: Promise<void> | undefined
@@ -1250,6 +1251,7 @@ export function createViteFrameworkPlugins(
     getViteCssCacheStats,
     hmrTimingRecorder,
     cssPipelineStrategy: frameworkCssPipelineStrategy,
+    frameworkRootImportShellTargetByFile,
   })
   const cssFinalizerOutputPlugin = createViteCssFinalizerOutputPlugin({
     opts,
@@ -1269,6 +1271,7 @@ export function createViteFrameworkPlugins(
     getSourceCandidatesForEntries,
     getSourceCandidateSourcesForEntries,
     waitForSourceCandidateSyncs,
+    frameworkRootImportShellTargetByFile,
     rememberMainCssSource: (file, rawSource) => cssMemory.rememberCssSource({
       outputFile: file,
       rawSource,

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-finalizer.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-finalizer.unit.test.ts
@@ -423,6 +423,44 @@ describe('vite css finalizer output plugin', () => {
     expect(opts.onUpdate).toHaveBeenCalled()
   })
 
+  it('restores a cached framework root import shell before final css injection', async () => {
+    const records = new Map<string, any>([
+      ['src/components/card.vue', { css: '.card{color:blue}', injectIntoMain: true, outputFile: 'components/card.wxss' }],
+    ])
+    const { context } = createContext({
+      opts: {
+        appType: 'uni-app-vite',
+        cssMatcher: (file: string) => file.endsWith('.wxss'),
+        htmlMatcher: (file: string) => file.endsWith('.wxml'),
+        mainCssChunkMatcher: (file: string) => file === 'app.wxss' || file === 'main.wxss',
+        styleHandler: vi.fn(async (css: string) => ({ css })),
+        onUpdate: vi.fn(),
+        generator: {
+          target: 'weapp',
+        },
+      },
+      cssPipelineStrategy: {
+        shouldKeepRootMiniProgramStyleAsImportShell: () => true,
+      },
+      frameworkRootImportShellTargetByFile: new Map([
+        ['app.wxss', 'main.wxss'],
+      ]),
+      getViteProcessedCssAssetResults: vi.fn(() => records.entries()),
+      isCssAssetProcessed: vi.fn(() => true),
+    })
+    const plugin = createViteCssFinalizerOutputPlugin(context as any)
+    const bundle: OutputBundle = {
+      'app.wxss': asset('app.wxss', '.generated-root{display:flex}'),
+      'main.wxss': asset('main.wxss', '.tailwind{display:block}'),
+    }
+
+    await getHandler(plugin).call(plugin, {}, bundle)
+
+    expect(String((bundle['app.wxss'] as OutputAsset).source)).toBe('@import "./main.wxss";\n')
+    expect(String((bundle['main.wxss'] as OutputAsset).source)).toContain('.card{color:blue}')
+    expect(context.debug).toHaveBeenCalledWith('restore framework root css import shell: %s -> %s', 'app.wxss', 'main.wxss')
+  })
+
   it('injects uni-app-x harmony apply styles when finalizer has no css assets', async () => {
     mocks.generateTailwindV4Css.mockResolvedValue({
       css: '.flex{display:flex}',

--- a/packages/weapp-tailwindcss/test/bundlers/vite-helpers.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-helpers.unit.test.ts
@@ -18,6 +18,7 @@ import {
   isRootMiniProgramStyleOutputFile,
   shouldKeepRootMiniProgramStyleAsImportShell,
   shouldMoveRootMiniProgramStyleToImportShellOrigin,
+  shouldPreserveFrameworkRootMiniProgramImportShell,
 } from '@/bundlers/vite/generate-bundle/root-style-output'
 import { resolveCurrentSourceCandidateSource } from '@/bundlers/vite/generate-bundle/source-candidate-source'
 import { scoreTailwindV4CssSourceFileMatch } from '@/bundlers/shared/generator-css/source-resolver/matching'
@@ -95,6 +96,27 @@ describe('bundlers/vite helper modules', () => {
     expect(shouldKeepRootMiniProgramStyleAsImportShell(undefined)).toBe(false)
     expect(shouldMoveRootMiniProgramStyleToImportShellOrigin(true)).toBe(true)
     expect(shouldMoveRootMiniProgramStyleToImportShellOrigin(false)).toBe(false)
+    expect(shouldPreserveFrameworkRootMiniProgramImportShell({
+      css: '@import "./main.acss";',
+      file: 'app.acss',
+      isWebGeneratorTarget: false,
+      matchesCss: true,
+      shouldKeep: () => true,
+    })).toBe(true)
+    expect(shouldPreserveFrameworkRootMiniProgramImportShell({
+      css: '@import "./main.acss";',
+      file: 'pages/app.acss',
+      isWebGeneratorTarget: false,
+      matchesCss: true,
+      shouldKeep: () => true,
+    })).toBe(false)
+    expect(shouldPreserveFrameworkRootMiniProgramImportShell({
+      css: '@import "./main.acss";\npage{}',
+      file: 'app.acss',
+      isWebGeneratorTarget: false,
+      matchesCss: true,
+      shouldKeep: () => true,
+    })).toBe(false)
   })
 
   it('preserves vite serve root mini-program import shells for framework-owned shell policies only', () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -7779,6 +7779,16 @@ module.exports = {
     const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-taro-app-origin-shell-'))
     createdDirs.push(root)
     const sourceFile = path.join(root, 'src/app.css')
+    const sourceCss = '@import "tailwindcss" source(none);'
+    await mkdir(path.dirname(sourceFile), { recursive: true })
+    await writeFile(sourceFile, sourceCss, 'utf8')
+    const cssSources = [{
+      file: sourceFile,
+      base: path.dirname(sourceFile),
+      css: sourceCss,
+      dependencies: [],
+    }]
+    const frameworkRootImportShellTargetByFile = new Map<string, string>()
     const records = new Map<string, { css: string, injectIntoMain?: boolean | undefined, outputFile?: string | undefined }>()
     const generateBundle = createGenerateBundleHook({
       opts: createContext({
@@ -7786,6 +7796,14 @@ module.exports = {
         cssMatcher: (file: string) => file.endsWith('.wxss'),
         mainCssChunkMatcher: vi.fn((file: string) => file === 'app.wxss'),
         styleHandler: vi.fn(async (code: string) => ({ css: code })),
+        tailwindcssBasedir: root,
+        cssEntries: [sourceFile],
+        tailwindcss: {
+          v4: {
+            cssEntries: [sourceFile],
+            cssSources,
+          },
+        },
         tailwindRuntime: {
           getClassSet: vi.fn(async () => new Set(['tw-app-entry'])),
           getClassSetSync: vi.fn(() => new Set(['tw-app-entry'])),
@@ -7822,7 +7840,7 @@ module.exports = {
       getViteProcessedCssAssetResults: () => records.entries(),
       getViteProcessedCssAssetResult: file => records.get(file),
       getSourceCandidates: () => new Set(['tw-app-entry']),
-      getSourceCandidateSource: file => file === sourceFile ? '@import "tailwindcss" source(none);' : undefined,
+      getSourceCandidateSource: file => file === sourceFile ? sourceCss : undefined,
       getSourceCandidatesForEntries: () => new Set(['tw-app-entry']),
       waitForSourceCandidateSyncs: vi.fn(async () => undefined),
       rememberCssSource: vi.fn(),
@@ -7830,13 +7848,14 @@ module.exports = {
       getRememberedCssSources: () => new Map([
         ['app-origin.wxss', {
           outputFile: 'app-origin.wxss',
-          rawSource: '@import "tailwindcss" source(none);',
+          rawSource: sourceCss,
           sourceFile,
         }],
       ]),
       getRememberedCssSignature: () => undefined,
       setRememberedCssSignature: vi.fn(),
       recordGeneratorCandidates: vi.fn(),
+      frameworkRootImportShellTargetByFile,
       cssPipelineStrategy: {
         shouldKeepRootMiniProgramStyleAsImportShell: () => true,
         shouldMoveRootMiniProgramStyleToImportShellOrigin: () => true,
@@ -7858,7 +7877,9 @@ module.exports = {
     await generateBundle.call({ addWatchFile: vi.fn() }, {}, bundle)
 
     expect((bundle['app.wxss'] as OutputAsset).source.toString()).toBe('@import "./app-origin.wxss";\n')
+    expect((bundle['app-origin.wxss'] as OutputAsset).source.toString()).toContain('.tw-app-entry')
     expect((bundle['app-origin.wxss'] as OutputAsset).source.toString()).not.toContain('weapp-tailwindcss generated css')
+    expect(frameworkRootImportShellTargetByFile.has('app-origin.wxss')).toBe(false)
   }, TEST_TIMEOUT_MS)
 
   it('does not match plain taro temporary css assets to remembered subpackage css', async () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -11966,7 +11966,7 @@ const cls = "w-[1.5px]"
     expect(nextAppOriginCss).not.toContain('text-[#111111]')
   }, TEST_TIMEOUT_MS)
 
-  it('replays updated vite pipeline main css into uni-app dev app.wxss', async () => {
+  it('keeps uni-app dev app.wxss as an import shell when the incremental bundle omits main.wxss', async () => {
     const localCandidates = (candidates: Set<string>) =>
       new Set([...candidates].filter(candidate => /^text-\[\d+\.\d+rpx\]$/.test(candidate)))
     const generateMock = vi.fn(async (options: { candidates: Set<string> }) => ({
@@ -12017,6 +12017,14 @@ const cls = "w-[1.5px]"
     const WeappTailwindcss = await loadWeappTailwindcssPlugin()
     const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-app-wxss-replay-'))
     createdDirs.push(root)
+    const cssSourceFile = path.resolve(root, 'src/main.css')
+    const cssSource = '@import "tailwindcss" source(none);\n@source "../src/**/*.{vue,js,ts}";'
+    const cssSources = [{
+      file: cssSourceFile,
+      base: path.dirname(cssSourceFile),
+      css: cssSource,
+      dependencies: [],
+    }]
     const runtimeSet = new Set<string>()
     const forceRuntimeRefresh = process.env['WEAPP_TW_VITE_FORCE_RUNTIME_REFRESH']
     process.env['WEAPP_TW_VITE_FORCE_RUNTIME_REFRESH'] = '1'
@@ -12024,11 +12032,29 @@ const cls = "w-[1.5px]"
       appType: 'uni-app-vite',
       cssMatcher: (file: string) => file.endsWith('.wxss'),
       mainCssChunkMatcher: vi.fn((file: string) => file === 'app.wxss' || file === 'src/tailwind.wxss'),
+      tailwindcssBasedir: root,
+      cssEntries: [cssSourceFile],
+      tailwindcss: {
+        v4: {
+          cssEntries: [cssSourceFile],
+          cssSources,
+        },
+      },
       tailwindRuntime: {
         getClassSet: vi.fn(async () => new Set(runtimeSet)),
         getClassSetSync: vi.fn(() => new Set(runtimeSet)),
         majorVersion: 4,
         extract: vi.fn(async () => ({ classSet: new Set(runtimeSet) })),
+        options: {
+          projectRoot: root,
+          tailwindcss: {
+            cwd: root,
+            v4: {
+              cssEntries: [cssSourceFile],
+              cssSources,
+            },
+          },
+        },
       },
     }))
     const plugins = WeappTailwindcss()
@@ -12042,6 +12068,7 @@ const cls = "w-[1.5px]"
     await (postPlugin.configResolved as any)?.call(postPlugin, {
       command: 'serve',
       root,
+      weapp: { srcRoot: 'src' },
       css: { postcss: { plugins: [] } },
       build: { outDir: 'dist/dev/mp-weixin' },
       plugins: [{ name: 'vite:uni' }],
@@ -12049,6 +12076,7 @@ const cls = "w-[1.5px]"
     await (serveGeneratePlugin.configResolved as any)?.call(serveGeneratePlugin, {
       command: 'serve',
       root,
+      weapp: { srcRoot: 'src' },
       css: { postcss: { plugins: [] } },
       build: { outDir: 'dist/dev/mp-weixin' },
       plugins: [{ name: 'vite:uni' }],
@@ -12056,28 +12084,29 @@ const cls = "w-[1.5px]"
 
     const transform = getTransformHandler(serveGeneratePlugin)
     const generateBundle = getGenerateBundleHandler(postPlugin)
-    const cssSourceFile = path.resolve(root, 'src/main.css')
-    const cssSource = '@import "tailwindcss" source(none);\n@source "../src/**/*.{vue,js,ts}";'
+    const importShell = '@import "./main.wxss";\n'
 
     try {
       runtimeSet.add('text-[102.43rpx]')
       await transform?.call({ addWatchFile: vi.fn() } as any, cssSource, cssSourceFile)
 
       const firstBundle = {
-        'src/main.wxss': {
+        'main.wxss': {
           ...createRollupAsset(`${createBundlerGeneratedCssMarker('vite', cssSourceFile)}\n.${replaceWxml('text-[102.43rpx]')}{font-size:102.43rpx}`),
-          fileName: 'src/main.wxss',
+          fileName: 'main.wxss',
           originalFileNames: [cssSourceFile],
         },
         'app.wxss': {
-          ...createRollupAsset(''),
+          ...createRollupAsset(importShell),
           fileName: 'app.wxss',
         },
       }
       await generateBundle?.call(postPlugin, {} as any, firstBundle)
       const firstAppCss = (firstBundle['app.wxss'] as OutputAsset).source.toString()
-      expect(firstAppCss).toContain(replaceWxml('text-[102.43rpx]'))
-      expect(firstAppCss).toContain('102.43rpx')
+      const firstMainCss = (firstBundle['main.wxss'] as OutputAsset).source.toString()
+      expect(firstAppCss).toBe(importShell)
+      expect(firstMainCss).toContain(replaceWxml('text-[102.43rpx]'))
+      expect(firstMainCss).toContain('102.43rpx')
 
       runtimeSet.clear()
       runtimeSet.add('text-[103.43rpx]')
@@ -12101,33 +12130,21 @@ const cls = "w-[1.5px]"
           fileName: 'pages/index/index.wxml',
         },
         'app.wxss': {
-          ...createRollupAsset(firstAppCss),
+          ...createRollupAsset(importShell),
           fileName: 'app.wxss',
         },
       }
-      await generateBundle?.call(postPlugin, {} as any, secondBundle)
+      const emittedAssets: Array<{ fileName?: string, source?: string | Uint8Array }> = []
+      await generateBundle?.call({
+        ...postPlugin,
+        emitFile(asset: { fileName?: string, source?: string | Uint8Array }) {
+          emittedAssets.push(asset)
+          return asset.fileName ?? ''
+        },
+      }, {} as any, secondBundle)
       const secondAppCss = (secondBundle['app.wxss'] as OutputAsset).source.toString()
-      expect(secondAppCss).toContain(replaceWxml('text-[103.43rpx]'))
-      expect(secondAppCss).toContain('103.43rpx')
-      expect(secondAppCss).not.toContain(replaceWxml('text-[104.43rpx]'))
-
-      runtimeSet.clear()
-      runtimeSet.add('text-[104.43rpx]')
-      const thirdBundle = {
-        'pages/index/index.wxml': {
-          ...createRollupAsset(`<view class="${replaceWxml('text-[104.43rpx]')}"></view>`),
-          fileName: 'pages/index/index.wxml',
-        },
-        'app.wxss': {
-          ...createRollupAsset(firstAppCss),
-          fileName: 'app.wxss',
-        },
-      }
-      await generateBundle?.call(postPlugin, {} as any, thirdBundle)
-      const thirdAppCss = (thirdBundle['app.wxss'] as OutputAsset).source.toString()
-      expect(thirdAppCss).toContain(replaceWxml('text-[104.43rpx]'))
-      expect(thirdAppCss).toContain('104.43rpx')
-      expect(thirdAppCss).not.toContain(replaceWxml('text-[103.43rpx]'))
+      expect(secondAppCss).toBe(importShell)
+      expect(emittedAssets.some(asset => asset.fileName === 'main.wxss')).toBe(true)
     }
     finally {
       if (forceRuntimeRefresh === undefined) {
@@ -12232,6 +12249,211 @@ const cls = "w-[1.5px]"
     expect(generateCssByGeneratorMock).toHaveBeenCalledTimes(frameworkCases.length)
     expect(generateCssByGeneratorMock).toHaveBeenCalledWith(expect.objectContaining({
       rawSource: '@import "tailwindcss" source(none);',
+    }))
+  }, TEST_TIMEOUT_MS)
+
+  it.each([
+    { extension: 'wxss', markupExtension: 'wxml', platform: 'mp-weixin' },
+    { extension: 'acss', markupExtension: 'axml', platform: 'mp-alipay' },
+  ])('keeps uni-app root .$extension import shell when incremental css bundle omits the imported asset', async ({
+    extension,
+    markupExtension,
+    platform,
+  }) => {
+    const generateCssByGeneratorMock = vi.fn(async (options: { runtime: Set<string>, rawSource: string }) => ({
+      css: [...options.runtime].sort().map(candidate => `.${replaceWxml(candidate)}{font-size:${candidate.match(/^text-\[(.+)\]$/)?.[1] ?? '0rpx'}}`).join('\n'),
+      rawCss: options.rawSource,
+      target: 'weapp',
+      classSet: new Set(options.runtime),
+      rawCandidates: new Set(options.runtime),
+      dependencies: [],
+      sources: [],
+      root: null,
+      version: 4,
+    }))
+    vi.resetModules()
+    vi.doMock('@/bundlers/shared/generator-css', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/bundlers/shared/generator-css')>()
+      return {
+        ...actual,
+        generateCssByGenerator: generateCssByGeneratorMock,
+      }
+    })
+    vi.doMock('@/generator', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/generator')>()
+      return {
+        ...actual,
+        normalizeWeappTailwindcssGeneratorOptions: normalizeGeneratorOptions,
+      }
+    })
+
+    const { createGenerateBundleHook: createGenerateBundleHookWithMock } = await import('@/bundlers/vite/generate-bundle')
+    const root = await mkdtemp(path.join(os.tmpdir(), `weapp-tw-vite-uni-root-shell-${extension}-`))
+    createdDirs.push(root)
+    await mkdir(path.join(root, 'src'), { recursive: true })
+    const cssSourceFile = path.join(root, 'src/main.css')
+    const cssSource = '@import "tailwindcss" source(none);\n@source "../src/**/*.{vue,js,ts}";'
+    const cssSources = [{
+      file: cssSourceFile,
+      base: path.dirname(cssSourceFile),
+      css: cssSource,
+      dependencies: [],
+    }]
+    const runtimeSet = new Set(['text-[102.43rpx]'])
+    const context = createContext({
+      appType: 'uni-app-vite',
+      cssMatcher: (file: string) => file.endsWith(`.${extension}`),
+      htmlMatcher: (file: string) => file.endsWith(`.${markupExtension}`),
+      mainCssChunkMatcher: vi.fn((file: string) => file === `app.${extension}`),
+      tailwindcssBasedir: root,
+      cssEntries: [cssSourceFile],
+      tailwindcss: {
+        v4: {
+          cssEntries: [cssSourceFile],
+          cssSources,
+        },
+      },
+      tailwindRuntime: {
+        getClassSet: vi.fn(async () => new Set(runtimeSet)),
+        getClassSetSync: vi.fn(() => new Set(runtimeSet)),
+        majorVersion: 4,
+        extract: vi.fn(async () => ({ classSet: new Set(runtimeSet) })),
+        options: {
+          projectRoot: root,
+          tailwindcss: {
+            cwd: root,
+            v4: {
+              cssEntries: [cssSourceFile],
+              cssSources,
+            },
+          },
+        },
+      },
+    })
+    const appStyleFile = `app.${extension}`
+    const mainStyleFile = `main.${extension}`
+    const markupFile = `pages/index/index.${markupExtension}`
+    const importShell = `@import "./${mainStyleFile}";\n`
+    const rememberedCssSources = new Map<string, {
+      outputFile: string
+      rawSource: string
+      sourceFile: string
+    }>()
+    const rememberedCssSignatures = new Map<string, string>()
+    const viteProcessedCssResults = new Map<string, {
+      css: string
+      injectIntoMain?: boolean
+      outputFile?: string
+    }>()
+    const generateBundle = createGenerateBundleHookWithMock({
+      opts: context as any,
+      runtimeState: {
+        tailwindRuntime: context.tailwindRuntime as any,
+        readyPromise: Promise.resolve(),
+      },
+      ensureRuntimeClassSet: vi.fn(async () => new Set(runtimeSet)),
+      ensureBundleRuntimeClassSet: vi.fn(async () => new Set(runtimeSet)),
+      cssPipelineStrategy: {
+        shouldKeepRootMiniProgramStyleAsImportShell: () => true,
+      },
+      debug: vi.fn(),
+      getResolvedConfig: () => ({
+        command: 'serve',
+        plugins: [{ name: 'vite:uni' }],
+        root,
+        weapp: { srcRoot: 'src' },
+        css: { postcss: { plugins: [] } },
+        build: { outDir: `dist/dev/${platform}` },
+      } as unknown as ResolvedConfig),
+      markCssAssetProcessed: vi.fn(),
+      isCssAssetProcessed: vi.fn(() => false),
+      isViteProcessedCssAsset: vi.fn(() => false),
+      recordCssAssetResult: vi.fn(),
+      recordViteProcessedCssAssetResult(file, css, options) {
+        viteProcessedCssResults.set(file, {
+          css,
+          injectIntoMain: options?.injectIntoMain,
+          outputFile: options?.outputFile,
+        })
+      },
+      getViteProcessedCssAssetResults: () => viteProcessedCssResults.entries(),
+      getViteProcessedCssAssetResult: file => viteProcessedCssResults.get(file),
+      getSourceCandidates: () => new Set(runtimeSet),
+      getSourceCandidatesForEntries: () => new Set(runtimeSet),
+      getSourceCandidateSource: () => undefined,
+      getSourceCandidateSources: () => [],
+      getSourceCandidateSourcesForEntries: () => [],
+      waitForSourceCandidateSyncs: vi.fn(async () => undefined),
+      rememberCssSource(source, signature) {
+        rememberedCssSources.set(source.sourceFile, source)
+        if (signature) {
+          rememberedCssSignatures.set(source.sourceFile, signature)
+        }
+      },
+      refreshRememberedCssSource: vi.fn(async source => source),
+      getRememberedCssSources: () => rememberedCssSources,
+      getRememberedCssSignature: file => rememberedCssSignatures.get(file),
+      setRememberedCssSignature: (file, signature) => rememberedCssSignatures.set(file, signature),
+      recordGeneratorCandidates: vi.fn(),
+    })
+    const firstBundle = {
+      [markupFile]: {
+        ...createRollupAsset(`<view class="${replaceWxml('text-[102.43rpx]')}"></view>`),
+        fileName: markupFile,
+      },
+      [appStyleFile]: {
+        ...createRollupAsset(cssSource),
+        fileName: appStyleFile,
+      },
+    }
+    await generateBundle.call({ addWatchFile: vi.fn() }, {} as any, firstBundle)
+
+    expect((firstBundle[appStyleFile] as OutputAsset).source.toString()).toBe(importShell)
+    expect((firstBundle[mainStyleFile] as OutputAsset).source.toString()).toContain(replaceWxml('text-[102.43rpx]'))
+
+    runtimeSet.clear()
+    runtimeSet.add('text-[103.43rpx]')
+    rememberedCssSources.clear()
+    rememberedCssSignatures.clear()
+    rememberedCssSources.set(appStyleFile, {
+      outputFile: appStyleFile,
+      rawSource: cssSource,
+      sourceFile: cssSourceFile,
+    })
+    rememberedCssSources.set(mainStyleFile, {
+      outputFile: mainStyleFile,
+      rawSource: cssSource,
+      sourceFile: `${cssSourceFile}?replay`,
+    })
+    generateCssByGeneratorMock.mockClear()
+    const emittedAssets: Array<{ fileName?: string, source?: string | Uint8Array }> = []
+    const secondBundle = {
+      [markupFile]: {
+        ...createRollupAsset(`<view class="${replaceWxml('text-[103.43rpx]')}"></view>`),
+        fileName: markupFile,
+      },
+      [appStyleFile]: {
+        ...createRollupAsset(importShell),
+        fileName: appStyleFile,
+      },
+    }
+    await generateBundle.call({
+      addWatchFile: vi.fn(),
+      emitFile: vi.fn((asset: { fileName?: string, source?: string | Uint8Array }) => {
+        emittedAssets.push(asset)
+        return asset.fileName ?? ''
+      }),
+    }, {} as any, secondBundle)
+
+    const replayedMainStyle = emittedAssets.filter(asset => asset.fileName === mainStyleFile).at(-1)?.source?.toString()
+    expect((secondBundle[appStyleFile] as OutputAsset).source.toString()).toBe(importShell)
+    expect(replayedMainStyle).toContain(replaceWxml('text-[103.43rpx]'))
+    expect(replayedMainStyle).not.toContain(replaceWxml('text-[102.43rpx]'))
+    expect(generateCssByGeneratorMock).toHaveBeenCalledWith(expect.objectContaining({
+      outputFile: mainStyleFile,
+      runtime: expect.objectContaining({
+        has: expect.any(Function),
+      }),
     }))
   }, TEST_TIMEOUT_MS)
 

--- a/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-assets.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-assets.unit.test.ts
@@ -415,7 +415,7 @@ describe('vite processed css assets', () => {
     expect(pageCss).not.toContain('.duplicate')
   })
 
-  it('skips preserved mini-program import shells without a single root target', () => {
+  it('limits framework-owned import shell protection to root mini-program styles', () => {
     const records = new Map<string, any>([
       ['src/app.css', { css: '.generated{color:blue}', injectIntoMain: true, outputFile: 'pages/index.wxss' }],
     ])
@@ -431,8 +431,8 @@ describe('vite processed css assets', () => {
       createCssPipelineContext,
       getViteProcessedCssAssetResults: () => records.entries(),
       debug,
-    })).toBe(0)
-    expect(String((scopedImportBundle['pages/index.wxss'] as OutputAsset).source)).toBe('@import "./dep.wxss";')
+    })).toBe(1)
+    expect(String((scopedImportBundle['pages/index.wxss'] as OutputAsset).source)).toContain('.generated{color:blue}')
 
     debug.mockClear()
     const twoImportBundle: OutputBundle = {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-remembered-css-replay.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-remembered-css-replay.unit.test.ts
@@ -53,6 +53,7 @@ describe('bundlers/vite remembered css replay', () => {
       createScopedSourceCandidateGetter: vi.fn(() => undefined),
       createScopedSourceCandidateSourceGetter: vi.fn(() => () => new Map()),
       cssTaskFactories,
+      cssPipelineContext: { opts: { cssMatcher: (file: string) => file.endsWith('.wxss') } } as any,
       debug: vi.fn(),
       defaultStyleOutputExtension: '.wxss',
       emitOrReplayCssAsset: vi.fn(),
@@ -135,6 +136,10 @@ describe('bundlers/vite remembered css replay', () => {
       createScopedSourceCandidateGetter: vi.fn(() => undefined),
       createScopedSourceCandidateSourceGetter: vi.fn(() => () => new Map()),
       cssTaskFactories,
+      cssPipelineContext: { opts: { cssMatcher: (file: string) => file.endsWith('.wxss') } } as any,
+      cssPipelineStrategy: {
+        shouldKeepRootMiniProgramStyleAsImportShell: () => true,
+      },
       debug: vi.fn(),
       defaultStyleOutputExtension: '.wxss',
       emitOrReplayCssAsset,

--- a/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
@@ -2899,14 +2899,14 @@ describe('watch-hmr regression cases', () => {
     }
   })
 
-  it('opts out same-class global-style stability for platform-variant watch cases', () => {
+  it('keeps same-class global-style stability enabled for uni-app watch cases', () => {
     const demoBaseCases = buildDemoBaseCases('/repo')
     const demoExtendedCases = buildDemoExtendedCases('/repo')
     const weappViteCase = demoBaseCases.find(watchCase => watchCase.name === 'weapp-vite-tailwindcss-v4')
     const uniAppVue3ViteCase = demoExtendedCases.find(watchCase => watchCase.name === 'uni-app-vite-tailwindcss-v4')
 
     expect(weappViteCase?.requireStableGlobalStyleOnSameClassLiteral).toBe(false)
-    expect(uniAppVue3ViteCase?.requireStableGlobalStyleOnSameClassLiteral).toBe(false)
+    expect(uniAppVue3ViteCase?.requireStableGlobalStyleOnSameClassLiteral).toBeUndefined()
   })
 
   it('does not require initial compile success for weapp-vite powered watch cases with unstable ready logs', () => {

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases/demo/extended.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases/demo/extended.ts
@@ -295,9 +295,6 @@ export function buildDemoExtendedCases(baseCwd: string): WatchCase[] {
     label: 'demo/uni-app-vite-tailwindcss-v4',
     project: 'demo/uni-app-vite-tailwindcss-v4',
     group: 'demo',
-    // uni-app Vite v4 watch 在 same-class-literal 场景会重写 app.wxss；
-    // 仍校验 HMR 生效、回滚与 escaped class，不强制全局样式文本完全稳定。
-    requireStableGlobalStyleOnSameClassLiteral: false,
     // uni-app Vite v4 的独立分包 HMR 会触发较重的 CSS 汇总阶段；
     // 这里保留 case 级预算，避免放宽其它 demo 的处理耗时约束。
     maxPluginProcessMs: 4000,


### PR DESCRIPTION
## Summary

- preserve framework-owned pure local import root style wrappers during Vite serve and incremental bundles
- replay generated Tailwind CSS into the imported target without overwriting the root shell
- add a reusable 7-case HMR matrix for the CI-compatible uni-app Vite demos across wxss, acss, qss, and ttss
- record explicit exemptions for Taro merged root styles, styleInjector-disabled output, and local-only HBuilderX chains

## Verification

- `pnpm --filter weapp-tailwindcss exec vitest run test/bundlers/vite-plugin.bundle.unit.test.ts test/bundlers/vite-css-finalizer.unit.test.ts test/bundlers/vite-helpers.unit.test.ts test/bundlers/vite-processed-css-assets.unit.test.ts test/bundlers/vite-remembered-css-replay.unit.test.ts test/watch-hmr-regression.unit.test.ts` (371 passed)
- `pnpm --filter weapp-tailwindcss build`
- `pnpm e2e:root-style-shell-hmr` (7 passed)
- filtered subpackage multiplatform build regression for mp-weixin/mp-alipay/mp-toutiao in isolated and single cssEntries modes (6 passed)
- `pnpm exec vitest run --bail=1 -c ./e2e/vitest.e2e.config.ts e2e/e2e-matrix.test.ts` (32 passed)
- targeted ESLint and workflow YAML parse

The broad filtered static run also passed all uni-app checks but retained four existing Taro Vite output failures unrelated to this change.

## Release

- reuses the existing Chinese patch changeset `.changeset/quiet-walls-serve.md`
- no `create-weapp-vite` bump is required because templates and scaffold behavior are unchanged
