### PR TITLE
fix(ci): 避免发版元数据触发 benchmark 误报

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -109,6 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
       - name: Download benchmark reports
         if: always()
         continue-on-error: true
@@ -126,20 +129,13 @@ jobs:
             exit 0
           fi
           echo "benchmark-shard result: $BENCHMARK_RESULT"
-          report_found=0
-          while IFS= read -r report; do
-            report_found=1
-            echo "::group::Benchmark report: $report"
-            echo "performance guard details:"
-            sed -n '/## 性能门禁/,/## 失败项/p' "$report" || true
-            sed -n '/## 失败项/,$p' "$report" || true
-            echo "::endgroup::"
-          done < <(find .tmp/benchmark-ci/artifacts -name report.md -type f -print 2>/dev/null | sort)
-          if [ "$report_found" = 0 ]; then
-            echo "::warning title=Benchmark diagnostics unavailable::No benchmark report artifact was available; inspect the failed shard log."
-          fi
+          node benchmark/version-compare/scripts/report-shard-failures.mjs .tmp/benchmark-ci/artifacts
 
       - name: Require every benchmark shard
         env:
           BENCHMARK_RESULT: ${{ needs.benchmark-shard.result }}
-        run: test "$BENCHMARK_RESULT" = success
+        run: |
+          if [ "$BENCHMARK_RESULT" != success ]; then
+            echo "::error title=Benchmark matrix failed::At least one benchmark shard failed. Review the Benchmark shard failure annotations above for the exact project and metric."
+          fi
+          test "$BENCHMARK_RESULT" = success

