### PR TITLE
fix: 清理小程序最终产物中的空 at-rule

### DIFF
--- a/.changeset/clean-empty-mini-program-at-rules.md
+++ b/.changeset/clean-empty-mini-program-at-rules.md
@@ -1,0 +1,6 @@
+---
+"@weapp-tailwindcss/postcss": patch
+"weapp-tailwindcss": patch
+---
+
+修复小程序最终样式产物在条件编译、缓存复用与嵌套规则清理后残留空 `@media`、`@supports` 等块级 at-rule，避免 WXSS 编译报错，同时保留开发态增量构建所需的条件规则占位容器。

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -78,6 +78,7 @@ jobs:
             watch_max_plugin_process_ms: '60000'
             watch_command_timeout_ms: '1500000'
           # Taro 小程序继续按主包与分包拆分，完整轮次并行执行，避免单 job 串行超过 30 分钟。
+          # Webpack 主包需要额外覆盖 report 写入与子进程退出，命令预算为 25 分钟，job 仍受 30 分钟硬上限约束。
           - os: macos-latest
             runner_label: macos
             watch_case: taro-vite-react-tailwindcss-v4
@@ -117,7 +118,7 @@ jobs:
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1200000'
+            watch_command_timeout_ms: '1500000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-webpack-react-tailwindcss-v4
@@ -171,7 +172,7 @@ jobs:
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1200000'
+            watch_command_timeout_ms: '1500000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-webpack-vue3-tailwindcss-v4
@@ -291,7 +292,7 @@ jobs:
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1200000'
+            watch_command_timeout_ms: '1500000'
           - os: ubuntu-latest
             runner_label: linux
             watch_case: taro-webpack-react-tailwindcss-v4
@@ -345,7 +346,7 @@ jobs:
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1200000'
+            watch_command_timeout_ms: '1500000'
           - os: ubuntu-latest
             runner_label: linux
             watch_case: taro-webpack-vue3-tailwindcss-v4

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -77,53 +77,115 @@ jobs:
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
             watch_command_timeout_ms: '1500000'
-          # Taro 项目按单项目、小程序与 Web 拆分，保留完整变更轮次且避免串行 job 超过 30 分钟。
+          # Taro 小程序继续按主包与分包拆分，完整轮次并行执行，避免单 job 串行超过 30 分钟。
           - os: macos-latest
             runner_label: macos
             watch_case: taro-vite-react-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: macos-latest
+            runner_label: macos
+            watch_case: taro-vite-react-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-webpack-react-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '600000'
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: macos-latest
+            runner_label: macos
+            watch_case: taro-webpack-react-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '600000'
+            taro_dev_ready_timeout_ms: '900000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-vite-vue3-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: macos-latest
+            runner_label: macos
+            watch_case: taro-vite-vue3-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: macos-latest
             runner_label: macos
             watch_case: taro-webpack-vue3-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '600000'
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: macos-latest
+            runner_label: macos
+            watch_case: taro-webpack-vue3-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '600000'
+            taro_dev_ready_timeout_ms: '900000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: macos-latest
             runner_label: macos
             watch_case: demo-uni
@@ -193,49 +255,111 @@ jobs:
           - os: ubuntu-latest
             runner_label: linux
             watch_case: taro-vite-react-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: ubuntu-latest
+            runner_label: linux
+            watch_case: taro-vite-react-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: ubuntu-latest
             runner_label: linux
             watch_case: taro-webpack-react-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '600000'
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: ubuntu-latest
+            runner_label: linux
+            watch_case: taro-webpack-react-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '600000'
+            taro_dev_ready_timeout_ms: '900000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: ubuntu-latest
             runner_label: linux
             watch_case: taro-vite-vue3-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '420000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: ubuntu-latest
+            runner_label: linux
+            watch_case: taro-vite-vue3-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '420000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: ubuntu-latest
             runner_label: linux
             watch_case: taro-webpack-vue3-tailwindcss-v4
-            round_profile: mini-program
+            round_profile: mini-program-main
             watch_save_snapshots: '1'
             watch_mini_program_only: '1'
+            watch_mini_program_scope: main-package
+            watch_max_attempts: '1'
             timeout_minutes: 30
             watch_timeout_ms: '600000'
             taro_dev_ready_timeout_ms: '900000'
             watch_poll_ms: '40'
             watch_max_plugin_process_ms: '60000'
-            watch_command_timeout_ms: '1500000'
+            watch_command_timeout_ms: '1200000'
+          - os: ubuntu-latest
+            runner_label: linux
+            watch_case: taro-webpack-vue3-tailwindcss-v4
+            round_profile: mini-program-subpackages
+            watch_save_snapshots: '1'
+            watch_mini_program_only: '1'
+            watch_mini_program_scope: subpackages
+            watch_max_attempts: '1'
+            timeout_minutes: 30
+            watch_timeout_ms: '600000'
+            taro_dev_ready_timeout_ms: '900000'
+            watch_poll_ms: '40'
+            watch_max_plugin_process_ms: '60000'
+            watch_command_timeout_ms: '1200000'
           - os: ubuntu-latest
             runner_label: linux
             watch_case: demo-uni
@@ -685,6 +809,7 @@ jobs:
           E2E_WATCH_ROUND_PROFILE: ${{ matrix.round_profile }}
           E2E_WATCH_WEB_ONLY: ${{ matrix.watch_web_only || '0' }}
           E2E_WATCH_MINI_PROGRAM_ONLY: ${{ matrix.watch_mini_program_only || '0' }}
+          E2E_WATCH_MINI_PROGRAM_SCOPE: ${{ matrix.watch_mini_program_scope || '' }}
           E2E_WATCH_MAIN_STYLE_ONLY: ${{ matrix.watch_main_style_only || '0' }}
           E2E_WATCH_MAIN_STYLE_SUBPACKAGE_LIMIT: ${{ matrix.watch_main_style_subpackage_limit || '' }}
           E2E_WATCH_SAVE_SNAPSHOTS: ${{ matrix.watch_save_snapshots }}

