### PR TITLE
fix(weapp-tailwindcss): preserve explicit source scopes

### DIFF
--- a/.changeset/bright-rivers-source.md
+++ b/.changeset/bright-rivers-source.md
@@ -2,4 +2,4 @@
 "weapp-tailwindcss": patch
 ---
 
-修复 Vite 与 weapp-vite 项目配置多个 Tailwind CSS v4 `@source` 扫描根时的候选作用域合并问题，确保 monorepo 外部包、`@source not`、`@config` content 排除规则以及主包/分包样式隔离同时生效。
+修复 Vite 与 weapp-vite 项目配置多个 Tailwind CSS v4 `@source` 扫描根时的候选作用域合并问题，确保 monorepo 外部包、`@source not`、`@config` content 排除规则以及主包/分包样式隔离同时生效；同时恢复 Vite dev HMR 的增量 CSS 回放，在保留完整当前候选集的同时继续保留默认不删除的旧 CSS。

--- a/.changeset/bright-rivers-source.md
+++ b/.changeset/bright-rivers-source.md
@@ -2,4 +2,4 @@
 "weapp-tailwindcss": patch
 ---
 
-修复 Vite 与 weapp-vite 项目同时配置多个 Tailwind CSS v4 `@source` 扫描根时，monorepo 外部包候选被本地样式目录错误过滤的问题。
+修复 Vite 与 weapp-vite 项目配置多个 Tailwind CSS v4 `@source` 扫描根时的候选作用域合并问题，确保 monorepo 外部包、`@source not`、`@config` content 排除规则以及主包/分包样式隔离同时生效。

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -79,11 +79,11 @@ jobs:
             watch_case: demo-taro-react
             round_profile: default
             watch_save_snapshots: '1'
-            timeout_minutes: 70
+            timeout_minutes: 75
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '3300000'
+            watch_command_timeout_ms: '3600000'
           - os: macos-latest
             runner_label: macos
             watch_case: demo-taro-vue3

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css.ts
@@ -747,6 +747,11 @@ export async function generateCssByGenerator(
       file,
     )
     let css = generatedCss
+    const distinctUserLayerParts = hasDistinctUserRawSource
+      && hasUserCssLayerBlocks(generatedUserCssRawSource)
+      ? splitUserCssLayerBlocks(generatedUserCssRawSource)
+      : undefined
+    let restoredDistinctUserLayerCss = false
     if (
       generated.target === 'weapp'
       && generatorRawSource.includes('weapp-tailwindcss generator-placeholder')
@@ -787,6 +792,30 @@ export async function generateCssByGenerator(
           }
         }
       }
