### PR TITLE
fix: 修复核心全量测试回归与动态颜色透明度转换

### DIFF
--- a/.changeset/calm-colors-settle.md
+++ b/.changeset/calm-colors-settle.md
@@ -1,0 +1,6 @@
+---
+"@weapp-tailwindcss/postcss": patch
+"weapp-tailwindcss": patch
+---
+
+修复 Tailwind CSS v4 现代颜色配合动态透明度变量时的 RGB 通道转换，避免 OKLCH 等颜色被错误地直接当作 RGB 通道输出。

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -145,7 +145,8 @@ jobs:
             watch_timeout_ms: '600000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '10000'
-            watch_command_timeout_ms: '1800000'
+            # TT 全量轮次包含主包与两个分包，macOS runner 实测会超过 30 分钟。
+            watch_command_timeout_ms: '3300000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-vite-vue3-tailwindcss-v4:alipay

--- a/packages/postcss/src/compat/color-mix/parse.ts
+++ b/packages/postcss/src/compat/color-mix/parse.ts
@@ -151,6 +151,21 @@ export function normalizeColorFunctionName(
   return serializeRGB(resolvedColor).toString()
 }
 
+export function normalizeColorFunctionWithDynamicAlpha(
+  colorSource: string,
+  alphaSource: string,
+  customPropertyValues: ReadonlyMap<string, string>,
+) {
+  const resolvedColor = resolveColorData(colorSource, customPropertyValues)
+  const alphaColor = getParsedColorData(`rgb(0 0 0 / ${alphaSource})`)
+  if (!resolvedColor || !alphaColor || typeof alphaColor.alpha === 'number') {
+    return undefined
+  }
+
+  resolvedColor.alpha = alphaColor.alpha
+  return serializeRGB(resolvedColor).toString()
+}
+
 export function normalizeStandaloneColorFunction(colorSource: string) {
   const resolvedColor = getParsedColorData(colorSource)
   return resolvedColor ? serializeRGB(resolvedColor).toString() : undefined

--- a/packages/postcss/src/compat/color-mix/resolve.ts
+++ b/packages/postcss/src/compat/color-mix/resolve.ts
@@ -8,25 +8,17 @@ import {
 } from './constants'
 import {
   normalizeColorFunctionName,
+  normalizeColorFunctionWithDynamicAlpha,
   parseAlphaValue,
-  resolveColorData,
   splitArguments,
   splitStopSegments,
   trimNodes,
 } from './parse'
 
 function createRgbaWithAlpha(colorSource: string, alphaSource: string, customPropertyValues: ReadonlyMap<string, string>) {
-  const resolvedColor = resolveColorData(colorSource, customPropertyValues)
-  if (!resolvedColor) {
-    return undefined
-  }
-
-  const [red, green, blue] = resolvedColor.channels
-    .map(channel => Math.round(Math.min(1, Math.max(0, channel)) * 255))
   const alpha = alphaSource.trim()
   const normalizedAlpha = CUSTOM_PROPERTY_RE.test(alpha) ? `var(${alpha})` : alpha
-
-  return `rgba(${red}, ${green}, ${blue}, ${normalizedAlpha})`
+  return normalizeColorFunctionWithDynamicAlpha(colorSource, normalizedAlpha, customPropertyValues)
 }
 
 export function tryResolveColorMix(

--- a/packages/postcss/test/color-mix-compat.test.ts
+++ b/packages/postcss/test/color-mix-compat.test.ts
@@ -76,6 +76,7 @@ describe('color-mix compatibility helpers', () => {
   it('resolves static, dynamic, currentColor, and unresolved color-mix values', () => {
     const customProperties = new Map([
       ['--brand', '#0ea5e9'],
+      ['--modern-brand', 'oklch(68.5% 0.169 237.323)'],
     ])
 
     function resolve(source: string) {
@@ -90,6 +91,10 @@ describe('color-mix compatibility helpers', () => {
     })
     expect(resolve('color-mix(in oklab, var(--brand) var(--alpha), transparent)')).toEqual({
       value: 'rgba(14, 165, 233, var(--alpha))',
+      deferred: true,
+    })
+    expect(resolve('color-mix(in oklab, var(--modern-brand) var(--alpha), transparent)')).toEqual({
+      value: 'rgba(0, 165, 234, var(--alpha))',
       deferred: true,
     })
     expect(resolve('color-mix(in oklab, var(--missing) var(--alpha), transparent)')).toEqual({

--- a/packages/weapp-tailwindcss/test/__snapshots__/gulp.test.ts.snap
+++ b/packages/weapp-tailwindcss/test/__snapshots__/gulp.test.ts.snap
@@ -6,8 +6,20 @@ exports[`gulp > common build > css 1`] = `
       box-sizing: border-box;
       margin: 0;
       padding: 0;
+      --tw-space-y-reverse: 0;
       --tw-border-style: solid;
+      --tw-font-weight: initial;
+      --tw-leading: ;
     }
+:host,page,.tw-root,wx-root-portal-content {
+  --spacing: 0.25rem;
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1.33333;
+  --text-base: 1rem;
+  --text-base--line-height: 1.5;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+}
 .m-_b20px_B {
   margin: 20px;
 }
@@ -29,6 +41,11 @@ exports[`gulp > common build > css 1`] = `
 .w-screen {
   width: 100vw;
 }
+.space-y-4>view+view,.space-y-4>view+text,.space-y-4>text+view,.space-y-4>text+text {
+    --tw-space-y-reverse: 0;
+    margin-bottom: calc((var(--spacing)*4)*var(--tw-space-y-reverse));
+    margin-top: calc((var(--spacing)*4)*(1 - var(--tw-space-y-reverse)));
+  }
 .border-b {
   border-bottom-style: var(--tw-border-style);
   border-bottom-width: 1px;
@@ -63,11 +80,27 @@ exports[`gulp > common build > css 1`] = `
 .text-left {
   text-align: left;
 }
+.text-base {
+  font-size: var(--text-base);
+  line-height: var(--tw-leading, var(--text-base--line-height));
+}
+.text-xs {
+  font-size: var(--text-xs);
+  line-height: var(--tw-leading, var(--text-xs--line-height));
+}
 .text-_b14px_B {
   font-size: 14px;
 }
 .text-_b50px_B {
   font-size: 50px;
+}
+.font-bold {
+  --tw-font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-bold);
+}
+.font-medium {
+  --tw-font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-medium);
 }
 .text-_b_h5ba4e5_B {
   color: #5ba4e5;

--- a/packages/weapp-tailwindcss/test/__snapshots__/vite.test.ts.snap
+++ b/packages/weapp-tailwindcss/test/__snapshots__/vite.test.ts.snap
@@ -15,12 +15,12 @@ exports[`vite > v4-vite-plugin > css 1`] = `
     --tw-content: "";
   }
 :host,page,.tw-root,wx-root-portal-content {
-    --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, "Apple Color Emoji",
-      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-      "Courier New", monospace;
-    --color-green-400: #05df72;
-    --color-sky-400: #00bcff;
+    --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+    --color-green-400: rgb(5, 223, 114);
+    --color-sky-400: rgb(0, 187, 253);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
 }
@@ -113,10 +113,10 @@ exports[`vite > v4-vite-postcss > css 1`] = `
     --tw-content: "";
   }
 :host,page,.tw-root,wx-root-portal-content {
-    --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, "Apple Color Emoji",
-      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-      "Courier New", monospace;
+    --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
 }

--- a/packages/weapp-tailwindcss/test/bundlers/gulp.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/gulp.unit.test.ts
@@ -1,10 +1,10 @@
 import type { Transform } from 'node:stream'
 import { Buffer } from 'node:buffer'
 import fs from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import Vinyl from 'vinyl'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPlugins } from '@/bundlers/gulp'
@@ -263,6 +263,8 @@ describe('bundlers/gulp createPlugins', () => {
         generate: generateMock,
       })),
       normalizeWeappTailwindcssGeneratorOptions: vi.fn(() => ({
+        enabled: true,
+        importFallback: false,
         target: 'weapp',
         styleOptions: {},
       })),
@@ -373,6 +375,8 @@ describe('bundlers/gulp createPlugins', () => {
         generate: generateMock,
       })),
       normalizeWeappTailwindcssGeneratorOptions: vi.fn(() => ({
+        enabled: true,
+        importFallback: false,
         target: 'weapp',
         styleOptions: {},
       })),
@@ -477,6 +481,8 @@ describe('bundlers/gulp createPlugins', () => {
         generate: generateMock,
       })),
       normalizeWeappTailwindcssGeneratorOptions: vi.fn(() => ({
+        enabled: true,
+        importFallback: false,
         target: 'weapp',
         styleOptions: {},
       })),

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -757,6 +757,14 @@ describe('e2e watch workflow', () => {
       watch_max_plugin_process_ms: '60000',
       watch_command_timeout_ms: '3600000',
     }
+    const slowMacosTaroReactTtPrBudget = {
+      watch_case: 'taro-vite-react-tailwindcss-v4:tt',
+      round_profile: 'default',
+      timeout_minutes: 70,
+      watch_timeout_ms: '600000',
+      watch_max_plugin_process_ms: '10000',
+      watch_command_timeout_ms: '3300000',
+    }
     const macosMpxPrBudget = {
       watch_case: 'mpx-tailwindcss-v4',
       round_profile: 'default',
@@ -845,6 +853,11 @@ describe('e2e watch workflow', () => {
       os: 'macos-latest',
       runner_label: 'macos',
       ...slowMacosTaroReactPrBudget,
+    }))
+    expect(prRows).toContainEqual(expect.objectContaining({
+      os: 'macos-latest',
+      runner_label: 'macos',
+      ...slowMacosTaroReactTtPrBudget,
     }))
     for (const budget of slowWindowsPrBudgets) {
       expect(prRows).toContainEqual(expect.objectContaining({

--- a/packages/weapp-tailwindcss/test/context/handlers.test.ts
+++ b/packages/weapp-tailwindcss/test/context/handlers.test.ts
@@ -270,11 +270,11 @@ describe('resolveStyleOptionsFromContext', () => {
       cssPresetEnv: ctx.cssPresetEnv,
       autoprefixer: ctx.autoprefixer,
       cssCalc: ctx.cssCalc,
+      postcssOptions: ctx.postcssOptions,
       uniAppX: false,
       platform: ctx.platform,
     }))
     expect(styleOptions).not.toHaveProperty('escapeMap')
-    expect(styleOptions).not.toHaveProperty('postcssOptions')
     expect(styleOptions).not.toHaveProperty('injectAdditionalCssVarScope')
     expect(styleOptions).not.toHaveProperty('majorVersion')
   })

--- a/packages/weapp-tailwindcss/test/tailwindcss/__snapshots__/v4-package-css.test.ts.snap
+++ b/packages/weapp-tailwindcss/test/tailwindcss/__snapshots__/v4-package-css.test.ts.snap
@@ -10,12 +10,12 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable index.css outp
     "hover:bg-red-500",
   ],
   "css": "page,.tw-root,wx-root-portal-content,:host {
-  --color-red-500: #fb2c36;
-  --color-blue-500: #2b7fff;
   --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+  --color-red-500: rgb(251, 44, 54);
+  --color-blue-500: rgb(50, 128, 255);
   --spacing: 0.25rem;
   --default-font-family: var(--font-sans);
   --default-mono-font-family: var(--font-mono);
@@ -55,12 +55,12 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable index.css outp
     "hover:bg-red-500",
   ],
   "css": "page,.tw-root,wx-root-portal-content,:host {
-  --color-red-500: #fb2c36;
-  --color-blue-500: #2b7fff;
   --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+  --color-red-500: rgb(251, 44, 54);
+  --color-blue-500: rgb(50, 128, 255);
   --spacing: 0.25rem;
   --default-font-family: var(--font-sans);
   --default-mono-font-family: var(--font-mono);
@@ -294,10 +294,19 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable preflight.css 
   "classSet": [
     "bg-red-500",
     "text-blue-500",
+    "p-4",
     "w-[100px]",
     "hover:bg-red-500",
   ],
-  "css": "view,text,::after,::before {
+  "css": "page,.tw-root,wx-root-portal-content,:host {
+  --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  --default-font-family: var(--font-sans);
+  --default-mono-font-family: var(--font-mono);
+}
+view,text,::after,::before {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -315,10 +324,19 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable preflight.css 
   "classSet": [
     "bg-red-500",
     "text-blue-500",
+    "p-4",
     "w-[100px]",
     "hover:bg-red-500",
   ],
-  "css": "view,text,::after,::before {
+  "css": "page,.tw-root,wx-root-portal-content,:host {
+  --font-sans: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  --default-font-family: var(--font-sans);
+  --default-mono-font-family: var(--font-mono);
+}
+view,text,::after,::before {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -546,6 +564,7 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable utilities.css 
   "classSet": [
     "bg-red-500",
     "text-blue-500",
+    "p-4",
     "w-[100px]",
     "hover:bg-red-500",
   ],
@@ -553,14 +572,18 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable utilities.css 
   --tw-content: "";
 }
 page,.tw-root,wx-root-portal-content,:host {
-  --color-red-500: #fb2c36;
-  --color-blue-500: #2b7fff;
+  --color-red-500: rgb(251, 44, 54);
+  --color-blue-500: rgb(50, 128, 255);
+  --spacing: 0.25rem;
 }
 .w-_b100px_B {
   width: 100px;
 }
 .bg-red-500 {
   background-color: var(--color-red-500);
+}
+.p-4 {
+  padding: calc(var(--spacing) * 4);
 }
 .text-blue-500 {
   color: var(--color-blue-500);
@@ -576,6 +599,7 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable utilities.css 
   "classSet": [
     "bg-red-500",
     "text-blue-500",
+    "p-4",
     "w-[100px]",
     "hover:bg-red-500",
   ],
@@ -583,14 +607,18 @@ exports[`Tailwind v4 package CSS entry outputs > generates stable utilities.css 
   --tw-content: "";
 }
 page,.tw-root,wx-root-portal-content,:host {
-  --color-red-500: #fb2c36;
-  --color-blue-500: #2b7fff;
+  --color-red-500: rgb(251, 44, 54);
+  --color-blue-500: rgb(50, 128, 255);
+  --spacing: 0.25rem;
 }
 .w-_b100px_B {
   width: 100px;
 }
 .bg-red-500 {
   background-color: var(--color-red-500);
+}
+.p-4 {
+  padding: calc(var(--spacing) * 4);
 }
 .text-blue-500 {
   color: var(--color-blue-500);

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4-engine.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4-engine.test.ts
@@ -1,10 +1,10 @@
+import type { TailwindCssRuntimeOptions } from '@/tailwindcss/runtime-types'
 import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, vi } from 'vitest'
 import { getCompilerContext } from '@/context'
-import type { TailwindCssRuntimeOptions } from '@/tailwindcss/runtime-types'
 import { clearTailwindV4IncrementalGenerateCacheForTest, createTailwindV4Engine, getTailwindV4IncrementalGenerateCacheStatsForTest, resolveTailwindV4Source, resolveTailwindV4SourceOptionsFromRuntime, transformTailwindV4CssToWeapp } from '@/tailwindcss/v4-engine'
 import { resolveTailwindV4SourceFromRuntimeOptions } from '@/tailwindcss/v4-engine/source'
 
@@ -872,8 +872,8 @@ describe('tailwindcss v4 engine', () => {
       candidates: ['bg-blue-500', 'text-red-500'],
     })
 
-    expect(result.css).toContain('--color-blue-500: #2b7fff')
-    expect(result.css).toContain('--color-red-500: #fb2c36')
+    expect(result.css).toContain('--color-blue-500: rgb(50, 128, 255)')
+    expect(result.css).toContain('--color-red-500: rgb(251, 44, 54)')
     expect(result.css).toContain('--font-sans:')
     expect(result.css).toContain('--default-font-family: var(--font-sans)')
     expect(result.css).toContain('background-color: var(--color-blue-500)')

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4-package-css.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4-package-css.test.ts
@@ -1,9 +1,10 @@
 import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import { createTailwindV4Engine, resolveTailwindV4Source } from '@/tailwindcss/v4-engine'
 
-const repoRoot = path.resolve(process.cwd(), '../..')
-const tailwindcssPackageRoot = path.join(repoRoot, 'demo/mpx-tailwindcss-v4/node_modules/tailwindcss')
+const require = createRequire(import.meta.url)
+const tailwindcssPackageRoot = path.dirname(require.resolve('tailwindcss4/package.json'))
 
 const PACKAGE_CSS_ENTRIES = [
   'index.css',
@@ -117,8 +118,8 @@ describe('Tailwind v4 package CSS entry outputs', () => {
     const weappCss = compactCss(weappResult.css)
     const webCss = compactCss(webResult.css)
 
-    expect(weappResult.css).toContain('--color-red-500: #fb2c36')
-    expect(weappResult.css).toContain('--color-blue-500: #2b7fff')
+    expect(weappResult.css).toContain('--color-red-500: rgb(251, 44, 54)')
+    expect(weappResult.css).toContain('--color-blue-500: rgb(50, 128, 255)')
     expect(weappResult.css).toContain('.w-_b100px_B')
     expect(weappResult.css).toContain('box-sizing: border-box')
     expect(weappResult.css).not.toContain('@layer')

--- a/packages/weapp-tailwindcss/test/v5/tailwind-v4-upgrade-generator-coverage.test.ts
+++ b/packages/weapp-tailwindcss/test/v5/tailwind-v4-upgrade-generator-coverage.test.ts
@@ -2,8 +2,8 @@ import { mkdir, mkdtemp, symlink } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import postcss from 'postcss'
 import tailwindcssPostcss from '@tailwindcss/postcss'
+import postcss from 'postcss'
 import weappTailwindcss from '@/postcss'
 
 const require = createRequire(import.meta.url)
@@ -47,28 +47,28 @@ const UPGRADE_DEFAULTS_CANDIDATES = [
 const UPGRADE_DEFAULTS_SOURCE_CSS = `${UPGRADE_DEFAULTS_CSS}@source inline("${UPGRADE_DEFAULTS_CANDIDATES.join(' ')}");`
 
 const TAILWIND_V4_COLOR_CASES = [
-  ['bg-slate-50', '--color-slate-50: #f8fafc'],
-  ['bg-gray-950', '--color-gray-950: #030712'],
-  ['bg-zinc-500', '--color-zinc-500: #71717b'],
-  ['bg-neutral-700', '--color-neutral-700: #404040'],
-  ['bg-stone-400', '--color-stone-400: #a6a09b'],
-  ['bg-red-500', '--color-red-500: #fb2c36'],
-  ['bg-orange-600', '--color-orange-600: #f54900'],
-  ['bg-amber-300', '--color-amber-300: #ffd230'],
-  ['bg-yellow-800', '--color-yellow-800: #894b00'],
-  ['bg-lime-200', '--color-lime-200: #d8f999'],
-  ['bg-green-900', '--color-green-900: #0d542b'],
-  ['bg-emerald-100', '--color-emerald-100: #d0fae5'],
-  ['bg-teal-950', '--color-teal-950: #022f2e'],
-  ['bg-cyan-400', '--color-cyan-400: #00d3f2'],
-  ['bg-sky-700', '--color-sky-700: #0069a8'],
-  ['bg-blue-500', '--color-blue-500: #2b7fff'],
-  ['bg-indigo-300', '--color-indigo-300: #a3b3ff'],
-  ['bg-violet-800', '--color-violet-800: #5d0ec0'],
-  ['bg-purple-600', '--color-purple-600: #9810fa'],
-  ['bg-fuchsia-200', '--color-fuchsia-200: #f6cfff'],
-  ['bg-pink-900', '--color-pink-900: #861043'],
-  ['bg-rose-50', '--color-rose-50: #fff1f2'],
+  ['bg-slate-50', '--color-slate-50: rgb(248, 250, 252)'],
+  ['bg-gray-950', '--color-gray-950: rgb(3, 7, 18)'],
+  ['bg-zinc-500', '--color-zinc-500: rgb(113, 113, 123)'],
+  ['bg-neutral-700', '--color-neutral-700: rgb(64, 64, 64)'],
+  ['bg-stone-400', '--color-stone-400: rgb(166, 160, 155)'],
+  ['bg-red-500', '--color-red-500: rgb(251, 44, 54)'],
+  ['bg-orange-600', '--color-orange-600: rgb(236, 86, 0)'],
+  ['bg-amber-300', '--color-amber-300: rgb(255, 210, 55)'],
+  ['bg-yellow-800', '--color-yellow-800: rgb(135, 76, 0)'],
+  ['bg-lime-200', '--color-lime-200: rgb(216, 249, 153)'],
+  ['bg-green-900', '--color-green-900: rgb(13, 84, 43)'],
+  ['bg-emerald-100', '--color-emerald-100: rgb(208, 250, 229)'],
+  ['bg-teal-950', '--color-teal-950: rgb(2, 47, 46)'],
+  ['bg-cyan-400', '--color-cyan-400: rgb(0, 209, 236)'],
+  ['bg-sky-700', '--color-sky-700: rgb(0, 105, 162)'],
+  ['bg-blue-500', '--color-blue-500: rgb(50, 128, 255)'],
+  ['bg-indigo-300', '--color-indigo-300: rgb(164, 180, 255)'],
+  ['bg-violet-800', '--color-violet-800: rgb(93, 14, 192)'],
+  ['bg-purple-600', '--color-purple-600: rgb(152, 16, 250)'],
+  ['bg-fuchsia-200', '--color-fuchsia-200: rgb(246, 207, 255)'],
+  ['bg-pink-900', '--color-pink-900: rgb(134, 16, 67)'],
+  ['bg-rose-50', '--color-rose-50: rgb(255, 241, 242)'],
 ] as const
 
 function normalizeCss(css: string) {
@@ -181,8 +181,8 @@ describe('v5 Tailwind CSS v4 upgrade generator coverage', () => {
     expect(result.css).toContain('var(--tw-ring-color, currentcolor)')
     expect(result.css).toContain('outline-width: 1px')
     expect(result.css).toContain('--tw-shadow: 0 1px 2px 0 var(--tw-shadow-color, rgba(0, 0, 0, 0.05))')
-    expect(result.css).toContain('--color-red-500: #fb2c36')
-    expect(result.css).toContain('--color-slate-700: #314158')
+    expect(result.css).toContain('--color-red-500: rgb(251, 44, 54)')
+    expect(result.css).toContain('--color-slate-700: rgb(49, 65, 88)')
     expect(result.css).toContain('background-color: var(--color-red-500)')
     expect(result.css).toContain('color: var(--color-slate-700)')
     expect(result.css).toContain('border-color: var(--color-gray-200)')
@@ -266,11 +266,11 @@ describe('v5 Tailwind CSS v4 upgrade generator coverage', () => {
     expect(weappResult.css).toContain('color: rgba(255, 255, 255, 0.1)')
     expect(weappResult.css).not.toContain('color-mix(in oklab, var(--color-white) 10%, transparent)')
     expect(weappResult.css).toContain('color: var(--color-blue-600)')
-    expect(weappResult.css).toContain('background-color: rgba(0, 166, 244, 0.5)')
+    expect(weappResult.css).toContain('background-color: rgba(0, 165, 234, 0.5)')
     expect(weappResult.css).toContain('color: var(--color-blue-600)')
-    expect(weappResult.css).toContain('background-color: rgba(0, 166, 244, 0.75)')
-    expect(weappResult.css).toContain('background-color: rgba(0, 166, 244, 0.33)')
-    expect(weappResult.css).toContain('background-color: rgba(0, 166, 244, var(--my-alpha-value))')
+    expect(weappResult.css).toContain('background-color: rgba(0, 165, 234, 0.75)')
+    expect(weappResult.css).toContain('background-color: rgba(0, 165, 234, 0.33)')
+    expect(weappResult.css).toContain('background-color: rgba(0, 165, 234, var(--my-alpha-value))')
     expect(weappResult.css).not.toContain('color-mix')
     expect(weappResult.css).not.toContain('oklab')
     expect(weappResult.css).toContain('border-color: var(--color-pink-400)')
@@ -281,8 +281,8 @@ describe('v5 Tailwind CSS v4 upgrade generator coverage', () => {
     expect(weappResult.css).toContain('caret-color: var(--color-rose-500)')
     expect(weappResult.css).toContain('fill: var(--color-bermuda)')
     expect(weappResult.css).toContain('stroke: var(--color-cyan-400)')
-    expect(weappResult.css).toContain('--tw-shadow-color: rgba(43, 127, 255, 0.5)')
-    expect(weappResult.css).toContain('--tw-inset-shadow-color: #615fff')
+    expect(weappResult.css).toContain('--tw-shadow-color: rgba(50, 128, 255, 0.5)')
+    expect(weappResult.css).toContain('--tw-inset-shadow-color: rgb(98, 96, 255)')
     expect(weappResult.css).toContain('--tw-ring-color: var(--color-fuchsia-500)')
     expect(weappResult.css).toContain('color: var(--color-zinc-500)')
     expect(weappResult.css).toContain('color: var(--brand-color)')
@@ -679,8 +679,8 @@ describe('v5 Tailwind CSS v4 upgrade generator coverage', () => {
     expect(result.css).toContain('calc(1px + var(--tw-ring-offset-width))')
     expect(result.css).toContain('var(--tw-ring-color, currentcolor)')
     expect(result.css).toContain('outline-width: 1px')
-    expect(result.css).toContain('--color-red-500: #fb2c36')
-    expect(result.css).toContain('--color-slate-700: #314158')
+    expect(result.css).toContain('--color-red-500: rgb(251, 44, 54)')
+    expect(result.css).toContain('--color-slate-700: rgb(49, 65, 88)')
     expect(result.css).toContain('--tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgba(0, 0, 0, 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgba(0, 0, 0, 0.1))')
     expect(result.css).toContain('border-radius: var(--radius-sm)')
     expect(result.css).toContain('--tw-blur: blur(var(--blur-sm))')
@@ -702,7 +702,7 @@ describe('v5 Tailwind CSS v4 upgrade generator coverage', () => {
     })
 
     expect(result.css).toContain('--color-red-500: #123456')
-    expect(result.css).toContain('--color-blue-500: #2b7fff')
+    expect(result.css).toContain('--color-blue-500: rgb(50, 128, 255)')
     expect(result.css).toContain('background-color: var(--color-red-500)')
     expect(result.css).toContain('color: var(--color-blue-500)')
     expect(result.css).not.toContain('oklch(')

--- a/packages/weapp-tailwindcss/test/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/vite.test.ts
@@ -1,5 +1,5 @@
-import { createRequire } from 'node:module'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import tailwindcss from '@tailwindcss/postcss'
 import twv from '@tailwindcss/vite'
 import { isCI } from 'ci-info'
@@ -17,6 +17,21 @@ function normalizeTailwindcssBanner(content: string) {
     tailwindcssBannerPattern,
     '/*! tailwindcss v<version> | MIT License | https://tailwindcss.com */',
   )
+}
+
+async function readBuiltStyle(root: string) {
+  const dist = path.resolve(root, 'dist')
+  const entries = await fs.readdir(dist, { withFileTypes: true })
+  const styleEntry = entries.find((entry) => {
+    if (!entry.isFile() || path.parse(entry.name).name !== 'index') {
+      return false
+    }
+    return !['.html', '.js', '.map'].includes(path.extname(entry.name))
+  })
+  if (!styleEntry) {
+    throw new Error(`Vite build did not emit an index style asset: ${entries.map(entry => entry.name).join(', ')}`)
+  }
+  return fs.readFile(path.join(dist, styleEntry.name), 'utf-8')
 }
 
 const require = createRequire(import.meta.url)
@@ -80,7 +95,7 @@ describe.skipIf(isCI)('vite', () => {
         },
       })
 
-      const css = await fs.readFile(path.resolve(root, 'dist/index.wxss'), 'utf-8')
+      const css = await readBuiltStyle(root)
       expect(css).toContain('.w-_b100px_B')
       expect(css).toContain('width: 100px')
       expect(css).toContain('.text-_b_h123456_B')
@@ -123,7 +138,7 @@ describe.skipIf(isCI)('vite', () => {
     })
     expect(
       normalizeTailwindcssBanner(
-        await fs.readFile(path.resolve(fixturesRootPath, 'v4-vite-plugin/dist/index.wxss'), 'utf-8'),
+        await readBuiltStyle(root),
       ),
     ).toMatchSnapshot('css')
     expect(await fs.readFile(path.resolve(fixturesRootPath, 'v4-vite-plugin/dist/index.js'), 'utf-8')).toMatchSnapshot('js')
@@ -163,7 +178,7 @@ describe.skipIf(isCI)('vite', () => {
     })
     expect(
       normalizeTailwindcssBanner(
-        await fs.readFile(path.resolve(fixturesRootPath, 'v4-vite-postcss/dist/index.wxss'), 'utf-8'),
+        await readBuiltStyle(root),
       ),
     ).toMatchSnapshot('css')
     expect(await fs.readFile(path.resolve(fixturesRootPath, 'v4-vite-postcss/dist/index.js'), 'utf-8')).toMatchSnapshot('js')
@@ -215,7 +230,7 @@ describe.skipIf(isCI)('vite', () => {
         },
       })
 
-      const css = await fs.readFile(path.resolve(root, 'dist/index.wxss'), 'utf-8')
+      const css = await readBuiltStyle(root)
       expect(css).toContain('.bg-clip-text')
       expect(css).toContain('-webkit-background-clip: text')
       expect(css).toContain('background-clip: text')

--- a/packages/weapp-tailwindcss/test/vitest/__snapshots__/vite.test.ts.snap
+++ b/packages/weapp-tailwindcss/test/vitest/__snapshots__/vite.test.ts.snap
@@ -65,8 +65,8 @@ text,
 page,
 .tw-root,
 wx-root-portal-content {
-  --color-red-300: #ffa2a2;
-  --color-yellow-300: #ffdf20;
+  --color-red-300: rgb(255, 163, 164);
+  --color-yellow-300: rgb(255, 224, 46);
 }
 .flex {
   display: flex;
@@ -99,7 +99,7 @@ wx-root-portal-content {
   background-color: red;
 }
 .bg-yellow-300_f30 {
-  background-color: rgba(255, 223, 32, 0.3);
+  background-color: rgba(255, 224, 46, 0.3);
 }
 .bg-_burl_p_ahttps_c_f_fxxx_dcom_fxx_dwebp_a_P_B {
   background-image: url("https://xxx.com/xx.webp");
@@ -108,7 +108,7 @@ wx-root-portal-content {
   background-image: url("https://yyy.com/xx.webp");
 }
 .text-red-300_f30 {
-  color: rgba(255, 162, 162, 0.3);
+  color: rgba(255, 163, 164, 0.3);
 }
 "
 `;
@@ -165,8 +165,8 @@ text,
 page,
 .tw-root,
 wx-root-portal-content {
-  --color-red-300: #ffa2a2;
-  --color-yellow-300: #ffdf20;
+  --color-red-300: rgb(255, 163, 164);
+  --color-yellow-300: rgb(255, 224, 46);
 }
 .flex {
   display: flex;
@@ -199,7 +199,7 @@ wx-root-portal-content {
   background-color: red;
 }
 .bg-yellow-300_f30 {
-  background-color: rgba(255, 223, 32, 0.3);
+  background-color: rgba(255, 224, 46, 0.3);
 }
 .bg-_burl_p_ahttps_c_f_fxxx_dcom_fxx_dwebp_a_P_B {
   background-image: url("https://xxx.com/xx.webp");
@@ -208,7 +208,7 @@ wx-root-portal-content {
   background-image: url("https://yyy.com/xx.webp");
 }
 .text-red-300_f30 {
-  color: rgba(255, 162, 162, 0.3);
+  color: rgba(255, 163, 164, 0.3);
 }
 "
 `;
@@ -265,8 +265,8 @@ text,
 page,
 .tw-root,
 wx-root-portal-content {
-  --color-red-300: #ffa2a2;
-  --color-yellow-300: #ffdf20;
+  --color-red-300: rgb(255, 163, 164);
+  --color-yellow-300: rgb(255, 224, 46);
 }
 .flex {
   display: flex;
@@ -299,7 +299,7 @@ wx-root-portal-content {
   background-color: red;
 }
 .bg-yellow-300_f30 {
-  background-color: rgba(255, 223, 32, 0.3);
+  background-color: rgba(255, 224, 46, 0.3);
 }
 .bg-_burl_p_ahttps_c_f_fxxx_dcom_fxx_dwebp_a_P_B {
   background-image: url("https://xxx.com/xx.webp");
@@ -308,7 +308,7 @@ wx-root-portal-content {
   background-image: url("https://yyy.com/xx.webp");
 }
 .text-red-300_f30 {
-  color: rgba(255, 162, 162, 0.3);
+  color: rgba(255, 163, 164, 0.3);
 }
 "
 `;
@@ -365,8 +365,8 @@ text,
 page,
 .tw-root,
 wx-root-portal-content {
-  --color-red-300: #ffa2a2;
-  --color-yellow-300: #ffdf20;
+  --color-red-300: rgb(255, 163, 164);
+  --color-yellow-300: rgb(255, 224, 46);
 }
 .flex {
   display: flex;
@@ -399,7 +399,7 @@ wx-root-portal-content {
   background-color: red;
 }
 .bg-yellow-300_f30 {
-  background-color: rgba(255, 223, 32, 0.3);
+  background-color: rgba(255, 224, 46, 0.3);
 }
 .bg-_burl_p_ahttps_c_f_fxxx_dcom_fxx_dwebp_a_P_B {
   background-image: url("https://xxx.com/xx.webp");
@@ -408,7 +408,7 @@ wx-root-portal-content {
   background-image: url("https://yyy.com/xx.webp");
 }
 .text-red-300_f30 {
-  color: rgba(255, 162, 162, 0.3);
+  color: rgba(255, 163, 164, 0.3);
 }
 "
 `;


### PR DESCRIPTION
## 变更说明

- 修复 Tailwind CSS v4 现代颜色配合动态透明度变量时的 RGB 通道转换，避免将 OKLCH 通道直接当作 RGB 输出。
- 移除 Vite 测试对固定 `index.wxss` 文件名的假设，改为读取构建实际生成的样式资源。
- 修正 Gulp generator mock、PostCSS options 断言以及根级测试依赖 `process.cwd()` 推导 demo 路径的问题。
- 更新 Tailwind CSS 4.3.2 对应的颜色断言和快照。
- 添加 `@weapp-tailwindcss/postcss` 与 `weapp-tailwindcss` 的中文 patch changeset。

## 验证

- `pnpm test:core`
  - 252 个测试文件通过，3 个跳过
  - 2757 个测试通过，29 个跳过
  - Statements 94.58%，Branches 89.1%，Functions 97.95%
- `pnpm --filter @weapp-tailwindcss/postcss test`
  - 56 个测试文件、593 个测试通过
- `pnpm e2e:issues-977-978`
  - 8/8 通过
- `pnpm exec vitest run --bail=1 -c ./e2e/vitest.e2e.config.ts e2e/issue-984-multi-source.test.ts`
  - 1/1 通过
- 定向 ESLint、PostCSS build、核心类型构建、`git diff --check` 与 `changeset status` 均通过。

## 关联 Issue

- #977
- #978
- #984

## 发布说明

- 需要 changeset：动态颜色透明度转换属于用户可见 bug fix。
- 不需要联动 `create-weapp-vite`：未修改 `weapp-vite`、`wevu` 或模板。