### PR TITLE
ci(watch): split Windows demo shards

### DIFF
--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -276,34 +276,74 @@ jobs:
             watch_command_timeout_ms: '1500000'
           - os: windows-latest
             runner_label: windows
-            watch_case: demo-core
+            watch_case: gulp-tailwindcss-v4
             round_profile: default
             watch_save_snapshots: '1'
-            timeout_minutes: 95
+            timeout_minutes: 60
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '5100000'
+            watch_command_timeout_ms: '3000000'
           - os: windows-latest
             runner_label: windows
-            watch_case: demo-taro-react
+            watch_case: weapp-vite-tailwindcss-v4
             round_profile: default
             watch_save_snapshots: '1'
-            timeout_minutes: 90
+            timeout_minutes: 60
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '4800000'
+            watch_command_timeout_ms: '3000000'
           - os: windows-latest
             runner_label: windows
-            watch_case: demo-taro-vue3
+            watch_case: mpx-tailwindcss-v4
             round_profile: default
             watch_save_snapshots: '1'
-            timeout_minutes: 90
+            timeout_minutes: 60
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '4800000'
+            watch_command_timeout_ms: '3000000'
+          - os: windows-latest
+            runner_label: windows
+            watch_case: taro-vite-react-tailwindcss-v4
+            round_profile: default
+            watch_save_snapshots: '1'
+            timeout_minutes: 60
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '3000000'
+          - os: windows-latest
+            runner_label: windows
+            watch_case: taro-webpack-react-tailwindcss-v4
+            round_profile: default
+            watch_save_snapshots: '1'
+            timeout_minutes: 60
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '3000000'
+          - os: windows-latest
+            runner_label: windows
+            watch_case: taro-vite-vue3-tailwindcss-v4
+            round_profile: default
+            watch_save_snapshots: '1'
+            timeout_minutes: 60
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '3000000'
+          - os: windows-latest
+            runner_label: windows
+            watch_case: taro-webpack-vue3-tailwindcss-v4
+            round_profile: default
+            watch_save_snapshots: '1'
+            timeout_minutes: 60
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '3000000'
           - os: windows-latest
             runner_label: windows
             watch_case: demo-uni

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -619,6 +619,15 @@ describe('e2e watch workflow', () => {
     const rows: Array<Record<string, unknown>> = workflow.jobs['pr-quick-gate'].strategy.matrix.include
     const cases = matrixCases(rows)
     const demoShards = ['demo-core', 'demo-taro-react', 'demo-taro-vue3', 'demo-uni']
+    const windowsSplitDemoCases = [
+      'gulp-tailwindcss-v4',
+      'weapp-vite-tailwindcss-v4',
+      'mpx-tailwindcss-v4',
+      'taro-vite-react-tailwindcss-v4',
+      'taro-webpack-react-tailwindcss-v4',
+      'taro-vite-vue3-tailwindcss-v4',
+      'taro-webpack-vue3-tailwindcss-v4',
+    ]
     const completeMiniProgramCases = [
       'taro-vite-react-tailwindcss-v4:alipay',
       'taro-vite-react-tailwindcss-v4:tt',
@@ -631,10 +640,14 @@ describe('e2e watch workflow', () => {
     ]
 
     expect(workflow.jobs['pr-quick-gate'].strategy['fail-fast']).toBe(false)
-    for (const runner of ['macos', 'linux', 'windows']) {
+    for (const runner of ['macos', 'linux']) {
       for (const watchCase of demoShards) {
         expect(cases, `${runner} should cover ${watchCase}`).toContain(`${runner}:22:${watchCase}:default`)
       }
+    }
+    expect(cases).toContain('windows:22:demo-uni:default')
+    for (const watchCase of windowsSplitDemoCases) {
+      expect(cases, `windows should split ${watchCase}`).toContain(`windows:22:${watchCase}:default`)
     }
     for (const runner of ['linux', 'windows']) {
       for (const watchCase of completeMiniProgramCases) {
@@ -647,8 +660,10 @@ describe('e2e watch workflow', () => {
     expect(macosPlatformCases).toEqual(['uni-app-vite-tailwindcss-v4:mp-weixin'])
     expect(rows.filter(row => row.runner_label === 'macos')).toHaveLength(9)
     expect(rows.filter(row => row.runner_label === 'linux')).toHaveLength(12)
-    expect(rows.filter(row => row.runner_label === 'windows')).toHaveLength(13)
-    expect(cases.some(item => item.includes(':weapp-vite-tailwindcss-'))).toBe(false)
+    expect(rows.filter(row => row.runner_label === 'windows')).toHaveLength(17)
+    expect(cases.filter(item => item.includes(':weapp-vite-tailwindcss-'))).toEqual([
+      'windows:22:weapp-vite-tailwindcss-v4:default',
+    ])
     expect(cases).not.toContain('macos:22:taro-webpack-react-tailwindcss-v4:issue33')
     expect(rows.some(row => String(row.watch_case).includes('hbuilderx') || String(row.watch_case).includes('uni-app-x'))).toBe(false)
     expect(workflow.jobs['root-style-import-shell-hmr']['runs-on']).toBe('ubuntu-latest')
@@ -780,6 +795,22 @@ describe('e2e watch workflow', () => {
       watch_max_plugin_process_ms: pluginBudget,
       watch_command_timeout_ms: '2700000',
     }))
+    const windowsSplitDemoPrBudgets = [
+      'gulp-tailwindcss-v4',
+      'weapp-vite-tailwindcss-v4',
+      'mpx-tailwindcss-v4',
+      'taro-vite-react-tailwindcss-v4',
+      'taro-webpack-react-tailwindcss-v4',
+      'taro-vite-vue3-tailwindcss-v4',
+      'taro-webpack-vue3-tailwindcss-v4',
+    ].map(watchCase => ({
+      watch_case: watchCase,
+      round_profile: 'default',
+      timeout_minutes: 60,
+      watch_timeout_ms: '420000',
+      watch_max_plugin_process_ms: '60000',
+      watch_command_timeout_ms: '3000000',
+    }))
     const slowNightlyBudgets = [
       {
         os: 'macos-latest',
@@ -853,7 +884,6 @@ describe('e2e watch workflow', () => {
     for (const runner of [
       { os: 'macos-latest', runner_label: 'macos' },
       { os: 'ubuntu-latest', runner_label: 'linux' },
-      { os: 'windows-latest', runner_label: 'windows' },
     ]) {
       expect(prRows).toContainEqual(expect.objectContaining({
         ...runner,
@@ -865,6 +895,13 @@ describe('e2e watch workflow', () => {
           ...budget,
         }))
       }
+    }
+    for (const budget of windowsSplitDemoPrBudgets) {
+      expect(prRows).toContainEqual(expect.objectContaining({
+        os: 'windows-latest',
+        runner_label: 'windows',
+        ...budget,
+      }))
     }
     for (const runner of [
       { os: 'ubuntu-latest', runner_label: 'linux' },

--- a/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
@@ -3142,7 +3142,14 @@ describe('watch-hmr regression cases', () => {
       expect(matrixEntries).toContainEqual(expect.objectContaining(entry))
     }
     expect(String(workflowSource)).toContain('${{ matrix.artifact_case || matrix.watch_case }}')
-    expect(prMatrixEntries.some(entry => String(entry.watch_case).startsWith('weapp-vite-tailwindcss-'))).toBe(false)
+    expect(prMatrixEntries.filter(entry => String(entry.watch_case).startsWith('weapp-vite-tailwindcss-'))).toEqual([
+      expect.objectContaining({
+        os: 'windows-latest',
+        runner_label: 'windows',
+        watch_case: 'weapp-vite-tailwindcss-v4',
+        round_profile: 'default',
+      }),
+    ])
   })
 
   it('keeps watch plugin processing budget strict while retry settings stay explicit', async () => {


### PR DESCRIPTION
## 背景

PR #992 扩展了 macOS、Ubuntu、Windows 的 demo watch 覆盖。完整矩阵证明 Windows runner 并发充足，但 `demo-core`、`demo-taro-react`、`demo-taro-vue3` 在单 job 内串行执行多个项目，分别超过原有 40/60/80 分钟内部预算。

## 调整

- macOS 与 Ubuntu 保留现有 shard；macOS 继续只跑微信小程序显式平台。
- Windows 将 3 个聚合 shard 拆成 7 个具体 demo job：gulp、weapp-vite、mpx、Taro Vite/Webpack React、Taro Vite/Webpack Vue3。
- Windows 仍覆盖全部 20 个自动化 demo case，job 数从 13 增至 17，利用 Windows 并发降低串行墙钟。
- 契约测试固定具体 case、runner 数量和跨平台完整覆盖。

## 验证

- `pnpm --filter weapp-tailwindcss exec vitest run test/ci/workflows.test.ts test/watch-hmr-coverage-matrix.unit.test.ts`：51 passed
- `pnpm exec vitest run -c ./e2e/vitest.e2e.config.ts e2e/e2e-matrix.test.ts`：33 passed
- `pnpm --filter weapp-tailwindcss lint`
- `git diff --check origin/main...HEAD`

本 PR 仅调整 CI 编排，不需要 changeset。