--- a/benchmark/version-compare/scripts/change-relevance.mjs
+++ b/benchmark/version-compare/scripts/change-relevance.mjs
@@ -1,0 +1,174 @@
+import { Buffer } from 'node:buffer'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
+
+const dependencyFields = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+const workspaceManifestPattern = /^(?:packages|packages-runtime)\/[^/]+\/package\.json$/
+
+export const performanceRelevantPaths = [
+  ':(glob)packages/*/src/**',
+  ':(glob)packages/*/package.json',
+  ':(glob)packages/*/tsconfig.json',
+  ':(glob)packages/*/tsdown.config.*',
+  ':(glob)packages-runtime/*/src/**',
+  ':(glob)packages-runtime/*/package.json',
+  ':(glob)packages-runtime/*/tsconfig.json',
+  ':(glob)packages-runtime/*/tsdown.config.*',
+  ':(glob)demo/**',
+  ':(glob)patches/**',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'turbo.json',
+]
+
+function isReleaseRangeChange(baselineSpec, currentSpec, versionTransition) {
+  const baselineVersion = versionTransition?.baseline
+  const currentVersion = versionTransition?.current
+  if (
+    typeof baselineVersion !== 'string'
+    || typeof currentVersion !== 'string'
+    || baselineVersion === currentVersion
+  ) {
+    return false
+  }
+  return baselineSpec.replaceAll(baselineVersion, '<released-version>')
+    === currentSpec.replaceAll(currentVersion, '<released-version>')
+}
+
+function normalizeManifestPair(baseline, current, workspaceVersionTransitions) {
+  const normalizedBaseline = structuredClone(baseline)
+  const normalizedCurrent = structuredClone(current)
+  delete normalizedBaseline.version
+  delete normalizedCurrent.version
+
+  for (const field of dependencyFields) {
+    const baselineDependencies = normalizedBaseline[field]
+    const currentDependencies = normalizedCurrent[field]
+    if (!baselineDependencies || !currentDependencies) {
+      continue
+    }
+    for (const [name, versionTransition] of workspaceVersionTransitions) {
+      if (
+        typeof baselineDependencies[name] === 'string'
+        && typeof currentDependencies[name] === 'string'
+        && isReleaseRangeChange(
+          baselineDependencies[name],
+          currentDependencies[name],
+          versionTransition,
+        )
+      ) {
+        baselineDependencies[name] = '<workspace-release-range>'
+        currentDependencies[name] = '<workspace-release-range>'
+      }
+    }
+  }
+
+  return [normalizedBaseline, normalizedCurrent]
+}
+
+export function hasPerformanceRelevantManifestChanges(baseline, current, workspaceVersionTransitions) {
+  if (!baseline || !current) {
+    return true
+  }
+  const normalized = normalizeManifestPair(baseline, current, workspaceVersionTransitions)
+  return !isDeepStrictEqual(...normalized)
+}
+
+export async function classifyChangedPerformanceFiles(changedFiles, readManifestPair) {
+  const manifestFiles = changedFiles.filter(file => workspaceManifestPattern.test(file))
+  const directRelevantFiles = changedFiles.filter(file => !workspaceManifestPattern.test(file))
+  const manifestPairs = new Map()
+  const workspaceVersionTransitions = new Map()
+
+  for (const file of manifestFiles) {
+    const pair = await readManifestPair(file)
+    manifestPairs.set(file, pair)
+    const name = pair?.current?.name ?? pair?.baseline?.name
+    if (typeof name === 'string') {
+      workspaceVersionTransitions.set(name, {
+        baseline: pair?.baseline?.version,
+        current: pair?.current?.version,
+      })
+    }
+  }
+
+  const relevantManifestFiles = []
+  const ignoredReleaseMetadataFiles = []
+  for (const file of manifestFiles) {
+    const pair = manifestPairs.get(file)
+    if (hasPerformanceRelevantManifestChanges(pair?.baseline, pair?.current, workspaceVersionTransitions)) {
+      relevantManifestFiles.push(file)
+    }
+    else {
+      ignoredReleaseMetadataFiles.push(file)
+    }
+  }
+
+  const relevantFiles = [...directRelevantFiles, ...relevantManifestFiles].sort()
+  return {
+    relevant: relevantFiles.length > 0,
+    relevantFiles,
+    ignoredReleaseMetadataFiles: ignoredReleaseMetadataFiles.sort(),
+  }
+}
+
+async function captureGit(repoRoot, args, { allowFailure = false } = {}) {
+  const child = spawn('git', args, {
+    cwd: repoRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const stdout = []
+  const stderr = []
+  child.stdout.on('data', chunk => stdout.push(chunk))
+  child.stderr.on('data', chunk => stderr.push(chunk))
+  const code = await new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', exitCode => resolve(exitCode ?? 1))
+  })
+  if (code !== 0 && !allowFailure) {
+    throw new Error(`git ${args.join(' ')} failed with code ${code}\n${Buffer.concat(stderr).toString('utf8')}`)
+  }
+  return {
+    code,
+    stdout: Buffer.concat(stdout),
+  }
+}
+
+async function readManifestAtRef(repoRoot, ref, file) {
+  const result = await captureGit(repoRoot, ['show', `${ref}:${file}`], { allowFailure: true })
+  if (result.code !== 0) {
+    return undefined
+  }
+  return JSON.parse(result.stdout.toString('utf8'))
+}
+
+async function readCurrentManifest(repoRoot, file) {
+  try {
+    return JSON.parse(await fs.readFile(path.join(repoRoot, file), 'utf8'))
+  }
+  catch (error) {
+    if (error?.code === 'ENOENT') {
+      return undefined
+    }
+    throw error
+  }
+}
+
+export async function classifyPerformanceChanges(repoRoot, ref) {
+  const diff = await captureGit(repoRoot, ['diff', '--name-only', '-z', ref, '--', ...performanceRelevantPaths])
+  const changedFiles = diff.stdout.toString('utf8').split('\0').filter(Boolean)
+  return classifyChangedPerformanceFiles(changedFiles, async file => ({
+    baseline: await readManifestAtRef(repoRoot, ref, file),
+    current: await readCurrentManifest(repoRoot, file),
+  }))
+}
+
+export function summarizeFiles(files, limit = 8) {
+  if (files.length <= limit) {
+    return files.join(', ')
+  }
+  return `${files.slice(0, limit).join(', ')} 等 ${files.length} 个文件`
+}

