### PR TITLE
fix: 修复 uni-app x Web 端 rem2rpx 输出

### DIFF
--- a/.changeset/fix-uni-app-x-web-rem2rpx.md
+++ b/.changeset/fix-uni-app-x-web-rem2rpx.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x 开启 `rem2rpx` 后 Web 端 `rpx` 任意值与字号工具类不生效的问题。

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -682,6 +682,15 @@ export const webCases: WebCase[] = [
           styles: { backgroundColor: 'rgb(67, 56, 202)', borderRadius: '13px', color: 'rgb(254, 243, 199)', width: '221px' },
         }],
       },
+      {
+        markerClass: 'hbuilderx-web-hmr-probe bg-[#0e7490] mt-[10rpx] text-xs',
+        markerText: 'hbuilderx-web-hmr-v4-rem-rpx',
+        cssContains: [/background-color:\s*#0e7490/, /\.mt-_b10rpx_B\s*\{[\s\S]*margin-top:\s*0\.3125rem/, /\.text-xs\s*\{[\s\S]*font-size:\s*0\.75rem/],
+        runtimeStyles: [{
+          selector: '.hbuilderx-web-hmr-probe',
+          styles: { backgroundColor: 'rgb(14, 116, 144)', fontSize: '12px', marginTop: '5px' },
+        }],
+      },
     ],
   },
 ]

--- a/packages/weapp-tailwindcss/src/context/style-options.ts
+++ b/packages/weapp-tailwindcss/src/context/style-options.ts
@@ -2,6 +2,7 @@ import type { IStyleHandlerOptions } from '@weapp-tailwindcss/postcss/types'
 import type { InternalUserDefinedOptions } from '@/types'
 import { normalizeWeappTailwindcssGeneratorOptions } from '@/generator'
 import { resolveGeneratorRuntimeBranch } from '@/runtime-branch'
+import { shouldUseUniAppWebRpxCompatibility } from '@/runtime-branch/generator-target-env'
 import { resolveUniAppXOptions } from '@/uni-app-x/options'
 
 export type ResolvedStyleOptions = Partial<IStyleHandlerOptions> & {
@@ -30,12 +31,16 @@ export function resolveStyleOptionsFromContext(
     uniAppX: resolvedUniAppXOptions,
   })
   const hasCssOptions = ctx.cssOptions !== undefined