+      if (
+        hasDistinctUserRawSource
+        && distinctUserLayerParts
+      ) {
+        const layerUserCss = await transformGeneratorUserCss(
+          distinctUserLayerParts.layer,
+          {
+            generatorTarget: generated.target,
+            generatorStyleOptions,
+            cssUserHandlerOptions,
+            styleHandler,
+            importFallback: generatorOptions.importFallback,
+            processed: userRawSourceProcessed,
+          },
+        )
+        const missingLayerUserCss = filterExistingCssRules(css, layerUserCss)
+        if (missingLayerUserCss.trim().length > 0) {
+          css = createCssSourceOrderAppend(wrapUserLayerComponentsCss(layerUserCss), css)
+          restoredDistinctUserLayerCss = true
+          if (shouldFinalizeMarkedUserLayerComponentsCss(file)) {
+            css = reorderMarkedUserLayerComponentsCss(css)
+          }
+        }
+      }
     }
     if (hasMatchedCssSourceFile || generated.target === 'web') {
       if (
@@ -794,7 +823,10 @@ export async function generateCssByGenerator(
         && !hasGeneratedCss
         && !hasGeneratedMarkers
       ) {
-        const userCss = await transformGeneratorUserCss(generatedUserCssRawSource, {
+        const distinctUserCssRawSource = restoredDistinctUserLayerCss
+          ? distinctUserLayerParts?.rest ?? generatedUserCssRawSource
+          : generatedUserCssRawSource
+        const userCss = await transformGeneratorUserCss(distinctUserCssRawSource, {
           generatorTarget: generated.target,
           generatorStyleOptions,
           cssUserHandlerOptions,
@@ -802,7 +834,7 @@ export async function generateCssByGenerator(
           importFallback: generatorOptions.importFallback,
           processed: userRawSourceProcessed,
         })
-        const missingUserCss = isCssAlreadyRepresentedByMarkers(css, generatedUserCssRawSource)
+        const missingUserCss = isCssAlreadyRepresentedByMarkers(css, distinctUserCssRawSource)
           ? filterExistingCssRules(css, userCss)
           : userCss
         css = createCssSourceOrderAppend(css, missingUserCss)
@@ -814,7 +846,10 @@ export async function generateCssByGenerator(
         && !hasGeneratedCss
       ) {
         const cleanedUserCssRawSource = removeTailwindV4GeneratedUserCssArtifacts(userCssRawSource)
-        const userCss = await transformGeneratorUserCss(cleanedUserCssRawSource, {
+        const cleanedUserCssRestSource = restoredDistinctUserLayerCss && hasUserCssLayerBlocks(cleanedUserCssRawSource)
+          ? splitUserCssLayerBlocks(cleanedUserCssRawSource).rest
+          : cleanedUserCssRawSource
+        const userCss = await transformGeneratorUserCss(cleanedUserCssRestSource, {
           generatorTarget: generated.target,
           generatorStyleOptions,
           cssUserHandlerOptions,
@@ -931,7 +966,10 @@ export async function generateCssByGenerator(
       && !hasGeneratedMarkers
       && !hasTailwindApplyDirective(generatedUserCssRawSource)
     ) {
-      const userCss = await transformGeneratorUserCss(generatedUserCssRawSource, {
+      const distinctUserCssRawSource = restoredDistinctUserLayerCss
+        ? distinctUserLayerParts?.rest ?? generatedUserCssRawSource
+        : generatedUserCssRawSource
+      const userCss = await transformGeneratorUserCss(distinctUserCssRawSource, {
         generatorTarget: generated.target,
         generatorStyleOptions,
         cssUserHandlerOptions,
@@ -939,7 +977,7 @@ export async function generateCssByGenerator(
         importFallback: generatorOptions.importFallback,
         processed: userRawSourceProcessed,
       })
-      const missingUserCss = isCssAlreadyRepresentedByMarkers(css, generatedUserCssRawSource)
+      const missingUserCss = isCssAlreadyRepresentedByMarkers(css, distinctUserCssRawSource)
         ? filterExistingCssRules(css, userCss)
         : userCss
       css = createCssSourceOrderAppend(css, missingUserCss)

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-resolver.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-resolver.ts
@@ -798,10 +798,15 @@ export async function resolveGeneratorSource(
   const singleConfiguredCssSource = normalizedSourceOptions?.cssSources?.length === 1
     ? await resolveSingleTailwindV4CssSource(normalizedSourceOptions.cssSources[0]!, normalizedSourceOptions, { index: 0, matched: true })
     : undefined
+  const canResolveCombinedConfiguredCssSources = (normalizedSourceOptions?.cssSources?.length ?? 0) <= 1
+    || hasTailwindGeneratedCss(rawSource)
   const configuredCssSource = normalizedSourceOptions
     && hasConfiguredTailwindV4CssSource(normalizedSourceOptions)
     && hasTailwindGeneratedCssMarkers(rawSource)
-    ? matchedCssSource ?? candidateMatchedCssSource ?? singleConfiguredCssSource ?? await resolveTailwindV4Source(normalizedSourceOptions)
+    ? matchedCssSource
+    ?? candidateMatchedCssSource
+    ?? singleConfiguredCssSource
+    ?? (canResolveCombinedConfiguredCssSources ? await resolveTailwindV4Source(normalizedSourceOptions) : undefined)
     : undefined
   if (configuredCssSource) {
     return generatorOptions?.config

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
@@ -285,8 +285,20 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
     const envFlags = resolveGenerateBundleEnvFlags()
     const bundleFiles = Object.keys(bundle)
     const activeViteCssCacheFiles = new Set(bundleFiles.map(normalizeViteCssCacheKey))
-    const getConfiguredTailwindV4CssSourceEntries = () =>
-      collectConfiguredTailwindV4CssSourceEntries({
+    const normalizeSystemAliasPathKey = (file: string) =>
+      file.startsWith('/private/var/') ? file.slice('/private'.length) : file
+    const normalizeConfiguredCssSourceCacheKey = (file: string) =>
+      normalizeSystemAliasPathKey(normalizeOutputPathKey(path.resolve(file.replace(/[?#].*$/, ''))))
+    const runtimeTailwindcssOptions = resolveTailwindcssOptions(opts.tailwindcssRuntimeOptions)
+    const tailwindRuntimeOptions = resolveTailwindcssOptions(runtimeState.tailwindRuntime.options)
+    const configuredTailwindV4ExplicitCssEntryFiles = [...new Set([
+      ...(Array.isArray(opts.cssEntries) ? opts.cssEntries : []),
+      ...(Array.isArray(opts.tailwindcss?.v4?.cssEntries) ? opts.tailwindcss.v4.cssEntries : []),
+      ...(Array.isArray(runtimeTailwindcssOptions?.v4?.cssEntries) ? runtimeTailwindcssOptions.v4.cssEntries : []),
+      ...(Array.isArray(tailwindRuntimeOptions?.v4?.cssEntries) ? tailwindRuntimeOptions.v4.cssEntries : []),
+    ].filter((file): file is string => typeof file === 'string' && file.length > 0))]
+    const getConfiguredTailwindV4CssSourceEntries = () => {
+      const collectedEntries = collectConfiguredTailwindV4CssSourceEntries({
         ...opts,
         tailwindcssRuntimeOptions: {
           ...(opts.tailwindcssRuntimeOptions ?? {}),
@@ -296,6 +308,21 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
           },
         },
       }, opts.tailwindcssBasedir ?? rootDir)
+      const cachedEntries = configuredTailwindV4ExplicitCssEntryFiles.flatMap((file) => {
+        const resolvedFile = path.isAbsolute(file)
+          ? path.resolve(file)
+          : path.resolve(opts.tailwindcssBasedir ?? rootDir, file)
+        const source = getCssSource(resolvedFile)
+        return typeof source === 'string' && source.length > 0
+          ? [{ file: resolvedFile, source }]
+          : []
+      })
+      const cachedFileKeys = new Set(cachedEntries.map(entry => normalizeConfiguredCssSourceCacheKey(entry.file)))
+      return [
+        ...cachedEntries,
+        ...collectedEntries.filter(entry => !cachedFileKeys.has(normalizeConfiguredCssSourceCacheKey(entry.file))),
+      ]
+    }
     const normalizeGeneratorUserRawSource = (
       source: string,
       sourceFile: string,
@@ -328,28 +355,18 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
       hasOmittedKnownFiles,
     })
     const configuredTailwindV4CssSourceEntriesForScope = getConfiguredTailwindV4CssSourceEntries()
-    const normalizeSystemAliasPathKey = (file: string) =>
-      file.startsWith('/private/var/') ? file.slice('/private'.length) : file
     const normalizeConfiguredTailwindV4CssEntryFileKey = (file: string) => {
       const cleanFile = file.replace(/[?#].*$/, '')
       return normalizeSystemAliasPathKey(normalizeOutputPathKey(path.isAbsolute(cleanFile)
         ? path.resolve(cleanFile)
         : path.resolve(opts.tailwindcssBasedir ?? rootDir, cleanFile)))
     }
-    const runtimeTailwindcssOptions = resolveTailwindcssOptions(opts.tailwindcssRuntimeOptions)
-    const tailwindRuntimeOptions = resolveTailwindcssOptions(runtimeState.tailwindRuntime.options)
     const configuredTailwindV4CssSourceFileKeysForScope = new Set(
       configuredTailwindV4CssSourceEntriesForScope
         .map(entry => normalizeConfiguredTailwindV4CssEntryFileKey(entry.file)),
     )
     const configuredTailwindV4ExplicitCssEntryFileKeysForScope = new Set(
-      [
-        ...(Array.isArray(opts.cssEntries) ? opts.cssEntries : []),
-        ...(Array.isArray(opts.tailwindcss?.v4?.cssEntries) ? opts.tailwindcss.v4.cssEntries : []),
-        ...(Array.isArray(runtimeTailwindcssOptions?.v4?.cssEntries) ? runtimeTailwindcssOptions.v4.cssEntries : []),
-        ...(Array.isArray(tailwindRuntimeOptions?.v4?.cssEntries) ? tailwindRuntimeOptions.v4.cssEntries : []),
-      ]
-        .filter((file): file is string => typeof file === 'string' && file.length > 0)
+      configuredTailwindV4ExplicitCssEntryFiles
         .map(normalizeConfiguredTailwindV4CssEntryFileKey),
     )
     const isRootStyleOutputFile = (file: string) => {
@@ -402,9 +419,6 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
       if (matchedOriginalEntry && outputFile.replace(/[?#].*$/, '').endsWith('.css')) {
         return matchedOriginalEntry
       }
-      if (!shouldSelectConfiguredRootCssOutput(outputFile)) {
-        return undefined
-      }
       const shouldRequireExplicitConfiguredEntry = !cssPipelineContext.currentGeneratorBranch.isWeb
         && opts.cssMatcher(outputFile)
         && isRootStyleOutputFile(outputFile)
@@ -415,6 +429,16 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
           || configuredTailwindV4ExplicitCssEntryFileKeysForScope.has(normalizeConfiguredTailwindV4CssEntryFileKey(entry.file))
         ),
       )
+      const matchedOutputEntries = generationEntries.filter(entry =>
+        normalizeOutputPathKey(resolveConfiguredTailwindV4CssEntryOutputFile(entry.file).replace(/[?#].*$/, ''))
+        === normalizeOutputPathKey(outputFile.replace(/[?#].*$/, '')),
+      )
+      if (matchedOutputEntries.length === 1) {
+        return matchedOutputEntries[0]
+      }
+      if (!shouldSelectConfiguredRootCssOutput(outputFile)) {
+        return undefined
+      }
       if (generationEntries.length <= 1) {
         return generationEntries[0]
       }
@@ -821,6 +845,7 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
         // 否则会退回未转译内容并与同轮 JS/WXML 的 class 改写失配。
         const assetSourceFile = resolveAssetSourceFile(originalSource, file)
         const rawSource = normalizeRelativeCssConfigDirectives(originalEntrySource, assetSourceFile, outDir, opts)
+        const currentRawSourceHasExplicitScanContext = rawSource.includes('@source') || rawSource.includes('@config')
         const cssPipelineContext = {
           ...createInitialCssPipelineContext(file),
           bundle,
@@ -1011,6 +1036,13 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
         }
         rememberedCssSources = rememberedCssSources.filter((remembered) => {
           if (
+            currentRawSourceHasExplicitScanContext
+            && !remembered.rawSource.includes('@source')
+            && !remembered.rawSource.includes('@config')
+          ) {
+            return false
+          }
+          if (
             hasExplicitConfiguredRootCssEntryForOutput(outputFile)
             && !configuredTailwindV4ExplicitCssEntryFileKeysForScope.has(normalizeConfiguredTailwindV4CssEntryFileKey(remembered.sourceFile))
           ) {
@@ -1063,7 +1095,12 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
         const hasExplicitRememberedRootSource = rememberedCssSources.some(remembered =>
           configuredTailwindV4ExplicitCssEntryFileKeysForScope.has(normalizeConfiguredTailwindV4CssEntryFileKey(remembered.sourceFile)),
         )
-        if (configuredRootSourceStyle && (!hasUsableRememberedTailwindSource || !hasExplicitRememberedRootSource)) {
+        const shouldUseConfiguredRootSourceStyle = configuredRootSourceStyle != null
+          && (
+            !currentRawSourceHasExplicitScanContext
+            || hasTailwindGenerationSource(configuredRootSourceStyle.rawSource)
+          )
+        if (shouldUseConfiguredRootSourceStyle && (!hasUsableRememberedTailwindSource || !hasExplicitRememberedRootSource)) {
           rememberedCssSources = [configuredRootSourceStyle]
           hasUsableRememberedTailwindSource = true
           debug('source style source inferred from configured root tailwind v4 css source: %s -> %s', outputFile, configuredRootSourceStyle.sourceFile)
@@ -1241,6 +1278,11 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
               }
             }
           }
+        }
+        if (currentRawSourceHasExplicitScanContext) {
+          rememberedCssSources = rememberedCssSources.filter(remembered =>
+            remembered.rawSource.includes('@source') || remembered.rawSource.includes('@config'),
+          )
         }
         let rememberedCssSource = mergeRememberedCssSources(rememberedCssSources, outputFile)
         if (

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle.ts
@@ -17,6 +17,7 @@ import { validateCandidatesByGenerator } from '../shared/generator-css'
 import { hasTailwindApplyDirective, hasTailwindRootDirectives, hasTailwindSourceDirectives } from '../shared/generator-css/directives'
 import { isPureLocalCssImportWrapper } from '../shared/generator-css/local-imports'
 import { normalizeMiniProgramGeneratorCssSource } from '../shared/generator-css/output-import-shell'
+import { hasUserCssLayerBlocks } from '../shared/generator-css/user-css'
 import { normalizeOutputPathKey } from '../shared/module-graph'
 import { generateTailwindV4Css } from '../shared/v4-generation-core'
 import { createBundleModuleGraphOptions } from './bundle-entries'
@@ -165,6 +166,7 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
       setRememberedCssSignature,
       getKnownCssSource,
       getKnownSfcSource,
+      getOriginalCssLayerSource,
       recordGeneratorCandidates,
       pruneViteCssCaches,
       getViteCssCacheStats,
@@ -1369,6 +1371,21 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
         const generatorSourceFile = vitePipelineCssAsset
           ? rememberedCssSource?.sourceFile ?? assetSourceFile
           : assetSourceFile
+        const originalGeneratorLayerSource = vitePipelineCssAsset
+          ? getOriginalCssLayerSource?.(generatorSourceFile)
+          : undefined
+        const generatorUserLayerRawSource = originalGeneratorLayerSource
+          && normalizeCssSourceForCompare(originalGeneratorLayerSource) !== normalizeCssSourceForCompare(generatorRawSource)
+          && hasUserCssLayerBlocks(originalGeneratorLayerSource)
+          ? normalizeMiniProgramGeneratorRawSource(
+              normalizeGeneratorUserRawSource(
+                originalGeneratorLayerSource,
+                generatorSourceFile,
+                assetSourceFile,
+              ),
+              outputFile,
+            )
+          : undefined
         const webviewRootCssInjectionTarget = vitePipelineCssAsset
           ? resolveConfiguredCssEntryRootInjectionTarget(generatorSourceFile, outputFile)
           : undefined
@@ -1617,6 +1634,17 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
                   : previousCss
                 const shouldGenerateCssWithCore = hasTailwindGenerationSource(generatorTransformRawSource)
                   || hasBundlerGeneratedCssMarker(rawSource)
+                const bundleUserRawSource = vitePipelineCssAsset
+                  && !hasBundlerGeneratedCssMarker(rawSource)
+                  && normalizeCssSourceForCompare(rawSource) !== normalizeCssSourceForCompare(generatorRawSource)
+                  ? normalizeMiniProgramGeneratorRawSource(
+                      normalizeGeneratorUserRawSource(rawSource, generatorSourceFile, assetSourceFile),
+                      outputFile,
+                    )
+                  : undefined
+                const generatorUserRawSource = [generatorUserLayerRawSource, bundleUserRawSource]
+                  .filter((source): source is string => typeof source === 'string' && source.trim().length > 0)
+                  .join('\n')
                 const generated = shouldGenerateCssWithCore
                   ? await generateTailwindV4Css({
                       opts,
@@ -1633,9 +1661,7 @@ export function createGenerateBundleHook(context: GenerateBundleContext) {
                       styleHandler,
                       debug,
                       previousCss: previousGeneratorCss,
-                      ...(vitePipelineCssAsset && !hasBundlerGeneratedCssMarker(rawSource) && normalizeCssSourceForCompare(rawSource) !== normalizeCssSourceForCompare(generatorRawSource)
-                        ? { userRawSource: normalizeMiniProgramGeneratorRawSource(normalizeGeneratorUserRawSource(rawSource, generatorSourceFile, assetSourceFile), outputFile) }
-                        : {}),
+                      ...(generatorUserRawSource ? { userRawSource: generatorUserRawSource } : {}),
                       ...(usesConfiguredTailwindV4FallbackSource
                         ? { restoreLocalCssImports: false }
                         : {}),

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/scoped-generator.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/scoped-generator.ts
@@ -35,6 +35,12 @@ function mergeCandidates(first: Set<string>, second: Set<string>) {
   return new Set([...first, ...second])
 }
 
+function canFallbackToOutputCandidates(rawSource: string, entries: TailwindSourceEntry[]) {
+  return rawSource.includes('@source')
+    && entries.length > 0
+    && entries.every(entry => !entry.negated)
+}
+
 function resolveScopedSourceEntries(rawSource: string, sourceFile: string, resolvedEntries: TailwindSourceEntry[] | undefined) {
   if (!hasOwnSourceDirectives(rawSource)) {
     return {
@@ -121,7 +127,9 @@ export async function createScopedGeneratorRuntime(options: {
       const explicitCandidates = getSourceCandidatesForEntries(entries)
       const outputCandidates = scopedSourceCandidateGetter?.(undefined)
       const scopedCandidates = outputCandidates
-        ? intersectCandidates(explicitCandidates, outputCandidates)
+        ? explicitCandidates.size === 0 && canFallbackToOutputCandidates(rawSource, entries)
+          ? outputCandidates
+          : intersectCandidates(explicitCandidates, outputCandidates)
         : explicitCandidates
       const shouldMergeFallbackRuntime = hasCssMacroTailwindV4CustomVariantConditionalComments(rawSource)
       return shouldMergeFallbackRuntime ? mergeCandidates(scopedCandidates, fallbackRuntime) : scopedCandidates

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/scoped-generator.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/scoped-generator.ts
@@ -17,17 +17,22 @@ function createLocalSourceEntries(sourceFile: string): TailwindSourceEntry[] {
   }]
 }
 
-function mergeCandidates(first: Set<string>, second: Set<string>) {
-  return new Set([...first, ...second])
+function intersectCandidates(first: Set<string>, second: Set<string>) {
+  if (first.size === 0 || second.size === 0) {
+    return new Set<string>()
+  }
+  const [small, large] = first.size <= second.size ? [first, second] : [second, first]
+  const scoped = new Set<string>()
+  for (const candidate of small) {
+    if (large.has(candidate)) {
+      scoped.add(candidate)
+    }
+  }
+  return scoped
 }
 
-// 输出侧 sourceFile 可能无法还原显式 entries，仅在显式与本地范围都为空时复用已收集作用域。
-function resolveScopedCandidates<T extends Set<string> | Map<string, Set<string>>>(
-  scoped: T,
-  local: T | undefined,
-  fallback: T | undefined,
-) {
-  return scoped.size === 0 && local?.size === 0 && fallback?.size ? fallback : scoped
+function mergeCandidates(first: Set<string>, second: Set<string>) {
+  return new Set([...first, ...second])
 }
 
 function resolveScopedSourceEntries(rawSource: string, sourceFile: string, resolvedEntries: TailwindSourceEntry[] | undefined) {
@@ -37,15 +42,13 @@ function resolveScopedSourceEntries(rawSource: string, sourceFile: string, resol
       localEntries: undefined,
     }
   }
-  if (resolvedEntries?.length) {
+  if (resolvedEntries !== undefined) {
     return {
       entries: resolvedEntries,
-      localEntries: createLocalSourceEntries(sourceFile),
     }
   }
   return {
     entries: createLocalSourceEntries(sourceFile),
-    localEntries: undefined,
   }
 }
 
@@ -65,15 +68,11 @@ export async function createScopedGeneratorCandidateSignature(
   if (!getSourceCandidatesForEntries || !hasOwnSourceDirectives(rawSource)) {
     return fallbackSignature
   }
-  const { entries, localEntries } = await resolveScopedGeneratorSourceEntries(rawSource, sourceFile)
+  const { entries } = await resolveScopedGeneratorSourceEntries(rawSource, sourceFile)
   if (entries === undefined) {
     return fallbackSignature
   }
-  const scopedCandidates = resolveScopedCandidates(
-    getSourceCandidatesForEntries(entries),
-    localEntries ? getSourceCandidatesForEntries(localEntries) : undefined,
-    localEntries ? getSourceCandidatesForEntries(undefined) : undefined,
-  )
+  const scopedCandidates = getSourceCandidatesForEntries(entries)
   const scopedSignature = createCandidateSignature(scopedCandidates)
   return options.includeFallbackSignature === true
     ? `${scopedSignature}:${fallbackSignature}`
@@ -88,15 +87,11 @@ export async function createScopedGeneratorSourceTraceMap(
   if (!getSourceCandidateSourcesForEntries || !hasOwnSourceDirectives(rawSource)) {
     return getSourceCandidateSourcesForEntries?.(undefined)
   }
-  const { entries, localEntries } = await resolveScopedGeneratorSourceEntries(rawSource, sourceFile)
+  const { entries } = await resolveScopedGeneratorSourceEntries(rawSource, sourceFile)
   if (entries === undefined) {
     return getSourceCandidateSourcesForEntries(undefined)
   }
-  return resolveScopedCandidates(
-    getSourceCandidateSourcesForEntries(entries),
-    localEntries ? getSourceCandidateSourcesForEntries(localEntries) : undefined,
-    localEntries ? getSourceCandidateSourcesForEntries(undefined) : undefined,
-  )
+  return getSourceCandidateSourcesForEntries(entries)
 }
 
 export async function createScopedGeneratorRuntime(options: {
@@ -121,15 +116,13 @@ export async function createScopedGeneratorRuntime(options: {
     scopedSourceCandidateGetter,
   } = options
   if (getSourceCandidatesForEntries && rawSource && sourceFile) {
-    const { entries, localEntries } = await resolveScopedGeneratorSourceEntries(rawSource, sourceFile)
+    const { entries } = await resolveScopedGeneratorSourceEntries(rawSource, sourceFile)
     if (entries !== undefined && (entries.length > 0 || hasOwnSourceDirectives(rawSource))) {
-      const scopedCandidates = resolveScopedCandidates(
-        scopedSourceCandidateGetter?.(entries) ?? getSourceCandidatesForEntries(entries),
-        localEntries
-          ? scopedSourceCandidateGetter?.(localEntries) ?? getSourceCandidatesForEntries(localEntries)
-          : undefined,
-        localEntries ? scopedSourceCandidateGetter?.(undefined) : undefined,
-      )
+      const explicitCandidates = getSourceCandidatesForEntries(entries)
+      const outputCandidates = scopedSourceCandidateGetter?.(undefined)
+      const scopedCandidates = outputCandidates
+        ? intersectCandidates(explicitCandidates, outputCandidates)
+        : explicitCandidates
       const shouldMergeFallbackRuntime = hasCssMacroTailwindV4CustomVariantConditionalComments(rawSource)
       return shouldMergeFallbackRuntime ? mergeCandidates(scopedCandidates, fallbackRuntime) : scopedCandidates
     }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/types.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/types.ts
@@ -46,6 +46,7 @@ export interface GenerateBundleContext {
   setRememberedCssSignature?: (file: string, cssRuntimeSignature: string) => void
   getKnownCssSource?: (file: string) => string | undefined
   getKnownSfcSource?: (file: string) => string | undefined
+  getOriginalCssLayerSource?: (file: string) => string | undefined
   recordGeneratorCandidates?: (candidates: Set<string>) => void
   pruneViteCssCaches?: (options: {
     activeFiles: Set<string>

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
@@ -14,7 +14,7 @@ import { logger } from '@weapp-tailwindcss/logger'
 import { compileCssMacroConditionalComments, removeTailwindPostcssPlugins, resolveFilteredPostcssConfig, transformWebCssCompat, unwrapUnsupportedCascadeLayers } from '@weapp-tailwindcss/postcss'
 import { LRUCache } from 'lru-cache'
 import { hasTailwindApplyDirective, hasTailwindRootDirectives, hasTailwindSourceDirectives, normalizeTailwindConfigDirectives, normalizeTailwindSourceForGenerator } from '@/bundlers/shared/generator-css/directives'
-import { hasUserCssLayerBlocks, normalizeEmptyTailwindCustomVariants } from '@/bundlers/shared/generator-css/user-css'
+import { hasUserCssLayerBlocks, normalizeEmptyTailwindCustomVariants, splitUserCssLayerBlocks } from '@/bundlers/shared/generator-css/user-css'
 import { vitePluginName } from '@/constants'
 import { getCompilerContext } from '@/context'
 import { toCustomAttributesEntities } from '@/context/custom-attributes'
@@ -424,6 +424,18 @@ export function createViteFrameworkPlugins(
     customAttributesEntities,
     disabledDefaultTemplateHandler,
   })
+  const originalCssLayerSourceByFile = new LRUCache<string, string>({ max: 128 })
+  const rememberOriginalCssLayerSource = (id: string, code: string) => {
+    const file = cleanUrl(id)
+    if (!isCSSRequest(file)) {
+      return
+    }
+    if (!hasUserCssLayerBlocks(code)) {
+      originalCssLayerSourceByFile.delete(file)
+      return
+    }
+    originalCssLayerSourceByFile.set(file, splitUserCssLayerBlocks(code).layer)
+  }
   const sourceCandidateScanCache = new LRUCache<string, SourceCandidateCollectorSnapshot>({
     max: SOURCE_CANDIDATE_SCAN_CACHE_MAX,
   })
@@ -1256,6 +1268,7 @@ export function createViteFrameworkPlugins(
     setRememberedCssSignature: cssMemory.setRememberedCssSignature,
     getKnownCssSource: cssMemory.getKnownCssSource,
     getKnownSfcSource: cssMemory.getKnownSfcSource,
+    getOriginalCssLayerSource: file => originalCssLayerSourceByFile.get(cleanUrl(file)),
     recordGeneratorCandidates,
     pruneViteCssCaches,
     getViteCssCacheStats,
@@ -1330,6 +1343,7 @@ export function createViteFrameworkPlugins(
         if (typeof rawCode !== 'string') {
           return
         }
+        rememberOriginalCssLayerSource(id, rawCode)
         const transformedCode = transformEarlyMiniProgramCss(rawCode)
         if (transformedCode === rawCode) {
           return
@@ -1340,6 +1354,9 @@ export function createViteFrameworkPlugins(
       transform: {
         order: 'pre',
         async handler(code, id) {
+          if (hasUserCssLayerBlocks(code)) {
+            rememberOriginalCssLayerSource(id, code)
+          }
           let transformedCode = code
           if (
             shouldOwnTailwindGeneration
@@ -1423,6 +1440,9 @@ export function createViteFrameworkPlugins(
           const hotSource = isSourceCandidateHotUpdate && canReadHotSource
             ? await ctx.read().catch(() => undefined)
             : undefined
+          if (typeof hotSource === 'string' && isCSSRequest(ctx.file)) {
+            rememberOriginalCssLayerSource(ctx.file, hotSource)
+          }
           const sourceCandidateChange = await syncChangedSourceCandidateFile(ctx.file, hotSource)
           const isWebLikeHotUpdate = isCurrentWebLikeStylePlatform()
           let canUseHmrCandidateAppend = false

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
@@ -1098,6 +1098,12 @@ export function createViteFrameworkPlugins(
         generatorCode: generatorTransformCode,
       }) ?? true
     )
+    const previousCss = pendingHmrChange && !forceFullHmrCssRegeneration
+      ? cleanGeneratedCssByFile.get(fileKey)
+      : undefined
+    const previousGeneratorCss = previousCss && !currentGeneratorBranch.isWeb
+      ? normalizeMiniProgramGeneratorCssSource(previousCss, outputFile)
+      : previousCss
     const generated = await hmrTimingRecorder.measure('generateCss.serve', () => generateTailwindV4Css({
       opts,
       runtimeState,
@@ -1114,6 +1120,10 @@ export function createViteFrameworkPlugins(
       generatorPlatform: resolveGeneratorPlatform(),
       styleHandler,
       debug,
+      previousCss: previousGeneratorCss,
+      previousClassSet: pendingHmrChange && !forceFullHmrCssRegeneration
+        ? generatedClassSetByFile.get(fileKey)
+        : undefined,
       deferEmptyScopedCssSource: shouldDeferEmptyScopedCssSource,
       disableSourceScan: false,
       restoreLocalCssImports: !currentGeneratorBranch.isWeb,

--- a/packages/weapp-tailwindcss/test/bundlers/generator-css.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/generator-css.unit.test.ts
@@ -5044,6 +5044,81 @@ describe('bundlers/shared generator css', () => {
     expect(styleHandler).not.toHaveBeenCalled()
   })
 
+  it('preserves distinct user layer css once on forced prefix mismatch', async () => {
+    const runtimeSet = new Set(['bg-blue-500'])
+    const generatorRawSource = [
+      '/*! tailwindcss v4.2.4 | MIT License | https://tailwindcss.com */',
+      '.stale-generated{display:block}',
+      '@config "./tailwind.config.js";',
+      '@source "./src/**/*.{tsx,ts}";',
+    ].join('\n')
+    const userRawSource = [
+      '@layer base { button::after, wx-button::after { display: none; border: none; content: ""; } }',
+      '@layer components { .layer-card-v4 { display: flex; } }',
+    ].join('\n')
+    const generatedCss = '.bg-blue-500{background-color:var(--color-blue-500)}'
+    const generateMock = vi.fn(async () => ({
+      css: generatedCss,
+      rawCss: '.bg-blue-500{background-color:var(--color-blue-500)}',
+      target: 'weapp',
+      classSet: runtimeSet,
+      dependencies: [],
+      sources: [],
+      root: null,
+    }))
+
+    vi.doMock('@/generator', () => ({
+      ...createDefaultGeneratorMock(),
+      createWeappTailwindcssGenerator: vi.fn(() => ({
+        generate: generateMock,
+      })),
+    }))
+
+    const { generateCssByGenerator } = await import('@/bundlers/shared/generator-css')
+    const styleHandler = vi.fn(async (code: string) => ({ css: code }))
+    const result = await generateCssByGenerator({
+      opts: {
+        styleHandler,
+      } as any,
+      runtimeState: {
+        tailwindRuntime: {
+          majorVersion: 4,
+        } as any,
+        readyPromise: Promise.resolve(),
+      },
+      runtime: runtimeSet,
+      rawSource: generatorRawSource,
+      userRawSource,
+      file: 'app.wxss',
+      cssHandlerOptions: {
+        isMainChunk: true,
+        postcssOptions: {
+          options: {
+            from: 'app.wxss',
+          },
+        },
+        majorVersion: 4,
+      } as any,
+      cssUserHandlerOptions: {
+        isMainChunk: false,
+        postcssOptions: {
+          options: {
+            from: 'app.wxss',
+          },
+        },
+        majorVersion: 4,
+      } as any,
+      styleHandler,
+      debug: vi.fn(),
+    })
+
+    expect(result?.css.match(/(?:^|[,{])\s*button::after/g)).toHaveLength(1)
+    expect(result?.css.match(/wx-button::after/g)).toHaveLength(1)
+    expect(result?.css.match(/\.layer-card-v4/g)).toHaveLength(1)
+    expect(result?.css).not.toContain('@layer')
+    expect(result?.css).toContain('.bg-blue-500')
+  })
+
   it('removes Tailwind display-p3 supports from forced legacy compat css', async () => {
     const runtimeSet = new Set(['bg-blue-500'])
     const rawSource = [

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -15719,12 +15719,14 @@ const fallback = "bg-[#434332] px-[32px]"
     createdDirs.push(root)
     const mainCssFile = path.join(root, 'src/main.css')
     const mainCssSource = '@import "tailwindcss" source(none);\n@source "./pages/**/*.{vue,js,ts}";'
+    const originalMainCssLayerSource = '@layer base { button::after { display: none; } }'
     const generateCssByGeneratorMock = vi.fn(async (options: {
       file: string
       rawSource: string
+      userRawSource?: string | undefined
     }) => {
       return {
-        css: '.from-main{color:red}',
+        css: ['.from-main{color:red}', options.userRawSource].filter(Boolean).join('\n'),
         rawCss: options.rawSource,
         target: 'weapp',
         source: 'generator',
@@ -15807,7 +15809,7 @@ const fallback = "bg-[#434332] px-[32px]"
       getViteProcessedCssAssetResult: () => undefined,
       getSourceCandidates: () => runtimeSet,
       getSourceCandidatesForEntries: () => runtimeSet,
-      getSourceCandidateSource: () => undefined,
+      getSourceCandidateSource: () => mainCssSource,
       getSourceCandidateSources: () => [],
       getSourceCandidateSourcesForEntries: () => [],
       waitForSourceCandidateSyncs: vi.fn(async () => undefined),
@@ -15816,6 +15818,8 @@ const fallback = "bg-[#434332] px-[32px]"
       getRememberedCssSources: () => new Map(),
       getRememberedCssSignature: () => undefined,
       setRememberedCssSignature: vi.fn(),
+      getKnownCssSource: () => mainCssSource,
+      getOriginalCssLayerSource: () => originalMainCssLayerSource,
       recordGeneratorCandidates: vi.fn(),
     })
     const bundle = {
@@ -15829,11 +15833,13 @@ const fallback = "bg-[#434332] px-[32px]"
     await generateBundle.call({ addWatchFile: vi.fn() }, {}, bundle)
 
     const appCss = String((bundle['app.wxss'] as OutputAsset).source)
-    expect(appCss).toContain('.from-main')
     expect(generateCssByGeneratorMock).toHaveBeenCalledWith(expect.objectContaining({
       file: mainCssFile,
       rawSource: mainCssSource,
+      userRawSource: expect.stringContaining('@layer base'),
     }))
+    expect(appCss).toContain('.from-main')
+    expect(appCss).toContain('button::after')
     expect(generateCssByGeneratorMock).not.toHaveBeenCalledWith(expect.objectContaining({
       file: 'app.wxss',
     }))

--- a/packages/weapp-tailwindcss/test/bundlers/vite-scoped-generator.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-scoped-generator.unit.test.ts
@@ -119,4 +119,30 @@ describe('bundlers/vite scoped generator runtime', () => {
     expect(signature).toBe(createCandidateSignature(allCandidates))
     expect(sourceTrace?.get(packageCandidate)).toEqual(new Set([packageSource]))
   })
+
+  it('intersects explicit Tailwind source roots with the current output scope', async () => {
+    const appCandidate = 'bg-[#123457]'
+    const packageCandidate = 'text-[#456789]'
+    const runtime = await createScopedGeneratorRuntime({
+      cssHandlerOptions: {
+        isMainChunk: false,
+      },
+      fallbackRuntime: new Set([appCandidate, packageCandidate]),
+      getSourceCandidatesForEntries: () => new Set([appCandidate, packageCandidate]),
+      majorVersion: 4,
+      outputFile: 'sub-package/app.wxss',
+      rawSource: [
+        '@import "tailwindcss";',
+        '@source "./pages/**/*.{wxml,ts}";',
+        '@source "../../../packages/ui/src/**/*.{wxml,ts}";',
+      ].join('\n'),
+      scopedSourceCandidateGetter: entries => entries === undefined
+        ? new Set([packageCandidate])
+        : new Set([appCandidate, packageCandidate]),
+      shouldExcludeSubpackageSourceCandidates: () => false,
+      sourceFile: '/project/apps/template/src/app.css',
+    })
+
+    expect(runtime).toEqual(new Set([packageCandidate]))
+  })
 })

--- a/packages/weapp-tailwindcss/test/bundlers/vite-scoped-generator.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-scoped-generator.unit.test.ts
@@ -145,4 +145,31 @@ describe('bundlers/vite scoped generator runtime', () => {
 
     expect(runtime).toEqual(new Set([packageCandidate]))
   })
+
+  it('uses the current output scope when positive @source entries resolve no candidates', async () => {
+    const outputCandidates = new Set([
+      'bg-explicit-entry',
+      "before:content-['explicit_entry']",
+    ])
+    const runtime = await createScopedGeneratorRuntime({
+      cssHandlerOptions: {
+        isMainChunk: false,
+      },
+      fallbackRuntime: new Set(['global-entry']),
+      getSourceCandidatesForEntries: entries => entries === undefined
+        ? outputCandidates
+        : new Set<string>(),
+      majorVersion: 4,
+      outputFile: 'features/entry.wxss',
+      rawSource: '@import "tailwindcss" source(none);\n@source "./**/*.{wxml,js,ts}";',
+      scopedSourceCandidateGetter: entries => entries === undefined
+        ? outputCandidates
+        : new Set<string>(),
+      shouldExcludeSubpackageSourceCandidates: () => false,
+      sourceFile: '/project/dist/features/entry.wxss',
+    })
+
+    expect(runtime).toEqual(outputCandidates)
+    expect(runtime).not.toContain('global-entry')
+  })
 })

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -749,6 +749,14 @@ describe('e2e watch workflow', () => {
         watch_command_timeout_ms: '1500000',
       },
     ]
+    const slowMacosTaroReactPrBudget = {
+      watch_case: 'demo-taro-react',
+      round_profile: 'default',
+      timeout_minutes: 75,
+      watch_timeout_ms: '420000',
+      watch_max_plugin_process_ms: '60000',
+      watch_command_timeout_ms: '3600000',
+    }
     const macosMpxPrBudget = {
       watch_case: 'mpx-tailwindcss-v4',
       round_profile: 'default',
@@ -833,6 +841,11 @@ describe('e2e watch workflow', () => {
         ...budget,
       }))
     }
+    expect(prRows).toContainEqual(expect.objectContaining({
+      os: 'macos-latest',
+      runner_label: 'macos',
+      ...slowMacosTaroReactPrBudget,
+    }))
     for (const budget of slowWindowsPrBudgets) {
       expect(prRows).toContainEqual(expect.objectContaining({
         os: 'windows-latest',

--- a/packages/weapp-tailwindcss/test/v5/vite-generator.bundle.test.ts
+++ b/packages/weapp-tailwindcss/test/v5/vite-generator.bundle.test.ts
@@ -1883,10 +1883,11 @@ describe('v5 vite generator bundle', () => {
     await generateBundle?.call(postPlugin, {} as any, bundle)
 
     const generatedCandidateSets = generateMock.mock.calls.map(call => [...call[0].candidates])
-    expect(generateMock).toHaveBeenCalledTimes(2)
+    expect(generateMock).toHaveBeenCalledTimes(3)
+    expect(generatedCandidateSets).toContainEqual(['vite-main-only'])
     expect(generatedCandidateSets).toContainEqual(['vite-normal-only'])
     expect(generatedCandidateSets).toContainEqual(['vite-independent-only'])
-    expect((bundle['app.css'] as OutputAsset).source).toBe('')
+    expect((bundle['app.css'] as OutputAsset).source).toContain('.vite-main-only')
     expect((bundle['app.css'] as OutputAsset).source).not.toContain('.vite-normal-only')
     expect((bundle['app.css'] as OutputAsset).source).not.toContain('.vite-independent-only')
     expect((bundle['pages/index/index.css'] as OutputAsset).source).toContain('.page-local{}')


### PR DESCRIPTION
## Summary

- separate explicit Tailwind source entries from output package scope before intersecting candidates
- recover configured CSS entry source from lifecycle caches without reading source files during generateBundle
- prevent virtual remembered sources from overriding current @source/@config context
- preserve main-package and subpackage CSS entry isolation while keeping every explicit source root

## Verification

- scoped generator and source candidate tests: 29 passed
- issue #984 boundary tests: 3 passed
- issue #984 monorepo E2E: 1 passed
- weapp-tailwindcss declaration build passed
- changeset status: patch bump for weapp-tailwindcss and existing dependent packages

Fixes #984