--- a/benchmark/version-compare/scripts/ci-report.mjs
+++ b/benchmark/version-compare/scripts/ci-report.mjs
@@ -577,6 +577,7 @@ export function toMarkdown(summary, baselineSpec) {
         `- 结果：${guard.passed ? '通过' : '失败'}`,
         `- 门禁模式：${guard.blocking === false ? '仅记录' : '阻断'}`,
         ...(guard.skipReason ? [`- 仅记录原因：${guard.skipReason}`] : []),
+        ...(guard.relevantChanges?.length ? [`- 阻断依据：检测到性能相关变更：${guard.relevantChanges.join(', ')}`] : []),
         `- 统一退化阈值：${guard.thresholds.regressionPercent}%`,
         `- 时间回归绝对下限：${fmtMs(guard.thresholds.minimumTimingRegressionMs)}ms`,
         `- 内存回归绝对下限：${fmtMs(guard.thresholds.minimumMemoryRegressionMb)}MB`,

--- a/benchmark/version-compare/scripts/report-shard-failures.mjs
+++ b/benchmark/version-compare/scripts/report-shard-failures.mjs
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+function formatNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(2) : '-'
+}
+
+function formatPercent(value, signed = true) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${signed && value >= 0 ? '+' : ''}${value.toFixed(2)}%` : '-'
+}
+
+function formatViolation(item) {
+  if (item.message) {
+    return `${item.key} / ${item.metric}: ${item.message}`
+  }
+  return `${item.key} / ${item.metric}: ${formatNumber(item.baseline)} -> ${formatNumber(item.current)} (${formatPercent(item.deltaPercent)}, threshold ${formatPercent(item.thresholdPercent, false)})`
+}
+
+export function collectBenchmarkDiagnostics(summary, source = 'summary.json') {
+  const diagnostics = []
+  for (const item of summary.currentOnlyErrors ?? []) {
+    diagnostics.push(`${source}: ${item.key}: ${String(item.error)}`)
+  }
+  if (summary.performanceGuard?.passed === false) {
+    for (const item of summary.performanceGuard.violations ?? []) {
+      diagnostics.push(`${source}: ${formatViolation(item)}`)
+    }
+  }
+  return diagnostics
+}
+
+function escapeAnnotation(value) {
+  return value
+    .replaceAll('%', '%25')
+    .replaceAll('\r', '%0D')
+    .replaceAll('\n', '%0A')
+}
+
+export function formatGitHubErrorAnnotation(message) {
+  return `::error title=Benchmark shard failure::${escapeAnnotation(message)}`
+}
+
+async function findSummaryFiles(root) {
+  const files = []
+  for (const entry of await fs.readdir(root, { withFileTypes: true })) {
+    const file = path.join(root, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await findSummaryFiles(file))
+    }
+    else if (entry.name === 'summary.json') {
+      files.push(file)
+    }
+  }
+  return files
+}
+
+async function main() {
+  const root = path.resolve(process.argv[2] ?? '.tmp/benchmark-ci/artifacts')
+  let summaryFiles = []
+  try {
+    summaryFiles = await findSummaryFiles(root)
+  }
+  catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error
+    }
+  }
+
+  if (summaryFiles.length === 0) {
+    process.stdout.write('::warning title=Benchmark diagnostics unavailable::No benchmark summary artifact was available; inspect the failed shard log.\n')
+    return
+  }
+
+  let diagnosticCount = 0
+  for (const file of summaryFiles.sort()) {
+    const summary = JSON.parse(await fs.readFile(file, 'utf8'))
+    for (const diagnostic of collectBenchmarkDiagnostics(summary, path.relative(root, file))) {
+      diagnosticCount += 1
+      process.stdout.write(`${formatGitHubErrorAnnotation(diagnostic)}\n`)
+    }
+  }
+  if (diagnosticCount === 0) {
+    process.stdout.write('::warning title=Benchmark shard failed without a reported regression::The shard exited unsuccessfully, but its summaries contain no current-only error or blocking performance violation. Inspect the failed shard log.\n')
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/benchmark/version-compare/scripts/run-ci.mjs
+++ b/benchmark/version-compare/scripts/run-ci.mjs
@@ -4,6 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { classifyPerformanceChanges, performanceRelevantPaths, summarizeFiles } from './change-relevance.mjs'
 import { asInformationalPerformanceGuard, buildSummary, evaluatePerformanceGuard, toMarkdown } from './ci-report.mjs'
 import { benchmarkProjectDirs } from './projects.mjs'
 
@@ -15,23 +16,6 @@ const dependencyFields = ['dependencies', 'devDependencies', 'peerDependencies',
 const publishedResolverDependencyNames = [
   '@weapp-core/escape',
 ]
-const performanceRelevantPaths = [
-  ':(glob)packages/*/src/**',
-  ':(glob)packages/*/package.json',
-  ':(glob)packages/*/tsconfig.json',
-  ':(glob)packages/*/tsdown.config.*',
-  ':(glob)packages-runtime/*/src/**',
-  ':(glob)packages-runtime/*/package.json',
-  ':(glob)packages-runtime/*/tsconfig.json',
-  ':(glob)packages-runtime/*/tsdown.config.*',
-  ':(glob)demo/**',
-  ':(glob)patches/**',
-  'package.json',
-  'pnpm-lock.yaml',
-  'pnpm-workspace.yaml',
-  'turbo.json',
-]
-
 function parseArg(name, fallback = '') {
   const index = process.argv.indexOf(name)
   return index === -1 ? fallback : (process.argv[index + 1] ?? fallback)
@@ -507,9 +491,10 @@ async function main() {
   await run(repoRoot, process.execPath, matrixArgs)
 
   const raw = JSON.parse(await fs.readFile(rawPath, 'utf8'))
-  const performanceRelevantChanges = baselineRef
-    ? await hasGitChanges(baselineRef, performanceRelevantPaths)
-    : true
+  const performanceChanges = baselineRef
+    ? await classifyPerformanceChanges(repoRoot, baselineRef)
+    : { relevant: true, relevantFiles: performanceRelevantPaths, ignoredReleaseMetadataFiles: [] }
+  const performanceRelevantChanges = performanceChanges.relevant
   if (baselineRef && !process.argv.includes('--skip-core-metrics')) {
     const coreMetricSpecs = [
       {
@@ -550,10 +535,17 @@ async function main() {
     const performanceGuard = evaluatePerformanceGuard(summary, {
       regressionPercent: parseNumber('--regression-percent', 5),
     })
+    const relevantFiles = summarizeFiles(performanceChanges.relevantFiles)
+    const ignoredFiles = summarizeFiles(performanceChanges.ignoredReleaseMetadataFiles)
+    const informationalReason = ignoredFiles
+      ? `PR 仅修改版本号或内部包发布范围等发版元数据：${ignoredFiles}`
+      : 'PR 未修改性能相关源码、依赖或 demo'
     summary.performanceGuard = performanceRelevantChanges
-      ? { ...performanceGuard, blocking: true }
-      : asInformationalPerformanceGuard(performanceGuard, 'PR 未修改性能相关源码、依赖或 demo')
+      ? { ...performanceGuard, blocking: true, relevantChanges: performanceChanges.relevantFiles }
+      : asInformationalPerformanceGuard(performanceGuard, informationalReason)
     process.stdout.write(`[benchmark] performance guard mode: ${performanceRelevantChanges ? 'blocking' : 'informational'}\n`)
+    process.stdout.write(`[benchmark] performance relevant files: ${relevantFiles || 'none'}\n`)
+    process.stdout.write(`[benchmark] ignored release metadata files: ${ignoredFiles || 'none'}\n`)
   }
   const markdown = toMarkdown(summary, baselineRef || baseline)
   await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')

--- a/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
@@ -76,6 +76,7 @@ describe('benchmark ci report', () => {
     expect(source).toContain('skip unchanged core metric')
     expect(source).toContain('performance guard violation')
     expect(source).toContain('performanceRelevantPaths')
+    expect(source).toContain('classifyPerformanceChanges')
     expect(source).toContain('asInformationalPerformanceGuard')
     expect(source.match(/hmrPluginStatistic: 'median'/g)).toHaveLength(3)
     expect(source).toContain("parseNumber('--poll-interval', 30)")
@@ -93,6 +94,72 @@ describe('benchmark ci report', () => {
     const versionLoopIndex = matrixSource.indexOf('for (const versionMeta of versions)', projectLoopIndex)
     expect(projectLoopIndex).toBeGreaterThan(-1)
     expect(versionLoopIndex).toBeGreaterThan(projectLoopIndex)
+  })
+
+  it('keeps Changesets release metadata non-blocking while preserving real dependency guards', async () => {
+    const { classifyChangedPerformanceFiles } = await import('../../../../benchmark/version-compare/scripts/change-relevance.mjs')
+    const manifests = new Map([
+      ['packages/weapp-tailwindcss/package.json', {
+        baseline: { name: 'weapp-tailwindcss', version: '5.2.0', dependencies: { '@weapp-core/escape': '^3.0.0' } },
+        current: { name: 'weapp-tailwindcss', version: '5.2.1', dependencies: { '@weapp-core/escape': '^3.0.0' } },
+      }],
+      ['packages/build-all/package.json', {
+        baseline: { name: '@weapp-tailwindcss/build-all', version: '1.0.0', dependencies: { 'weapp-tailwindcss': 'workspace:^5.2.0' } },
+        current: { name: '@weapp-tailwindcss/build-all', version: '1.0.1', dependencies: { 'weapp-tailwindcss': 'workspace:^5.2.1' } },
+      }],
+    ])
+    const releaseFiles = [...manifests.keys()]
+    const releaseResult = await classifyChangedPerformanceFiles(releaseFiles, async file => manifests.get(file))
+
+    expect(releaseResult).toEqual({
+      relevant: false,
+      relevantFiles: [],
+      ignoredReleaseMetadataFiles: releaseFiles.sort(),
+    })
+
+    manifests.set('packages/weapp-tailwindcss/package.json', {
+      baseline: { name: 'weapp-tailwindcss', version: '5.2.0', dependencies: { '@weapp-core/escape': '^3.0.0' } },
+      current: { name: 'weapp-tailwindcss', version: '5.2.1', dependencies: { '@weapp-core/escape': '^4.0.0' } },
+    })
+    const dependencyResult = await classifyChangedPerformanceFiles(releaseFiles, async file => manifests.get(file))
+
+    expect(dependencyResult.relevant).toBe(true)
+    expect(dependencyResult.relevantFiles).toEqual(['packages/weapp-tailwindcss/package.json'])
+
+    manifests.set('packages/weapp-tailwindcss/package.json', {
+      baseline: { name: 'weapp-tailwindcss', version: '5.2.0' },
+      current: { name: 'weapp-tailwindcss', version: '5.2.0' },
+    })
+    manifests.set('packages/build-all/package.json', {
+      baseline: { name: '@weapp-tailwindcss/build-all', version: '1.0.0', dependencies: { 'weapp-tailwindcss': 'workspace:^5.2.0' } },
+      current: { name: '@weapp-tailwindcss/build-all', version: '1.0.1', dependencies: { 'weapp-tailwindcss': 'workspace:^6.0.0' } },
+    })
+    const manualRangeResult = await classifyChangedPerformanceFiles(releaseFiles, async file => manifests.get(file))
+
+    expect(manualRangeResult.relevantFiles).toEqual(['packages/build-all/package.json'])
+  })
+
+  it('formats benchmark shard regressions as actionable GitHub annotations', async () => {
+    const { collectBenchmarkDiagnostics, formatGitHubErrorAnnotation } = await import('../../../../benchmark/version-compare/scripts/report-shard-failures.mjs')
+    const diagnostics = collectBenchmarkDiagnostics({
+      currentOnlyErrors: [],
+      performanceGuard: {
+        passed: false,
+        violations: [{
+          key: 'demo-taro-webpack-react-tailwindcss-v4__mp-weixin',
+          metric: 'hmrSteadyRssMb',
+          baseline: 1911.27,
+          current: 2118.32,
+          deltaPercent: 10.83,
+          thresholdPercent: 5,
+        }],
+      },
+    }, 'benchmark-performance-taro-webpack-react/summary.json')
+
+    expect(diagnostics).toEqual([
+      'benchmark-performance-taro-webpack-react/summary.json: demo-taro-webpack-react-tailwindcss-v4__mp-weixin / hmrSteadyRssMb: 1911.27 -> 2118.32 (+10.83%, threshold 5.00%)',
+    ])
+    expect(formatGitHubErrorAnnotation(diagnostics[0])).toContain('::error title=Benchmark shard failure::')
   })
 
   it('extracts plugin processing time from structured Vite and Webpack timing logs', async () => {
@@ -244,6 +311,7 @@ describe('benchmark ci report', () => {
       performanceGuard: result,
     }, 'main')
     expect(markdown).toContain('- 门禁模式：仅记录')
+    expect(markdown).toContain('- 仅记录原因：PR 未修改性能相关源码、依赖或 demo')
     expect(markdown).toContain('- 观察项：1')
     expect(markdown).toContain('demo-mpx-tailwindcss-v4__mp-weixin / hmrPeakRssMb')
   })

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -469,8 +469,11 @@ describe('ci workflows', () => {
     expect(workflow.jobs['current-vs-published'].needs).toBe('benchmark-shard')
     const publishedRuns = stepRuns(workflow, 'current-vs-published').join('\n')
     expect(publishedRuns).toContain('test "$BENCHMARK_RESULT" = success')
-    expect(publishedRuns).toContain('Benchmark report: $report')
-    expect(publishedRuns).toContain('performance guard')
+    expect(publishedRuns).toContain('report-shard-failures.mjs')
+    expect(publishedRuns).toContain('Benchmark matrix failed')
+    expect(workflow.jobs['current-vs-published'].steps.some((step: Record<string, unknown>) => {
+      return step.uses === 'actions/checkout@v6'
+    })).toBe(true)
     expect(workflow.jobs['current-vs-published'].steps.some((step: Record<string, unknown>) => {
       return step.uses === 'actions/download-artifact@v4'
         && (step.with as Record<string, unknown>)?.pattern === 'benchmark-performance-*'


### PR DESCRIPTION
## Summary

修复 Changesets 纯发版 PR 被 benchmark 错误识别为性能相关变更的问题，并让 benchmark 汇总 job 直接输出可操作的 GitHub 错误注解。

关联失败：
- actions/runs/30027343473/job/89275494695
- actions/runs/30027343473/job/89282500255

## Root cause

PR #1008 的 diff 只有 Changeset 删除、CHANGELOG 更新和 5 个 workspace package 版本号更新，但旧逻辑只按文件路径判断，任何 `packages/*/package.json` 变化都会启用阻断门禁。共享 runner 上 Taro Webpack watch RSS 的约 10.8% 波动因此被误判为真实回归；构建、HMR 和插件时间均无回归。

## Changes

- 对 workspace manifest 做结构化比较，忽略纯版本号和能精确对应同批包版本发布的内部依赖范围调整。
- 外部依赖、脚本、源码、demo、构建配置和手工内部依赖范围变更仍保持阻断。
- 在报告中记录门禁判定依据和被忽略的发布元数据文件。
- 汇总 job 读取 `summary.json`，为每个真实失败输出项目、指标、基线、当前值和阈值的 GitHub error annotation。
- 增加 Changesets 发版、真实依赖变化、手工内部范围变化和失败注解的回归测试。

## Testing

- `pnpm --filter weapp-tailwindcss exec vitest run test/ci/benchmark-report.test.ts test/ci/workflows.test.ts` (54 passed)
- 新脚本 `node --check` 通过
- 新脚本严格 ESLint 校验通过
- 使用 run 30027343473 的真实基线提交复验：5 个 package manifest 均判定为非阻断发版元数据
- 使用 job 89275494695 的真实 artifact 复验：输出两条包含 RSS 基线、当前值与 5% 阈值的错误注解

## Notes

`pnpm test:core` 本地全量运行遇到两个与本次 CI 脚本改动无关的既有用例问题：浏览器视觉等价测试失败，以及 Vite template-delete watch 用例 60 秒超时并遗留进程；已终止该次全量运行，定向 CI 回归测试已再次通过。