+  const configuredRem2rpx = ctx.cssOptions?.rem2rpx ?? ctx.rem2rpx
+  const rem2rpx = branch.isWeb && shouldUseUniAppWebRpxCompatibility(ctx.appType)
+    ? false
+    : configuredRem2rpx
   const cssOptions = {
     cssPreflight: ctx.cssOptions?.cssPreflight ?? ctx.cssPreflight,
     cssPreflightRange: ctx.cssOptions?.cssPreflightRange ?? ctx.cssPreflightRange,
     cssChildCombinatorReplaceValue: ctx.cssOptions?.cssChildCombinatorReplaceValue ?? ctx.cssChildCombinatorReplaceValue,
     cssSelectorReplacement: ctx.cssOptions?.cssSelectorReplacement ?? ctx.cssSelectorReplacement,
-    rem2rpx: ctx.cssOptions?.rem2rpx ?? ctx.rem2rpx,
+    rem2rpx,
     cssRemoveProperty: ctx.cssOptions?.cssRemoveProperty ?? ctx.cssRemoveProperty,
     cssRemoveHoverPseudoClass: ctx.cssOptions?.cssRemoveHoverPseudoClass ?? ctx.cssRemoveHoverPseudoClass,
     tailwindcssV4GradientFallback: ctx.cssOptions?.tailwindcssV4GradientFallback ?? ctx.tailwindcssV4GradientFallback,

--- a/packages/weapp-tailwindcss/src/runtime-branch/generator-target-env.ts
+++ b/packages/weapp-tailwindcss/src/runtime-branch/generator-target-env.ts
@@ -72,6 +72,12 @@ export function shouldUseWebGeneratorTargetFromEnv(): boolean {
     || getEnvValue('TARO_ENV') === 'h5'
 }
 
+export function shouldUseUniAppWebRpxCompatibility(appType: string | undefined): boolean {
+  return appType === 'uni-app-vite'
+    || appType === 'uni-app-x'
+    || shouldUseWebGeneratorTargetFromEnv()
+}
+
 export function shouldUseUniAppViteWebViewGeneratorTarget(appType: string | undefined, platform: string | undefined = getEnvValue('UNI_PLATFORM')): boolean {
   return appType === 'uni-app-vite' && isUniAppWebViewPlatform(platform)
 }

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/generator/incremental-cache.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/generator/incremental-cache.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import { postcss } from '@weapp-tailwindcss/postcss'
 import { LRUCache } from 'lru-cache'
 import { hasCssMacroTailwindV4Source, withCssMacroStyleOptions } from '@/css-macro/auto'
-import { shouldUseWebGeneratorTargetFromEnv } from '@/runtime-branch/generator-target-env'
+import { shouldUseUniAppWebRpxCompatibility } from '@/runtime-branch/generator-target-env'
 import { filterUnsupportedMiniProgramTailwindV4Candidates } from '../candidates'
 import { loadTailwindV4DesignSystem } from '../design-system'
 import { normalizeRpxLengthCandidates } from './rpx-candidates'
@@ -279,7 +279,7 @@ function shouldNormalizeRpxLengthCandidatesForTarget(
     return true
   }
   const options = styleOptions as (Partial<IStyleHandlerOptions> & { appType?: string | undefined }) | undefined
-  return options?.appType === 'uni-app-vite' || shouldUseWebGeneratorTargetFromEnv()
+  return shouldUseUniAppWebRpxCompatibility(options?.appType)
 }
 
 export function normalizeTargetRpxLengthCandidates(

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/miniprogram.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/miniprogram.ts
@@ -3,7 +3,7 @@ import type { TailwindV4GenerateTarget } from './types'
 import type { AppType } from '@/types'
 import { createStyleHandler, normalizeTailwindcssWebRpxDeclarations, postcss, protectDynamicColorMixAlpha } from '@weapp-tailwindcss/postcss'
 import { hasCssMacroStyleOptions, transformCssMacroCss } from '@/css-macro/auto'
-import { shouldUseWebGeneratorTargetFromEnv } from '@/runtime-branch/generator-target-env'
+import { shouldUseUniAppWebRpxCompatibility } from '@/runtime-branch/generator-target-env'
 import { pruneMiniProgramGeneratedCss } from '../miniprogram'
 
 const defaultStyleHandler = createStyleHandler({
@@ -71,10 +71,6 @@ export function transformTailwindV4WebRpxCss(css: string) {
   }
 }
 
-function shouldTransformWebRpxCss(options: TailwindV4TargetStyleOptions | undefined) {
-  return options?.appType === 'uni-app-vite' || shouldUseWebGeneratorTargetFromEnv()
-}
-
 export async function transformTailwindV4CssByTarget(
   css: string,
   target: TailwindV4GenerateTarget,
@@ -88,7 +84,7 @@ export async function transformTailwindV4CssByTarget(
     ? transformCssMacroCss(css, options)
     : css
   const resolvedWebCss = await webCss
-  return shouldTransformWebRpxCss(options)
+  return shouldUseUniAppWebRpxCompatibility(options?.appType)
     ? transformTailwindV4WebRpxCss(resolvedWebCss)
     : resolvedWebCss
 }

--- a/packages/weapp-tailwindcss/test/context/handlers.test.ts
+++ b/packages/weapp-tailwindcss/test/context/handlers.test.ts
@@ -343,6 +343,29 @@ describe('resolveStyleOptionsFromContext', () => {
     expect(styleOptions).not.toHaveProperty('cssOptions')
   })
 
+  it('disables rem2rpx for uni-app x web output without changing native or generic web output', async () => {
+    const { resolveStyleOptionsFromContext } = await import('@/context/style-options')
+    const createRem2rpxContext = (
+      appType: InternalUserDefinedOptions['appType'],
+      target: 'web' | 'weapp',
+    ) => ({
+      ...createContext(),
+      appType,
+      cssOptions: undefined,
+      generator: { target },
+      rem2rpx: true,
+    }) as unknown as InternalUserDefinedOptions
+
+    const uniAppXWeb = resolveStyleOptionsFromContext(createRem2rpxContext('uni-app-x', 'web'), 4)
+    const uniAppXNative = resolveStyleOptionsFromContext(createRem2rpxContext('uni-app-x', 'weapp'), 4)
+    const genericWeb = resolveStyleOptionsFromContext(createRem2rpxContext('native', 'web'), 4)
+
+    expect(uniAppXWeb.rem2rpx).toBe(false)
+    expect(uniAppXWeb).not.toHaveProperty('cssOptions')
+    expect(uniAppXNative.rem2rpx).toBe(true)
+    expect(genericWeb.rem2rpx).toBe(true)
+  })
+
   it('enables uni-app x native style options only for native app branches', async () => {
     const { resolveStyleOptionsFromContext } = await import('@/context/style-options')
     const originalUniUtsPlatform = process.env.UNI_UTS_PLATFORM

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4-engine.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4-engine.test.ts
@@ -413,6 +413,41 @@ describe('tailwindcss v4 engine', () => {
     expect(result.css).not.toContain('--tw-ring-color: 8rpx')
   })
 
+  it('converts uni-app x web rpx utilities back to rem without changing native output', async () => {
+    const source = await resolveTailwindV4Source({
+      css: `
+        @theme inline {
+          --text-xs: 24rpx;
+        }
+        @tailwind utilities;
+      `,
+      base: process.cwd(),
+    })
+    const styleOptions = {
+      appType: 'uni-app-x' as const,
+      rem2rpx: true,
+    }
+
+    const webResult = await createTailwindV4Engine(source).generate({
+      candidates: ['mt-[10rpx]', 'text-xs'],
+      scanSources: false,
+      styleOptions,
+      target: 'web',
+    })
+    const nativeResult = await createTailwindV4Engine(source).generate({
+      candidates: ['mt-[10rpx]', 'text-xs'],
+      scanSources: false,
+      styleOptions,
+      target: 'weapp',
+    })
+
+    expect(webResult.css).toMatch(/\.mt-\\\[10rpx\\\]\s*\{[\s\S]*margin-top:\s*0\.3125rem/)
+    expect(webResult.css).toMatch(/\.text-xs\s*\{[\s\S]*font-size:\s*0\.75rem/)
+    expect(webResult.css).not.toMatch(/(?:margin-top|font-size):\s*\d+(?:\.\d+)?rpx/)
+    expect(nativeResult.css).toMatch(/\.mt-_b10rpx_B\s*\{[\s\S]*margin-top:\s*10rpx/)
+    expect(nativeResult.css).toMatch(/\.text-xs\s*\{[\s\S]*font-size:\s*24rpx/)
+  })
+
   it('treats scanned rpx arbitrary values as lengths in generated uni-app web css', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-web-rpx-length-'))
     const pageFile = path.join(root, 'src/pages/index/index.vue')
@@ -693,6 +728,42 @@ describe('tailwindcss v4 engine', () => {
     expect(second.css).not.toContain('background-color: 10rpx')
     expect(second.css).not.toContain('outline-color: 5rpx')
     expect(second.css).not.toContain('--tw-ring-color: 8rpx')
+  })
+
+  it('converts newly added uni-app x web rpx utilities in incremental css', async () => {
+    const source = await resolveTailwindV4Source({
+      css: `
+        @theme inline {
+          --text-xs: 24rpx;
+        }
+        @tailwind utilities;
+        /* uni-app x web rpx incremental */
+      `,
+      base: process.cwd(),
+    })
+    const engine = createTailwindV4Engine(source)
+    const generateOptions = {
+      incrementalCache: true,
+      scanSources: false,
+      styleOptions: {
+        appType: 'uni-app-x' as const,
+        rem2rpx: true,
+      },
+      target: 'web' as const,
+    }
+
+    const first = await engine.generate({
+      ...generateOptions,
+      candidates: ['text-xs'],
+    })
+    const second = await engine.generate({
+      ...generateOptions,
+      candidates: ['text-xs', 'mt-[10rpx]'],
+    })
+
+    expect(first.css).toMatch(/\.text-xs\s*\{[\s\S]*font-size:\s*0\.75rem/)
+    expect(second.incrementalCss).toMatch(/\.mt-\\\[10rpx\\\]\s*\{[\s\S]*margin-top:\s*0\.3125rem/)
+    expect(second.incrementalCss).not.toContain('margin-top: 10rpx')
   })
 
   it('remembers requested candidates that do not generate css in the v4 incremental cache', async () => {


### PR DESCRIPTION
## 问题

uni-app x 开启 rem2rpx 后，Web 输出中的 mt-[10rpx] 与 text-xs 仍为 rpx。浏览器无法识别这些声明，导致计算样式分别回退为 marginTop: 0px 与 fontSize: 16px。

## 根因与修复

- Tailwind v4 Web rpx 兼容门控只识别 uni-app-vite，遗漏 uni-app-x。
- engine 转回 rem 后，共享 styleHandler 又按 rem2rpx 配置将其转换回 rpx。
- 抽取统一的 uni-app Web rpx 兼容判断，并让全量、增量生成及 style options 共用。
- uni-app x Web 跳过第二次 rem2rpx，native/weapp 与普通 Web 行为保持不变。

## 回归覆盖

- 全量生成：10rpx 转为 0.3125rem，24rpx 转为 0.75rem。
- 增量/HMR：新增 mt-[10rpx] 后输出正确 rem。
- native/weapp：继续输出 10rpx 与 24rpx。
- HBuilderX Web：计算样式 marginTop 为 5px，fontSize 为 12px。

## 本地验证

- pnpm --filter weapp-tailwindcss exec vitest run test/context/handlers.test.ts test/tailwindcss/v4-engine.test.ts
- pnpm --filter weapp-tailwindcss exec vitest run test/hbuilderx-local-matrix.unit.test.ts
- pnpm e2e:hbuilderx:local:demo:web
- pnpm --filter weapp-tailwindcss build
- pnpm exec changeset status
- git diff --check

全包测试中 v4-vite-plugin 在并发环境下超过固定 60 秒超时；隔离运行 test/vite.test.ts 为 8 passed、2 skipped。Android e2e 未运行，因为本地没有 adb 设备，emulator-5554 不可用。

## 发布

- 为 weapp-tailwindcss 添加 patch changeset。
- 不涉及 create-weapp-vite、wevu 或 templates，无需联动版本。