--- a/e2e/watch/hot-update/shared.ts
+++ b/e2e/watch/hot-update/shared.ts
@@ -358,6 +358,7 @@ interface HotUpdateReport {
   options?: {
     webOnly?: boolean
     miniProgramOnly?: boolean
+    miniProgramScope?: 'main-package' | 'subpackages'
     mainStyleOnly?: boolean
     mainStyleSubPackageLimit?: number
   }
@@ -448,6 +449,10 @@ function isWebOnlyProfile(report?: HotUpdateReport) {
 
 function isMainStyleOnlyProfile(report?: HotUpdateReport) {
   return toBoolEnv('E2E_WATCH_MAIN_STYLE_ONLY', false) || report?.options?.mainStyleOnly === true
+}
+
+function isSubPackagesOnlyProfile(report?: HotUpdateReport) {
+  return report?.options?.miniProgramScope === 'subpackages'
 }
 
 function resolveRequiredMutationRounds() {
@@ -1079,6 +1084,34 @@ export function assertHotUpdateReport(report: HotUpdateReport, target: WatchCase
     assertMainStyleOnlyHotUpdateReport(report, target, maxHotUpdateMs)
     return
   }
+  if (isSubPackagesOnlyProfile(report)) {
+    assertAllHotUpdateSamplesWithinBudget(report, maxHotUpdateMs)
+    expect(report.summary.count).toBeGreaterThan(0)
+    expect(report.cases.length).toBe(report.summary.count)
+    for (const item of report.cases) {
+      const baseCaseName = resolveReportBaseCaseName(item)
+      const configuredWatchCase = configuredWatchCasesByName.get(baseCaseName)
+      const subPackageMutationMetrics = item.subPackageMutationMetrics ?? []
+      expect(item.initialReadyMs).toBeGreaterThan(0)
+      expect(item.mainStyleHotUpdate).toBeUndefined()
+      expect(item.webHmr).toBeUndefined()
+      expect(subPackageMutationMetrics.map(metric => metric.root).sort()).toEqual(['sub-independent', 'sub-normal'])
+      for (const metric of subPackageMutationMetrics) {
+        const configuredMutation = configuredWatchCase?.subPackageMutations?.find(item => item.root === metric.root)
+        const expectedRoundCount = configuredMutation?.templateMutation.skipExtendedHmr
+          ? 1
+          : resolveRequiredMutationRounds().length
+        expect(metric.template.rounds.length).toBe(expectedRoundCount)
+        expect(metric.globalStyleOutputs.length).toBeGreaterThan(0)
+        expect(metric.style == null).toBe(configuredMutation?.skipStyleMutation === true)
+        if (configuredMutation?.mainStyleMutation) {
+          expect(metric.mainStyleHotUpdate).toBeDefined()
+        }
+      }
+      assertHmrDurationReport(report, item, maxHotUpdateMs)
+    }
+    return
+  }
 
   const requiredMutationRounds = resolveRequiredMutationRounds()
   const issue33RoundProfile = isIssue33RoundProfile()
@@ -1132,7 +1165,10 @@ export function assertHotUpdateReport(report: HotUpdateReport, target: WatchCase
     const subPackageMutationMetrics = item.subPackageMutationMetrics ?? []
     const hasStyleMutation = item.mutationMetrics.some(metric => metric.mutationKind === 'style')
     expect(item.mutationMetrics.length).toBe(2 + (hasStyleMutation ? 1 : 0) + (hasContentMutation ? 1 : 0))
-    if (SUBPACKAGE_HMR_CASES.has(baseCaseName)) {
+    if (report.options?.miniProgramScope === 'main-package') {
+      expect(subPackageMutationMetrics).toEqual([])
+    }
+    else if (SUBPACKAGE_HMR_CASES.has(baseCaseName)) {
       expect(subPackageMutationMetrics.length).toBe(2)
       expect(subPackageMutationMetrics.map(metric => metric.root).sort()).toEqual(['sub-independent', 'sub-normal'])
       expect(subPackageMutationMetrics.some(metric => metric.independent)).toBe(true)
@@ -1521,6 +1557,7 @@ export async function runHotUpdateTarget(target: WatchCaseName) {
   const skipBuild = toBoolEnv('E2E_WATCH_SKIP_BUILD', true)
   const quietSass = toBoolEnv('E2E_WATCH_QUIET_SASS', true)
   const miniProgramOnly = toBoolEnv('E2E_WATCH_MINI_PROGRAM_ONLY', false)
+  const miniProgramScope = process.env.E2E_WATCH_MINI_PROGRAM_SCOPE
   const mainStyleOnly = toBoolEnv('E2E_WATCH_MAIN_STYLE_ONLY', false)
   const mainStyleSubPackageLimit = process.env.E2E_WATCH_MAIN_STYLE_SUBPACKAGE_LIMIT
   const reportFile = createReportFilePath(cwd, runTarget)
@@ -1558,6 +1595,10 @@ export async function runHotUpdateTarget(target: WatchCaseName) {
 
   if (miniProgramOnly) {
     args.push('--mini-program-only')
+  }
+
+  if (miniProgramScope) {
+    args.push('--mini-program-scope', miniProgramScope)
   }
 
   if (mainStyleOnly) {

--- a/packages/postcss/src/compat/mini-program-css/finalize-options.ts
+++ b/packages/postcss/src/compat/mini-program-css/finalize-options.ts
@@ -5,6 +5,13 @@ export interface FinalizeMiniProgramCssOptions {
   cssSelectorReplacement?: CssSelectorReplacement | undefined
   isTailwindcssV4?: boolean | undefined
   /**
+   * 是否递归移除子规则被清理而变空的父级条件规则。
+   *
+   * 增量生成的 CSS 可能只包含条件规则中的新片段，父级容器由已缓存产物提供，
+   * 此时应保留占位容器，避免后续追加 CSS 时丢失层级。
+   */
+  removeEmptyAtRuleAncestors?: boolean | undefined
+  /**
    * 是否为 Tailwind CSS v4 渐变工具类生成小程序字面量兜底。
    */
   tailwindcssV4GradientFallback?: boolean | undefined

--- a/packages/postcss/src/compat/mini-program-css/finalize.ts
+++ b/packages/postcss/src/compat/mini-program-css/finalize.ts
@@ -80,7 +80,16 @@ function finalizeMiniProgramCssRoot(root: postcss.Root, options: FinalizeMiniPro
   const themeRule = collectThemeVariableRule(root, options)
   const hoistedRules = themeRule ? [...preflightRules, themeRule] : preflightRules
   insertHoistedRules(root, mergeEquivalentHoistedRules(hoistedRules), hoistAnchor)
-  removeEmptyAtRules(root)
+  if (options.removeEmptyAtRuleAncestors !== false) {
+    removeEmptyAtRules(root)
+  }
+  else {
+    root.walkAtRules((atRule) => {
+      if (atRule.nodes?.length === 0) {
+        atRule.remove()
+      }
+    })
+  }
 }
 
 export function hoistTailwindPreflightBase(css: string) {

--- a/packages/postcss/src/compat/mini-program-css/index.ts
+++ b/packages/postcss/src/compat/mini-program-css/index.ts
@@ -17,5 +17,6 @@ export {
 } from './prune-generated'
 export {
   hasMiniProgramCssSpecificityPlaceholders,
+  removeEmptyAtRules,
   stripMiniProgramCssSpecificityPlaceholders,
 } from './root-cleanups'

--- a/packages/postcss/src/compat/mini-program-css/root-cleanups.ts
+++ b/packages/postcss/src/compat/mini-program-css/root-cleanups.ts
@@ -80,11 +80,33 @@ function isEffectivelyEmptyContainer(container: postcss.Container) {
 }
 
 export function removeEmptyAtRules(root: postcss.Root) {
+  let removed = 0
+  const visit = (container: postcss.Container) => {
+    for (const node of [...(container.nodes ?? [])]) {
+      if (!('nodes' in node) || node.nodes === undefined) {
+        continue
+      }
+      visit(node)
+      if (node.type === 'atrule' && node.parent && isEffectivelyEmptyContainer(node)) {
+        node.remove()
+        removed++
+      }
+    }
+  }
+
+  visit(root)
+  return removed
+}
+
+export function removeEmptyBlockAtRules(root: postcss.Root) {
+  let removed = 0
   root.walkAtRules((atRule) => {
-    if (isEffectivelyEmptyContainer(atRule)) {
+    if (atRule.nodes?.length === 0) {
       atRule.remove()
+      removed++
     }
   })
+  return removed
 }
 
 function removeEmptyAtRuleAncestors(parent: postcss.Container | undefined) {

--- a/packages/postcss/src/handler.ts
+++ b/packages/postcss/src/handler.ts
@@ -6,6 +6,7 @@ import { defuOverrideArray } from '@weapp-tailwindcss/shared'
 import { LRUCache } from 'lru-cache'
 import postcss from 'postcss'
 import { protectDynamicColorMixAlpha } from './compat/color-mix'
+import { removeEmptyBlockAtRules } from './compat/mini-program-css/root-cleanups'
 import { probeFeatures, signalToCacheKey } from './content-probe'
 import { getDefaultOptions } from './defaults'
 import { fingerprintOptions } from './fingerprint'
@@ -128,6 +129,19 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
     ).async().then((result) => {
       const styleBranch = resolvePostcssFrameworkProfile(resolvedOptions)
       let finalResult = styleBranch.postprocess(result, resolvedOptions)
+      if (resolvedOptions.isMainChunk !== false && finalResult.root) {
+        let removed = 0
+        let removedTotal = 0
+        do {
+          removed = removeEmptyBlockAtRules(finalResult.root)
+          removedTotal += removed
+        } while (removed > 0)
+        if (removedTotal > 0) {
+          const nextResult = finalResult.root.toResult(finalResult.opts)
+          nextResult.messages.push(...finalResult.messages)
+          finalResult = nextResult
+        }
+      }
       if (protectedColorMix) {
         const restoredCss = protectedColorMix.restore(finalResult.css)
         if (restoredCss !== finalResult.css) {

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -21,6 +21,7 @@ export {
   hoistTailwindPreflightBase,
   normalizeMiniProgramGeneratedCssForPostcss,
   pruneMiniProgramGeneratedCss,
+  removeEmptyAtRules,
   removeUnsupportedAtSupports,
   removeUnsupportedCascadeLayers,
   removeUnsupportedMiniProgramAtRules,

--- a/packages/postcss/test/mini-program-css.test.ts
+++ b/packages/postcss/test/mini-program-css.test.ts
@@ -681,6 +681,23 @@ describe('mini-program css cleanup', () => {
     expect(css).not.toContain('margin')
   })
 
+  it('keeps incremental at-rule ancestors when recursive cleanup is disabled', () => {
+    const css = finalizeMiniProgramCss('@media screen{/* incremental placeholder */}', {
+      cssPreflight: false,
+      removeEmptyAtRuleAncestors: false,
+    })
+
+    expect(css).toBe('@media screen{/* incremental placeholder */}')
+  })
+
+  it('recursively removes empty at-rule ancestors for complete css output', () => {
+    const css = finalizeMiniProgramCss('@media screen{@supports (display:grid){}}', {
+      cssPreflight: false,
+    })
+
+    expect(css).toBe('')
+  })
+
   it('prunes browser-only generated css while preserving useful mini-program selectors', () => {
     const css = pruneMiniProgramGeneratedCss([
       '/* #ifdef MP-WEIXIN */',

--- a/packages/postcss/test/mini-program-generated-css.test.ts
+++ b/packages/postcss/test/mini-program-generated-css.test.ts
@@ -107,6 +107,19 @@ describe('mini-program generated css cleanup', () => {
     expect(css).not.toContain('box-sizing:border-box')
   })
 
+  it('removes empty conditional at-rules from generated mini-program css', () => {
+    const css = finalizeMiniProgramCss([
+      '@media (prefers-color-scheme: light) {}',
+      '@media (prefers-color-scheme: dark) { /* removed declarations */ }',
+      '@media screen { @supports (display: grid) {} }',
+      '.keep{color:red}',
+    ].join('\n'), { isTailwindcssV4: true })
+
+    expect(css).not.toContain('@media')
+    expect(css).not.toContain('@supports')
+    expect(css).toContain('.keep{color:red}')
+  })
+
   it('preserves user page custom properties that use Tailwind v4 theme namespaces', async () => {
     const styleHandler = createStyleHandler({
       majorVersion: 4,

--- a/packages/postcss/test/post.test.ts
+++ b/packages/postcss/test/post.test.ts
@@ -1,4 +1,5 @@
 import postcss from 'postcss'
+import { createStyleHandler } from '@/handler'
 import { postcssWeappTailwindcssPostPlugin } from '@/plugins/post'
 
 describe('postcss post plugin', () => {
@@ -25,5 +26,35 @@ describe('postcss post plugin', () => {
       }),
     ]).process(rawCode)
     expect(css).toMatchSnapshot()
+  })
+
+  it('preserves standalone conditional placeholders for incremental css assembly', async () => {
+    const input = '@media (min-width: 64rem) { /* incremental placeholder */ }'
+    const result = await postcss([
+      postcssWeappTailwindcssPostPlugin({
+        isMainChunk: true,
+      }),
+    ]).process(input, { from: undefined })
+
+    expect(result.css).toBe(input)
+  })
+
+  it('removes nested empty blocks after the postcss lifecycle completes', async () => {
+    const styleHandler = createStyleHandler({
+      isMainChunk: true,
+    })
+    const { css } = await styleHandler('@media (min-width: 64rem) { @supports (display: grid) {} }')
+
+    expect(css).toBe('')
+  })
+
+  it('keeps comment-only incremental placeholders after postprocessing', async () => {
+    const input = '@media (min-width: 64rem) { /* incremental placeholder */ }'
+    const styleHandler = createStyleHandler({
+      isMainChunk: true,
+    })
+    const { css } = await styleHandler(input)
+
+    expect(css).toBe(input)
   })
 })

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/generation-helpers/preflight.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/generation-helpers/preflight.ts
@@ -18,7 +18,12 @@ export function finalizeMiniProgramGeneratorCss(
   target: string,
   _majorVersion: number | undefined,
   cssPreflight: InternalUserDefinedOptions['cssPreflight'],
-  options: { injectPreflight?: boolean, preservePreflight?: boolean, styleOptions?: Partial<IStyleHandlerOptions> | undefined } = {},
+  options: {
+    injectPreflight?: boolean | undefined
+    preservePreflight?: boolean | undefined
+    removeEmptyAtRuleAncestors?: boolean | undefined
+    styleOptions?: Partial<IStyleHandlerOptions> | undefined
+  } = {},
 ) {
   if (!isMiniProgramGeneratorTarget(target)) {
     return css
@@ -29,6 +34,7 @@ export function finalizeMiniProgramGeneratorCss(
       cssSelectorReplacement: options.styleOptions?.cssOptions?.cssSelectorReplacement
         ?? options.styleOptions?.cssSelectorReplacement,
       isTailwindcssV4: true,
+      removeEmptyAtRuleAncestors: options.removeEmptyAtRuleAncestors,
       tailwindcssV4GradientFallback: options.styleOptions?.cssOptions?.tailwindcssV4GradientFallback
         ?? options.styleOptions?.tailwindcssV4GradientFallback,
     })
@@ -48,6 +54,7 @@ export function finalizeMiniProgramGeneratorCss(
     cssSelectorReplacement: options.styleOptions?.cssOptions?.cssSelectorReplacement
       ?? options.styleOptions?.cssSelectorReplacement,
     isTailwindcssV4: true,
+    removeEmptyAtRuleAncestors: options.removeEmptyAtRuleAncestors,
     tailwindcssV4GradientFallback: options.styleOptions?.cssOptions?.tailwindcssV4GradientFallback
       ?? options.styleOptions?.tailwindcssV4GradientFallback,
   })

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/pipeline/context.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/pipeline/context.ts
@@ -15,6 +15,7 @@ export interface GeneratorPipelineExecutionContext {
     options?: {
       injectPreflight?: boolean | undefined
       preservePreflight?: boolean | undefined
+      removeEmptyAtRuleAncestors?: boolean | undefined
       styleOptions?: Partial<IStyleHandlerOptions> | undefined
     },
   ) => string

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/pipeline/ordered-output.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/pipeline/ordered-output.ts
@@ -21,6 +21,7 @@ export async function finalizeOrderedGeneratorCss(
     const css = incrementalCss.trim().length > 0
       ? finalizeIncrementalGeneratorCss(options.previousCss, incrementalCss, generated.target, majorVersion, opts.cssPreflight, {
           injectPreflight: false,
+          removeEmptyAtRuleAncestors: false,
           styleOptions: generatorStyleOptions,
         }, generatorOptions.webCompat)
       : options.previousCss

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/final-css-assets.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/final-css-assets.ts
@@ -6,6 +6,7 @@ import {
   stripMiniProgramCssSpecificityPlaceholders,
 } from '@/bundlers/shared/css-cleanup'
 import { AssetEmissionPlan } from '@/compiler'
+import { removeEmptyCssAtRules } from '../processed-css-assets/cleanup'
 import { applyViteAssetEmissionPlan } from './asset-emission-plan'
 
 function readAssetSource(output: OutputAsset) {
@@ -30,6 +31,7 @@ export async function finalizeMiniProgramCssAssets(
     onUpdate: GenerateBundleContext['opts']['onUpdate']
     recordCssAssetResult: GenerateBundleContext['recordCssAssetResult']
     styleHandler: GenerateBundleContext['opts']['styleHandler']
+    useIncrementalMode?: boolean | undefined
     debug?: GenerateBundleContext['debug']
   },
 ) {
@@ -54,7 +56,10 @@ export async function finalizeMiniProgramCssAssets(
       continue
     }
     if (options.lastCssResultByFile?.has(file)) {
-      const outputCss = stripMiniProgramCssSpecificityPlaceholders(rawSource)
+      const structurallyCleanSource = options.useIncrementalMode
+        ? rawSource
+        : removeEmptyCssAtRules(rawSource)
+      const outputCss = stripMiniProgramCssSpecificityPlaceholders(structurallyCleanSource)
       if (outputCss !== rawSource) {
         plan.write(file, outputCss)
         writeTargets.set(file, output)
@@ -66,6 +71,17 @@ export async function finalizeMiniProgramCssAssets(
       continue
     }
     if (!shouldFinalizeMiniProgramCssAsset(rawSource)) {
+      const structurallyCleanSource = options.useIncrementalMode
+        ? rawSource
+        : removeEmptyCssAtRules(rawSource)
+      if (structurallyCleanSource !== rawSource) {
+        plan.write(file, structurallyCleanSource)
+        writeTargets.set(file, output)
+        options.recordCssAssetResult?.(file, structurallyCleanSource)
+        options.onUpdate(file, rawSource, structurallyCleanSource)
+        options.debug?.('remove empty mini-program css at-rules: %s bytes=%d', file, structurallyCleanSource.length)
+        updated++
+      }
       continue
     }
 
@@ -80,7 +96,10 @@ export async function finalizeMiniProgramCssAssets(
       },
       cssPresetEnv: {},
     })
-    const outputCss = stripMiniProgramCssSpecificityPlaceholders(css)
+    const structurallyCleanCss = options.useIncrementalMode
+      ? css
+      : removeEmptyCssAtRules(css)
+    const outputCss = stripMiniProgramCssSpecificityPlaceholders(structurallyCleanCss)
     if (outputCss === rawSource) {
       continue
     }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/finalize/bundle.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/finalize/bundle.ts
@@ -210,6 +210,7 @@ export async function finalizeGenerateBundle(options: FinalizeGenerateBundleOpti
     onUpdate,
     recordCssAssetResult,
     styleHandler,
+    useIncrementalMode,
   })
   recordTimingDetail('finalize.cssAssets', finalCssAssetsStartedAt)
   const webCompatStartedAt = performance.now()

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/cleanup.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/cleanup.ts
@@ -1,9 +1,10 @@
 import type { OutputAsset, OutputBundle } from 'rollup'
 import type { CollectViteProcessedCssAssetOptions } from './markers-imports'
 import type { InternalUserDefinedOptions } from '@/types'
-import { isMiniProgramLocalCssImportRequest, parseTailwindCssDirectiveRequest, postcss } from '@weapp-tailwindcss/postcss'
+import { isMiniProgramLocalCssImportRequest, parseTailwindCssDirectiveRequest, postcss, removeEmptyAtRules } from '@weapp-tailwindcss/postcss'
 import path from 'pathe'
 import { normalizeOutputPathKey } from '../../shared/module-graph'
+import { hasEmptyAtRuleBlockCandidate } from './empty-at-rule'
 import { appendCss, collectImportedStyleFiles, createCssAssetPipelineContext, getAssetFile, isStyleImportRequest, readAssetSource } from './markers-imports'
 import { isMiniProgramStyleOutputFile, isRootStyleOutputFile } from './style-files'
 
@@ -71,7 +72,7 @@ export function restoreCssImportAtRules(source: string, filtered: string, file?:
 }
 
 export function removeCommentOnlyAtRules(css: string) {
-  if (!css.includes('@')) {
+  if (!hasEmptyAtRuleBlockCandidate(css)) {
     return css
   }
   try {
@@ -89,6 +90,25 @@ export function removeCommentOnlyAtRules(css: string) {
       changed = true
     })
     return changed ? root.toString() : css
+  }
+  catch {
+    return css
+  }
+}
+
+export function removeEmptyCssAtRules(css: string) {
+  if (!hasEmptyAtRuleBlockCandidate(css)) {
+    return css
+  }
+  try {
+    const root = postcss.parse(css)
+    let removed = 0
+    let passRemoved = 0
+    do {
+      passRemoved = removeEmptyAtRules(root)
+      removed += passRemoved
+    } while (passRemoved > 0)
+    return removed > 0 ? root.toString() : css
   }
   catch {
     return css

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/empty-at-rule.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/empty-at-rule.ts
@@ -1,0 +1,104 @@
+function isAtRuleNameCharacter(code: number) {
+  return code === 45
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+}
+
+function isCssWhitespace(code: number) {
+  return code === 9 || code === 10 || code === 12 || code === 13 || code === 32
+}
+
+function findAtRuleBlockStart(css: string, start: number) {
+  let parenthesisDepth = 0
+  let quote = 0
+  let squareBracketDepth = 0
+  for (let index = start; index < css.length; index++) {
+    const code = css.charCodeAt(index)
+    if (quote !== 0) {
+      if (code === 92) {
+        index++
+      }
+      else if (code === quote) {
+        quote = 0
+      }
+      continue
+    }
+    if (code === 34 || code === 39) {
+      quote = code
+      continue
+    }
+    if (code === 92) {
+      index++
+      continue
+    }
+    if (code === 47 && css.charCodeAt(index + 1) === 42) {
+      const commentEnd = css.indexOf('*/', index + 2)
+      if (commentEnd < 0) {
+        return -1
+      }
+      index = commentEnd + 1
+      continue
+    }
+    if (code === 40) {
+      parenthesisDepth++
+      continue
+    }
+    if (code === 41 && parenthesisDepth > 0) {
+      parenthesisDepth--
+      continue
+    }
+    if (code === 91) {
+      squareBracketDepth++
+      continue
+    }
+    if (code === 93 && squareBracketDepth > 0) {
+      squareBracketDepth--
+      continue
+    }
+    if (code === 123 && parenthesisDepth === 0 && squareBracketDepth === 0) {
+      return index
+    }
+    if ((code === 59 || code === 125) && parenthesisDepth === 0 && squareBracketDepth === 0) {
+      return -1
+    }
+  }
+  return -1
+}
+
+function isEmptyAtRuleBody(css: string, blockStart: number) {
+  for (let index = blockStart + 1; index < css.length; index++) {
+    const code = css.charCodeAt(index)
+    if (isCssWhitespace(code)) {
+      continue
+    }
+    if (code === 47 && css.charCodeAt(index + 1) === 42) {
+      const commentEnd = css.indexOf('*/', index + 2)
+      if (commentEnd < 0) {
+        return false
+      }
+      index = commentEnd + 1
+      continue
+    }
+    return code === 125
+  }
+  return false
+}
+
+export function hasEmptyAtRuleBlockCandidate(css: string) {
+  let searchFrom = 0
+  while (searchFrom < css.length) {
+    const atRuleStart = css.indexOf('@', searchFrom)
+    if (atRuleStart < 0) {
+      return false
+    }
+    searchFrom = atRuleStart + 1
+    if (!isAtRuleNameCharacter(css.charCodeAt(searchFrom))) {
+      continue
+    }
+    const blockStart = findAtRuleBlockStart(css, searchFrom + 1)
+    if (blockStart >= 0 && isEmptyAtRuleBody(css, blockStart)) {
+      return true
+    }
+  }
+  return false
+}

--- a/packages/weapp-tailwindcss/test/bundlers/generator-css.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/generator-css.unit.test.ts
@@ -9971,6 +9971,16 @@ describe('bundlers/shared generator css', () => {
     expect(css).toContain('background-image:linear-gradient(to right, #06b6d4, #3b82f6)')
   })
 
+  it('preserves incremental at-rule placeholders during generator finalization', async () => {
+    const { finalizeMiniProgramGeneratorCss } = await import('@/bundlers/shared/generator-css/generation-helpers')
+    const css = finalizeMiniProgramGeneratorCss('@media screen{/* incremental placeholder */}', 'weapp', 4, false, {
+      injectPreflight: false,
+      removeEmptyAtRuleAncestors: false,
+    })
+
+    expect(css).toBe('@media screen{/* incremental placeholder */}')
+  })
+
   it('does not inject Tailwind v4 mini-program preflight twice when generator css already has reset', async () => {
     const { finalizeMiniProgramGeneratorCss } = await import('@/bundlers/shared/generator-css/generation-helpers')
     const css = finalizeMiniProgramGeneratorCss([

--- a/packages/weapp-tailwindcss/test/bundlers/vite-final-css-assets.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-final-css-assets.unit.test.ts
@@ -1,0 +1,87 @@
+import type { OutputAsset, OutputChunk } from 'rollup'
+import { describe, expect, it, vi } from 'vitest'
+import { finalizeMiniProgramCssAssets } from '@/bundlers/vite/generate-bundle/final-css-assets'
+import { createRollupAsset } from './vite-plugin.testkit'
+
+function createBundle(source: string) {
+  return {
+    'app.wxss': {
+      ...createRollupAsset(source),
+      fileName: 'app.wxss',
+    },
+  } satisfies Record<string, OutputAsset | OutputChunk>
+}
+
+describe('vite final mini-program css assets', () => {
+  it('removes empty conditional at-rules from cached app styles', async () => {
+    const bundle = createBundle([
+      '@import "./theme.wxss";',
+      '@media (prefers-color-scheme: light) {}',
+      '@media (prefers-color-scheme: dark) { /* removed declarations */ }',
+      '@media screen { @supports (display: grid) {} }',
+      '.keep{color:red}',
+    ].join('\n'))
+    const onUpdate = vi.fn()
+    const recordCssAssetResult = vi.fn()
+    const styleHandler = vi.fn(async (code: string) => ({ css: code }))
+
+    await finalizeMiniProgramCssAssets(bundle, {
+      cssMatcher: file => file.endsWith('.wxss'),
+      getCssHandlerOptions: () => ({ isMainChunk: true } as any),
+      isWebGeneratorTarget: false,
+      lastCssResultByFile: new Map([['app.wxss', 'cached']]),
+      onUpdate,
+      recordCssAssetResult,
+      styleHandler,
+    })
+
+    const css = String((bundle['app.wxss'] as OutputAsset).source)
+    expect(css).not.toContain('@media')
+    expect(css).not.toContain('@supports')
+    expect(css).toContain('@import "./theme.wxss";')
+    expect(css).toContain('.keep{color:red}')
+    expect(styleHandler).not.toHaveBeenCalled()
+    expect(recordCssAssetResult).toHaveBeenCalledWith('app.wxss', css)
+    expect(onUpdate).toHaveBeenCalledWith('app.wxss', expect.any(String), css)
+  })
+
+  it('does not rewrite cached css assets during incremental finalization', async () => {
+    const source = '@media (prefers-color-scheme: dark) {}\n.keep{color:red}'
+    const bundle = createBundle(source)
+    const onUpdate = vi.fn()
+
+    await finalizeMiniProgramCssAssets(bundle, {
+      cssMatcher: file => file.endsWith('.wxss'),
+      getCssHandlerOptions: () => ({ isMainChunk: true } as any),
+      isWebGeneratorTarget: false,
+      lastCssResultByFile: new Map([['app.wxss', 'cached']]),
+      onUpdate,
+      recordCssAssetResult: vi.fn(),
+      styleHandler: vi.fn(async (code: string) => ({ css: code })),
+      useIncrementalMode: true,
+    })
+
+    expect(String((bundle['app.wxss'] as OutputAsset).source)).toBe(source)
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it('cleans empty at-rules after handling uncached css assets', async () => {
+    const source = '@media (prefers-color-scheme: dark) { /* removed */ }\n.button:hover{color:red}'
+    const bundle = createBundle(source)
+    const styleHandler = vi.fn(async (code: string) => ({ css: code }))
+
+    await finalizeMiniProgramCssAssets(bundle, {
+      cssMatcher: file => file.endsWith('.wxss'),
+      getCssHandlerOptions: () => ({ isMainChunk: true } as any),
+      isWebGeneratorTarget: false,
+      onUpdate: vi.fn(),
+      recordCssAssetResult: vi.fn(),
+      styleHandler,
+    })
+
+    const css = String((bundle['app.wxss'] as OutputAsset).source)
+    expect(css).not.toContain('@media')
+    expect(css).toContain('.button:hover{color:red}')
+    expect(styleHandler).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-cleanup.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-cleanup.unit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { removeCommentOnlyAtRules, removeEmptyCssAtRules } from '@/bundlers/vite/processed-css-assets/cleanup'
+import { hasEmptyAtRuleBlockCandidate } from '@/bundlers/vite/processed-css-assets/empty-at-rule'
+
+describe('vite processed css cleanup', () => {
+  it('detects empty block at-rules with a linear precheck', () => {
+    expect(hasEmptyAtRuleBlockCandidate('@media screen { /* token */ .keep {} }')).toBe(false)
+    expect(hasEmptyAtRuleBlockCandidate('@media screen { @supports (display: grid) { /* removed */ } }')).toBe(true)
+    expect(hasEmptyAtRuleBlockCandidate('@supports (background: url(data:image/svg+xml;utf8,test)) {}')).toBe(true)
+    expect(hasEmptyAtRuleBlockCandidate('@custom "value;{}"; .keep {}')).toBe(false)
+  })
+
+  it('cleans empty at-rules without backtracking on comment-rich css', () => {
+    const source = [
+      '@media screen {',
+      '/* generated token */'.repeat(25),
+      '.keep { color: red; }',
+      '}',
+      '@supports (display: grid) {}',
+    ].join('\n')
+    const startedAt = performance.now()
+
+    const css = removeEmptyCssAtRules(source)
+
+    expect(performance.now() - startedAt).toBeLessThan(1000)
+    expect(css).toContain('@media screen')
+    expect(css).toContain('.keep { color: red; }')
+    expect(css).not.toContain('@supports')
+  })
+
+  it('cleans comment-only at-rules without backtracking on comment-rich css', () => {
+    const source = [
+      '@media screen {',
+      '/* generated token */'.repeat(25),
+      '.keep { color: red; }',
+      '}',
+      '@supports (display: grid) { /* removed declarations */ }',
+    ].join('\n')
+    const startedAt = performance.now()
+
+    const css = removeCommentOnlyAtRules(source)
+
+    expect(performance.now() - startedAt).toBeLessThan(1000)
+    expect(css).toContain('@media screen')
+    expect(css).toContain('.keep { color: red; }')
+    expect(css).not.toContain('@supports')
+  })
+})

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -720,6 +720,7 @@ describe('e2e watch workflow', () => {
     expect(cases).toContain('macos:22:demo-core:main-style')
     for (const runner of ['linux', 'macos']) {
       for (const watchCase of parallelTaroCases) {
+        const mainCommandTimeoutMs = watchCase.includes('webpack') ? '1500000' : '1200000'
         for (const profile of ['mini-program-main', 'mini-program-subpackages']) {
           expect(cases, `${runner} should cover ${watchCase} ${profile} HMR`).toContain(`${runner}:22:${watchCase}:${profile}`)
         }
@@ -731,7 +732,7 @@ describe('e2e watch workflow', () => {
             watch_mini_program_scope: 'main-package',
             watch_max_attempts: '1',
             timeout_minutes: 30,
-            watch_command_timeout_ms: '1200000',
+            watch_command_timeout_ms: mainCommandTimeoutMs,
           }),
           expect.objectContaining({
             round_profile: 'mini-program-subpackages',
@@ -893,9 +894,13 @@ describe('e2e watch workflow', () => {
       { watchCase: 'taro-vite-vue3-tailwindcss-v4', timeoutMs: '420000' },
       { watchCase: 'taro-webpack-vue3-tailwindcss-v4', timeoutMs: '600000' },
     ].flatMap(({ watchCase, timeoutMs }) => [
-      { profile: 'mini-program-main', scope: 'main-package' },
-      { profile: 'mini-program-subpackages', scope: 'subpackages' },
-    ].map(({ profile, scope }) => ({
+      {
+        commandTimeoutMs: watchCase.includes('webpack') ? '1500000' : '1200000',
+        profile: 'mini-program-main',
+        scope: 'main-package',
+      },
+      { commandTimeoutMs: '1200000', profile: 'mini-program-subpackages', scope: 'subpackages' },
+    ].map(({ commandTimeoutMs, profile, scope }) => ({
       watch_case: watchCase,
       round_profile: profile,
       watch_mini_program_only: '1',
@@ -904,7 +909,7 @@ describe('e2e watch workflow', () => {
       timeout_minutes: 30,
       watch_timeout_ms: timeoutMs,
       watch_max_plugin_process_ms: '60000',
-      watch_command_timeout_ms: '1200000',
+      watch_command_timeout_ms: commandTimeoutMs,
     })))
     const slowLinuxDemoCorePrBudget = {
       watch_case: 'demo-core',

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -720,7 +720,28 @@ describe('e2e watch workflow', () => {
     expect(cases).toContain('macos:22:demo-core:main-style')
     for (const runner of ['linux', 'macos']) {
       for (const watchCase of parallelTaroCases) {
-        expect(cases, `${runner} should cover ${watchCase} mini-program HMR`).toContain(`${runner}:22:${watchCase}:mini-program`)
+        for (const profile of ['mini-program-main', 'mini-program-subpackages']) {
+          expect(cases, `${runner} should cover ${watchCase} ${profile} HMR`).toContain(`${runner}:22:${watchCase}:${profile}`)
+        }
+        const scopeRows = rows.filter(row => row.runner_label === runner && row.watch_case === watchCase && String(row.round_profile).startsWith('mini-program-'))
+        expect(scopeRows).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            round_profile: 'mini-program-main',
+            watch_mini_program_only: '1',
+            watch_mini_program_scope: 'main-package',
+            watch_max_attempts: '1',
+            timeout_minutes: 30,
+            watch_command_timeout_ms: '1200000',
+          }),
+          expect.objectContaining({
+            round_profile: 'mini-program-subpackages',
+            watch_mini_program_only: '1',
+            watch_mini_program_scope: 'subpackages',
+            watch_max_attempts: '1',
+            timeout_minutes: 30,
+            watch_command_timeout_ms: '1200000',
+          }),
+        ]))
       }
     }
     for (const watchCase of parallelTaroCases) {
@@ -747,8 +768,8 @@ describe('e2e watch workflow', () => {
       .filter(row => row.runner_label === 'macos' && String(row.watch_case).includes(':'))
       .map(row => row.watch_case)
     expect(macosPlatformCases).toEqual(['uni-app-vite-tailwindcss-v4:mp-weixin'])
-    expect(rows.filter(row => row.runner_label === 'macos')).toHaveLength(13)
-    expect(rows.filter(row => row.runner_label === 'linux')).toHaveLength(14)
+    expect(rows.filter(row => row.runner_label === 'macos')).toHaveLength(17)
+    expect(rows.filter(row => row.runner_label === 'linux')).toHaveLength(18)
     expect(rows.filter(row => row.runner_label === 'windows')).toHaveLength(21)
     for (const row of [
       rows.find(row => row.runner_label === 'macos' && row.watch_case === 'demo-core'),
@@ -778,6 +799,7 @@ describe('e2e watch workflow', () => {
     expect(watchStep?.env).toMatchObject({
       E2E_TARO_DEV_READY_TIMEOUT_MS: '${{ matrix.taro_dev_ready_timeout_ms || matrix.watch_timeout_ms }}',
       E2E_WATCH_MINI_PROGRAM_ONLY: "${{ matrix.watch_mini_program_only || '0' }}",
+      E2E_WATCH_MINI_PROGRAM_SCOPE: "${{ matrix.watch_mini_program_scope || '' }}",
       E2E_WATCH_MAIN_STYLE_ONLY: "${{ matrix.watch_main_style_only || '0' }}",
       E2E_WATCH_MAIN_STYLE_SUBPACKAGE_LIMIT: "${{ matrix.watch_main_style_subpackage_limit || '' }}",
     })
@@ -870,15 +892,20 @@ describe('e2e watch workflow', () => {
       { watchCase: 'taro-webpack-react-tailwindcss-v4', timeoutMs: '600000' },
       { watchCase: 'taro-vite-vue3-tailwindcss-v4', timeoutMs: '420000' },
       { watchCase: 'taro-webpack-vue3-tailwindcss-v4', timeoutMs: '600000' },
-    ].map(({ watchCase, timeoutMs }) => ({
+    ].flatMap(({ watchCase, timeoutMs }) => [
+      { profile: 'mini-program-main', scope: 'main-package' },
+      { profile: 'mini-program-subpackages', scope: 'subpackages' },
+    ].map(({ profile, scope }) => ({
       watch_case: watchCase,
-      round_profile: 'mini-program',
+      round_profile: profile,
       watch_mini_program_only: '1',
+      watch_mini_program_scope: scope,
+      watch_max_attempts: '1',
       timeout_minutes: 30,
       watch_timeout_ms: timeoutMs,
       watch_max_plugin_process_ms: '60000',
-      watch_command_timeout_ms: '1500000',
-    }))
+      watch_command_timeout_ms: '1200000',
+    })))
     const slowLinuxDemoCorePrBudget = {
       watch_case: 'demo-core',
       round_profile: 'default',

--- a/packages/weapp-tailwindcss/test/watch-hmr-coverage-matrix.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-coverage-matrix.unit.test.ts
@@ -337,7 +337,16 @@ describe('watch-hmr coverage matrix', () => {
     ]))
     for (const watchCase of taroProjectCases) {
       expect(rows).toEqual(expect.arrayContaining([
-        expect.objectContaining({ watch_case: watchCase, round_profile: 'mini-program' }),
+        expect.objectContaining({
+          watch_case: watchCase,
+          round_profile: 'mini-program-main',
+          watch_mini_program_scope: 'main-package',
+        }),
+        expect.objectContaining({
+          watch_case: watchCase,
+          round_profile: 'mini-program-subpackages',
+          watch_mini_program_scope: 'subpackages',
+        }),
         expect.objectContaining({ watch_case: watchCase, round_profile: 'web-only' }),
       ]))
     }

--- a/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
@@ -2962,13 +2962,13 @@ describe('watch-hmr regression cases', () => {
     }
     const prMatrixEntries = workflow.jobs?.['pr-quick-gate']?.strategy?.matrix?.include ?? []
 
-    const prWebCaseNames = [
-      'taro-vite-react-tailwindcss-v4',
-      'taro-vite-vue3-tailwindcss-v4',
-      'uni-app-vite-tailwindcss-v4',
-    ]
+    const prWebCases = [
+      ['taro-vite-react-tailwindcss-v4', 'web-only'],
+      ['taro-vite-vue3-tailwindcss-v4', 'web-only'],
+      ['uni-app-vite-tailwindcss-v4', 'default'],
+    ] as const
 
-    for (const name of prWebCaseNames) {
+    for (const [name, roundProfile] of prWebCases) {
       expect(
         prMatrixEntries,
         `${name} should run in PR quick gate on macOS`,
@@ -2976,7 +2976,7 @@ describe('watch-hmr regression cases', () => {
         os: 'macos-latest',
         runner_label: 'macos',
         watch_case: name,
-        round_profile: 'default',
+        round_profile: roundProfile,
         watch_web_only: '1',
       }))
     }

--- a/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
@@ -1387,6 +1387,29 @@ describe('watch-hmr regression cli options', () => {
     }
   })
 
+  it('enables mini-program-only mode for an explicit mini-program scope', () => {
+    const originalArgv = process.argv
+    process.argv = [
+      'node',
+      'watch-hmr-regression',
+      '--case',
+      'taro-vite-react-tailwindcss-v4',
+      '--mini-program-scope',
+      'subpackages',
+    ]
+
+    try {
+      expect(resolveOptions()).toMatchObject({
+        caseName: 'taro-vite-react-tailwindcss-v4',
+        miniProgramOnly: true,
+        miniProgramScope: 'subpackages',
+      })
+    }
+    finally {
+      process.argv = originalArgv
+    }
+  })
+
   it('ignores empty numeric environment variables from workflow matrix defaults', () => {
     const originalArgv = process.argv
     const originalLimit = process.env.E2E_WATCH_MAIN_STYLE_SUBPACKAGE_LIMIT
@@ -1735,6 +1758,7 @@ describe('watch-hmr regression summary helpers', () => {
       skipBuild: true,
       quietSass: true,
       webOnly: false,
+      miniProgramScope: 'main-package',
       styleOnly: false,
       mainStyleOnly: false,
       reportFile,
@@ -1759,6 +1783,7 @@ describe('watch-hmr regression summary helpers', () => {
     expect(report.repositoryRoot).toBe(path.basename(tempDir))
     expect(report.options.caseName).toBe('demo')
     expect(report.options.webOnly).toBe(false)
+    expect(report.options.miniProgramScope).toBe('main-package')
     expect(report.options.mainStyleOnly).toBe(false)
     expect(report.summary).toMatchObject({ count: 1, hotUpdateAvgMs: 30, rollbackAvgMs: 40 })
     expect(report.summaryByMutationKind.template).toMatchObject({ count: 1, hotUpdateAvgMs: 30 })

--- a/packages/weapp-tailwindcss/test/watch-hmr-runner.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-runner.unit.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { runCase, runMainStyleOnlyCase, WatchHmrPartialMetricsError } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/runner'
+import { runCase, runMainStyleOnlyCase, runSubPackagesOnlyCase, WatchHmrPartialMetricsError } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/runner'
 import type {
   CliOptions,
   MutationRoundMetrics,
@@ -14,6 +14,7 @@ const createWatchSessionMock = vi.fn<() => WatchSession>()
 const runClassMutationMock = vi.fn()
 const runStyleMutationMock = vi.fn()
 const runMainStyleHotUpdateMock = vi.fn()
+const runSubPackageMutationMock = vi.fn()
 
 vi.mock('../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/session', () => ({
   createWatchSession: () => createWatchSessionMock(),
@@ -40,7 +41,7 @@ vi.mock('../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/mutat
   runClassMutation: (...args: unknown[]) => runClassMutationMock(...args),
   runMainStyleHotUpdate: (...args: unknown[]) => runMainStyleHotUpdateMock(...args),
   runStyleMutation: (...args: unknown[]) => runStyleMutationMock(...args),
-  runSubPackageMutation: vi.fn(),
+  runSubPackageMutation: (...args: unknown[]) => runSubPackageMutationMock(...args),
   waitForInitialWarmup: vi.fn(async () => 3),
   waitForOutputsReady: vi.fn(async () => 2),
 }))
@@ -53,6 +54,7 @@ function createOptions(): CliOptions {
     skipBuild: true,
     quietSass: true,
     webOnly: false,
+    miniProgramOnly: false,
     styleOnly: false,
     mainStyleOnly: false,
   }
@@ -155,6 +157,7 @@ describe('watch-hmr runner', () => {
     createWatchSessionMock.mockReset()
     runClassMutationMock.mockReset()
     runMainStyleHotUpdateMock.mockReset()
+    runSubPackageMutationMock.mockReset()
     runStyleMutationMock.mockReset()
   })
 
@@ -357,6 +360,108 @@ describe('watch-hmr runner', () => {
       independent: false,
     })
     expect(session.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs normal and independent subpackages without repeating main-package mutations', async () => {
+    const sourceFile = path.join(tempDir, 'index.tsx')
+    const styleFile = path.join(tempDir, 'index.css')
+    const normalSubSource = path.join(tempDir, 'sub-normal.tsx')
+    const independentSubSource = path.join(tempDir, 'sub-independent.tsx')
+    for (const file of [sourceFile, styleFile, normalSubSource, independentSubSource]) {
+      await writeFile(file, 'export default "anchor"\n', 'utf8')
+    }
+    const session: WatchSession = {
+      child: {} as WatchSession['child'],
+      ensureRunning: vi.fn(),
+      lastCompileSuccessAt: vi.fn(() => 0),
+      logs: vi.fn(() => 'watch logs'),
+      memorySamplesSince: vi.fn(() => [
+        { at: 1, rssMb: 100, maxProcessRssMb: 90, processCount: 2 },
+      ]),
+      memoryDebugSamplesSince: vi.fn(() => []),
+      stop: vi.fn(async () => {}),
+      pluginProcessSamplesSince: vi.fn(() => []),
+    }
+    createWatchSessionMock.mockReturnValue(session)
+    runSubPackageMutationMock.mockImplementation((_watchCase: WatchCase, _options: CliOptions, _session: WatchSession, mutation: NonNullable<WatchCase['subPackageMutations']>[number]) => {
+      return Promise.resolve({
+        root: mutation.root,
+        independent: mutation.independent,
+        outputWxml: mutation.outputWxml,
+        outputJs: mutation.outputJs,
+        globalStyleOutputs: mutation.globalStyleCandidates,
+        template: createClassMetric('template', mutation.templateMutation.sourceFile),
+        style: createStyleMetric(mutation.styleMutation.sourceFile),
+      })
+    })
+
+    const createSubPackageMutation = (root: 'sub-normal' | 'sub-independent', sourcePath: string) => ({
+      root,
+      independent: root === 'sub-independent',
+      outputWxml: path.join(tempDir, `dist/${root}/index.wxml`),
+      outputJs: path.join(tempDir, `dist/${root}/index.js`),
+      outputStyleCandidates: [path.join(tempDir, `dist/${root}/index.wxss`)],
+      globalStyleCandidates: [path.join(tempDir, `dist/${root}/app.wxss`)],
+      templateMutation: {
+        sourceFile: sourcePath,
+        verifyEscapedIn: ['js'] as const,
+        mutate: (source: string) => source,
+      },
+      styleMutation: {
+        sourceFile: sourcePath,
+        mutate: (source: string) => source,
+      },
+    })
+    const watchCase: WatchCase = {
+      name: 'taro-vite-react-tailwindcss-v4',
+      label: 'demo/taro-vite-react-tailwindcss-v4',
+      project: 'demo/taro-vite-react-tailwindcss-v4',
+      group: 'demo',
+      cwd: tempDir,
+      devScript: 'dev:e2e-watch',
+      outputWxml: path.join(tempDir, 'dist/index.wxml'),
+      outputJs: path.join(tempDir, 'dist/index.js'),
+      outputStyleCandidates: [path.join(tempDir, 'dist/index.wxss')],
+      globalStyleCandidates: [path.join(tempDir, 'dist/app.wxss')],
+      templateMutation: {
+        sourceFile,
+        verifyEscapedIn: ['js'],
+        mutate: source => source,
+      },
+      scriptMutation: {
+        sourceFile,
+        verifyEscapedIn: ['js'],
+        mutate: source => source,
+      },
+      styleMutation: {
+        sourceFile: styleFile,
+        mutate: source => source,
+      },
+      subPackageMutations: [
+        createSubPackageMutation('sub-normal', normalSubSource),
+        createSubPackageMutation('sub-independent', independentSubSource),
+      ],
+    }
+
+    const result = await runSubPackagesOnlyCase(watchCase, {
+      ...createOptions(),
+      miniProgramOnly: true,
+      miniProgramScope: 'subpackages',
+    })
+
+    expect(runClassMutationMock).not.toHaveBeenCalled()
+    expect(runSubPackageMutationMock).toHaveBeenCalledTimes(2)
+    expect(result.subPackageMutationMetrics.map(metric => metric.root).sort()).toEqual([
+      'sub-independent',
+      'sub-normal',
+    ])
+    expect(result.mutationMetrics.map(metric => metric.mutationKind)).toEqual([
+      'template',
+      'style',
+      'template',
+      'style',
+    ])
+    expect(session.stop).toHaveBeenCalledTimes(2)
   })
 
   it('throws partial metrics when main-style-only fails after root metrics are collected', async () => {

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cli.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cli.ts
@@ -1,4 +1,4 @@
-import type { CliOptions } from './types'
+import type { CliOptions, MiniProgramScope } from './types'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -47,8 +47,21 @@ function parseBooleanEnv(name: string) {
   return value === '1' || value === 'true'
 }
 
+function parseMiniProgramScope(value: string | undefined): MiniProgramScope | undefined {
+  if (value == null || value.trim() === '') {
+    return undefined
+  }
+  if (value === 'main-package' || value === 'subpackages') {
+    return value
+  }
+  throw new Error(`invalid mini-program scope: ${value}`)
+}
+
 export function resolveOptions(): CliOptions {
   const argv = process.argv.slice(2)
+  const miniProgramScope = parseMiniProgramScope(
+    parseArg('--mini-program-scope', argv) ?? process.env.E2E_WATCH_MINI_PROGRAM_SCOPE,
+  )
   return {
     caseName: (parseArg('--case', argv) ?? 'all') as CliOptions['caseName'],
     timeoutMs: parseNumber(parseArg('--timeout', argv), 240000),
@@ -56,7 +69,10 @@ export function resolveOptions(): CliOptions {
     skipBuild: parseBooleanFlag('--skip-build', argv),
     quietSass: parseBooleanFlag('--quiet-sass', argv),
     webOnly: parseBooleanFlag('--web-only', argv),
-    miniProgramOnly: parseBooleanFlag('--mini-program-only', argv) || parseBooleanEnv('E2E_WATCH_MINI_PROGRAM_ONLY'),
+    miniProgramOnly: parseBooleanFlag('--mini-program-only', argv)
+      || parseBooleanEnv('E2E_WATCH_MINI_PROGRAM_ONLY')
+      || miniProgramScope != null,
+    miniProgramScope,
     styleOnly: parseBooleanFlag('--style-only', argv),
     mainStyleOnly: parseBooleanFlag('--main-style-only', argv),
     mainStyleSubPackageLimit: parseOptionalNumber(parseArg('--main-style-subpackage-limit', argv))

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/index.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { buildCases, isLocalOnlyWatchCase, pickCases } from './cases'
 import { formatPath, resolveBaseCwd, resolveOptions } from './cli'
-import { assertHotUpdateBudget, assertMemoryBudget, assertPluginProcessBudget, logSummary, runCase, runMainStyleOnlyCase, runWebOnlyCase, WatchHmrPartialMetricsError } from './runner'
+import { assertHotUpdateBudget, assertMemoryBudget, assertPluginProcessBudget, logSummary, runCase, runMainStyleOnlyCase, runSubPackagesOnlyCase, runWebOnlyCase, WatchHmrPartialMetricsError } from './runner'
 import { ensureLocalPackageBuild, sleep } from './session'
 import { runStyleOnlyCase } from './style-only'
 import {
@@ -61,13 +61,20 @@ export async function main() {
   try {
     for (const watchCase of selected) {
       process.stdout.write(`[watch-hmr] start ${watchCase.label} (${watchCase.devScript})\n`)
-      const result = options.mainStyleOnly
-        ? await runMainStyleOnlyCase(watchCase, options)
-        : options.styleOnly
-          ? (await runStyleOnlyCase(watchCase, options)).watchCaseMetrics
-          : options.webOnly
-            ? await runWebOnlyCase(watchCase, options)
-            : await runCase(watchCase, options)
+      const result = options.miniProgramScope === 'subpackages'
+        ? await runSubPackagesOnlyCase(watchCase, options)
+        : options.mainStyleOnly
+          ? await runMainStyleOnlyCase(watchCase, options)
+          : options.styleOnly
+            ? (await runStyleOnlyCase(watchCase, options)).watchCaseMetrics
+            : options.webOnly
+              ? await runWebOnlyCase(watchCase, options)
+              : await runCase(
+                  options.miniProgramScope === 'main-package'
+                    ? { ...watchCase, subPackageMutations: undefined }
+                    : watchCase,
+                  options,
+                )
       metrics.push(result)
       assertHotUpdateBudget(result, options)
       assertPluginProcessBudget(result, options)

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/runner.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/runner.ts
@@ -78,6 +78,7 @@ export class WatchHmrPartialMetricsError extends Error {
 
 interface SubPackageMutationRunResult {
   metric: WatchCaseMetrics['subPackageMutationMetrics'][number]
+  initialReadyMs: number
   memorySamples: ReturnType<WatchSession['memorySamplesSince']>
   memoryDebugSamples: ReturnType<WatchSession['memoryDebugSamplesSince']>
 }
@@ -112,8 +113,8 @@ async function runSubPackageMutationInNewSession(
   }, watchCase.env)
 
   try {
-    await waitForOutputsReady(subWatchCase, options, session, sessionStartedAt)
-    await waitForInitialWarmup(subWatchCase, options, session, sessionStartedAt)
+    const outputsReadyMs = await waitForOutputsReady(subWatchCase, options, session, sessionStartedAt)
+    const warmupMs = await waitForInitialWarmup(subWatchCase, options, session, sessionStartedAt)
     if ((watchCase.initialMutationDelayMs ?? 0) > 0) {
       process.stdout.write(
         `[watch-hmr] ${subWatchCase.label} split subpackage settle ${watchCase.initialMutationDelayMs}ms\n`,
@@ -132,6 +133,7 @@ async function runSubPackageMutationInNewSession(
 
     return {
       metric,
+      initialReadyMs: Math.max(outputsReadyMs, warmupMs),
       memorySamples: session.memorySamplesSince(sessionStartedAt),
       memoryDebugSamples: session.memoryDebugSamplesSince(sessionStartedAt),
     }
@@ -142,6 +144,105 @@ async function runSubPackageMutationInNewSession(
   }
   finally {
     await session.stop()
+  }
+}
+
+export async function runSubPackagesOnlyCase(watchCase: WatchCase, options: CliOptions): Promise<WatchCaseMetrics> {
+  const caseStartedAt = Date.now()
+  const subPackageMutations = watchCase.subPackageMutations ?? []
+  if (subPackageMutations.length === 0) {
+    throw new Error(`[${watchCase.label}] subpackages scope requires subPackageMutations`)
+  }
+
+  const sourceFiles = resolveCaseSourceFiles(watchCase)
+  const sourceOriginals = new Map<string, string>()
+  for (const sourceFile of sourceFiles) {
+    sourceOriginals.set(sourceFile, await fs.readFile(sourceFile, 'utf8'))
+  }
+
+  if (watchCase.initialBuildScript) {
+    process.stdout.write(`[watch-hmr] ${watchCase.label} prepare initial build (${watchCase.initialBuildScript})\n`)
+    await runPnpmCommand(watchCase.cwd, ['run', watchCase.initialBuildScript], 'prebuild')
+  }
+
+  try {
+    const results = []
+    for (const subPackageMutation of subPackageMutations) {
+      results.push(await runSubPackageMutationInNewSession(
+        watchCase,
+        options,
+        subPackageMutation,
+        sourceOriginals,
+      ))
+    }
+
+    const subPackageMutationMetrics = results.map(result => result.metric)
+    const mutationMetrics = subPackageMutationMetrics.flatMap(metric => [
+      metric.template,
+      ...(metric.style ? [metric.style] : []),
+    ])
+    const rounds = subPackageMutationMetrics.flatMap(metric => metric.template.rounds)
+    const preferredRound = resolvePreferredRound(subPackageMutationMetrics[0]!.template.rounds)
+    if (!preferredRound) {
+      throw new Error(`[${watchCase.label}] no preferred subpackage round produced`)
+    }
+    const memorySamples = results.flatMap(result => result.memorySamples)
+    const memoryDebugSamples = results.flatMap(result => result.memoryDebugSamples)
+    const memorySummary = summarizeMemorySamples(memorySamples)
+    const memoryDebugSummary = summarizeMemoryDebugSamples(memoryDebugSamples)
+    const globalStyleOutputs = [...new Set(subPackageMutationMetrics.flatMap(metric => metric.globalStyleOutputs))]
+
+    const metrics: WatchCaseMetrics = {
+      name: watchCase.name,
+      label: watchCase.label,
+      project: watchCase.project,
+      projectGroup: watchCase.group,
+      marker: preferredRound.marker,
+      classLiteral: preferredRound.classLiteral,
+      classTokens: preferredRound.classTokens,
+      escapedClasses: preferredRound.escapedClasses,
+      rounds,
+      verifyEscapedIn: subPackageMutationMetrics[0]!.template.verifyEscapedIn,
+      verifyClassLiteralIn: subPackageMutationMetrics[0]!.template.verifyClassLiteralIn,
+      globalStyleOutputs,
+      mutationMetrics,
+      subPackageMutationMetrics,
+      summaryByMutationKind: summarizeMutationMetricsByKind(mutationMetrics),
+      initialReadyMs: Math.max(...results.map(result => result.initialReadyMs)),
+      ...(watchCase.maxPluginProcessMs == null ? {} : { maxPluginProcessMs: watchCase.maxPluginProcessMs }),
+      hotUpdateOutputMs: preferredRound.hotUpdateOutputMs,
+      hotUpdateEffectiveMs: preferredRound.hotUpdateEffectiveMs,
+      hotUpdatePluginProcessMs: preferredRound.hotUpdatePluginProcessMs,
+      hotUpdatePluginProcessSamples: preferredRound.hotUpdatePluginProcessSamples,
+      rollbackOutputMs: preferredRound.rollbackOutputMs,
+      rollbackEffectiveMs: preferredRound.rollbackEffectiveMs,
+      rollbackPluginProcessMs: preferredRound.rollbackPluginProcessMs,
+      rollbackPluginProcessSamples: preferredRound.rollbackPluginProcessSamples,
+      totalMs: Date.now() - caseStartedAt,
+      memorySamples,
+      ...(memoryDebugSamples.length > 0 ? { memoryDebugSamples } : {}),
+      memorySummary,
+      memoryDebugSummary,
+      memoryPeakRssMb: memorySummary.peakRssMb,
+      memoryRssDeltaMb: memorySummary.rssDeltaMb,
+    }
+
+    process.stdout.write(
+      `[watch-hmr] ${watchCase.label} subpackages-only passed (subpackages=${subPackageMutationMetrics.length})\n`,
+    )
+    return metrics
+  }
+  finally {
+    for (const [sourcePath, original] of sourceOriginals.entries()) {
+      try {
+        const current = await fs.readFile(sourcePath, 'utf8')
+        if (current !== original) {
+          await writeFilePreserveEol(sourcePath, original, original)
+        }
+      }
+      catch {
+      }
+    }
   }
 }
 

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/summary.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/summary.ts
@@ -179,6 +179,7 @@ export async function writeReport(baseCwd: string, options: CliOptions, metrics:
       quietSass: options.quietSass,
       webOnly: options.webOnly,
       miniProgramOnly: options.miniProgramOnly,
+      miniProgramScope: options.miniProgramScope,
       styleOnly: options.styleOnly,
       mainStyleOnly: options.mainStyleOnly,
       mainStyleSubPackageLimit: options.mainStyleSubPackageLimit,

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types.ts
@@ -29,6 +29,7 @@ export const DEFAULT_PLUGIN_PROCESS_BUDGET_MS = 500
 export type MutationRoundName = typeof MUTATION_ROUND_NAMES[number]
 export type MutationKind = 'template' | 'script' | 'style' | 'content'
 export type ClassMutationKind = 'template' | 'script' | 'content'
+export type MiniProgramScope = 'main-package' | 'subpackages'
 
 export interface CliOptions {
   caseName: WatchCaseName
@@ -38,6 +39,7 @@ export interface CliOptions {
   quietSass: boolean
   webOnly: boolean
   miniProgramOnly: boolean
+  miniProgramScope?: MiniProgramScope
   styleOnly: boolean
   mainStyleOnly: boolean
   mainStyleSubPackageLimit?: number
@@ -809,6 +811,7 @@ export interface WatchReport {
     quietSass: boolean
     webOnly: boolean
     miniProgramOnly: boolean
+    miniProgramScope?: MiniProgramScope
     styleOnly: boolean
     mainStyleOnly: boolean
     mainStyleSubPackageLimit?: number


### PR DESCRIPTION
## 根因

uni-app 条件编译和选择器清理可能移除条件规则中的全部有效节点，但保留空的 `@media` / `@supports` 容器；同时 Vite 复用缓存 CSS asset 时会跳过 style handler，使空块直接进入最终 WXSS。

## 修复

- 使用 PostCSS AST 递归清理最终小程序 CSS 中的空块级 at-rule
- 覆盖缓存资产、普通资产和 style handler 返回结果三条 Vite 最终产物路径
- 显式区分最终构建与 watch 增量模式，保留 HMR 拼装需要的条件规则占位
- 使用线性预检避免对无空块候选的 CSS 做额外解析
- 保留 `@import`、`@charset` 和非空媒体查询
- 添加两个发布包的中文 patch changeset

## 验证

- `pnpm --filter @weapp-tailwindcss/postcss test -- --coverage.enabled=false`：626 passed，3 skipped
- PostCSS/Vite/生成器定向回归：255 passed
- `pnpm --filter @weapp-tailwindcss/postcss build`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm lint`
- `E2E_SKIP_OPEN_AUTOMATOR=1` uni-app Vite 微信小程序静态 E2E：2 passed
- 修复前后同一缓存产物探针：`count=0` 且保留两个空 media -> `count=1` 且仅保留有效 CSS

补充：核心包全量测试共 3031 passed、29 skipped；唯一失败为当前 `main` 的 watch CI profile 旧断言，和本 PR 修改文件无关。

Fixes #1005