### PR TITLE
fix(uni-app-x): 保留 HBuilderX 作者变量 fallback

### DIFF
--- a/.changeset/issue-902-hbuilderx-variable-fallback.md
+++ b/.changeset/issue-902-hbuilderx-variable-fallback.md
@@ -1,0 +1,6 @@
+---
+'@weapp-tailwindcss/postcss': patch
+weapp-tailwindcss: patch
+---
+
+修复 uni-app x uvue 产物中作者 CSS 变量 fallback 不兼容 HBuilderX 的问题，同时保留静态 fallback 与运行时变量覆盖能力。

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -275,7 +275,7 @@ function createUniAppXHBuilderXMiniProgramCase(options: {
       '.bg-_b_hf21903_B',
       '.text-_b_hda0e3c_B',
       '.bg-primary',
-      /background-color:\s*var\(--theme-color,\s*#0957de\)/i,
+      /background-color:\s*#0957de\s*;\s*background-color:\s*var\(--theme-color\)/i,
       /--theme-color:\s*#16a34a/i,
       '.w-64',
     ],

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -275,7 +275,7 @@ function createUniAppXHBuilderXMiniProgramCase(options: {
       '.bg-_b_hf21903_B',
       '.text-_b_hda0e3c_B',
       '.bg-primary',
-      /background-color:\s*#0957de\s*;\s*background-color:\s*var\(--theme-color\)/i,
+      /background-color:\s*var\(--theme-color,\s*#0957de\)/i,
       /--theme-color:\s*#16a34a/i,
       '.w-64',
     ],

--- a/packages/postcss/src/compat/uni-app-x-uvue/theme.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue/theme.ts
@@ -99,6 +99,67 @@ function resolveThemeValue(
   return parsed.toString()
 }
 
+function getUnresolvedAuthorVariableFallback(value: string) {
+  const parsed = valueParser(value)
+  const nodes = parsed.nodes.filter(node => node.type !== 'space' && node.type !== 'comment')
+  const variable = nodes.length === 1 ? nodes[0] : undefined
+  if (variable?.type !== 'function' || variable.value.toLowerCase() !== 'var') {
+    return undefined
+  }
+
+  const variableNode = variable.nodes.find(node => node.type === 'word')
+  const commaIndex = variable.nodes.findIndex(node => node.type === 'div' && node.value === ',')
+  if (
+    variableNode?.type !== 'word'
+    || !variableNode.value.startsWith('--')
+    || isTailwindcssV4ThemeVariable(variableNode.value)
+    || variableNode.value.startsWith('--default-')
+    || commaIndex < 0
+  ) {
+    return undefined
+  }
+
+  const fallback = valueParser.stringify(variable.nodes.slice(commaIndex + 1)).trim()
+  if (!fallback) {
+    return undefined
+  }
+
+  return {
+    name: variableNode.value,
+    fallback,
+  }
+}
+
+/**
+ * HBuilderX 不接受带 fallback 的 var() 声明，拆成静态 fallback 与动态变量两条声明。
+ */
+export function splitUnresolvedAuthorVariableFallbacks(
+  root: Root,
+  variables: ReadonlyMap<string, string>,
+) {
+  if (typeof root.walkDecls !== 'function') {
+    return false
+  }
+
+  let changed = false
+  root.walkDecls((decl) => {
+    if (decl.prop.startsWith('--')) {
+      return
+    }
+
+    const unresolved = getUnresolvedAuthorVariableFallback(decl.value)
+    if (!unresolved || variables.has(unresolved.name)) {
+      return
+    }
+
+    decl.parent?.insertBefore(decl, decl.clone({ value: unresolved.fallback }))
+    decl.value = `var(${unresolved.name})`
+    changed = true
+  })
+
+  return changed
+}
+
 /**
  * UVUE 不支持 Tailwind 的混合根选择器，因此先把根作用域中的静态主题 token
  * 内联到实际 utility，再移除仅用于变量承载的系统规则。
@@ -131,6 +192,8 @@ export function consumeUniAppXSystemRootTheme(
       decl.value = resolveThemeValue(decl.value, variables)
     })
   }
+
+  splitUnresolvedAuthorVariableFallbacks(root, variables)
 
   for (const rule of carrierRules) {
     rule.remove()

--- a/packages/postcss/src/handler.ts
+++ b/packages/postcss/src/handler.ts
@@ -7,6 +7,7 @@ import { LRUCache } from 'lru-cache'
 import postcss from 'postcss'
 import { protectDynamicColorMixAlpha, protectDynamicVarFallbacks } from './compat/color-mix'
 import { removeEmptyBlockAtRules } from './compat/mini-program-css/root-cleanups'
+import { splitUnresolvedAuthorVariableFallbacks } from './compat/uni-app-x-uvue/theme'
 import { probeFeatures, signalToCacheKey } from './content-probe'
 import { getDefaultOptions } from './defaults'
 import { fingerprintOptions } from './fingerprint'
@@ -92,7 +93,7 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
     opt?: Partial<IStyleHandlerOptions>,
   ) {
     const resolvedOptions = resolver.resolve(opt)
-    const protectedVarFallbacks = resolvedOptions.uniAppX && resolvedOptions.uniAppXCssTarget === 'uvue'
+    const protectedVarFallbacks = resolvedOptions.uniAppX
       ? protectDynamicVarFallbacks(rawSource)
       : {
           css: rawSource,
@@ -158,6 +159,12 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
           nextResult.root = postcss.parse(restoredCss, finalResult.opts)
           nextResult.messages.push(...finalResult.messages)
           finalResult = nextResult
+        }
+      }
+      if (resolvedOptions.uniAppX && finalResult.root) {
+        const changed = splitUnresolvedAuthorVariableFallbacks(finalResult.root, new Map())
+        if (changed) {
+          finalResult.css = finalResult.root.toString()
         }
       }
       // 缓存最终结果

--- a/packages/postcss/src/handler.ts
+++ b/packages/postcss/src/handler.ts
@@ -93,7 +93,10 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
     opt?: Partial<IStyleHandlerOptions>,
   ) {
     const resolvedOptions = resolver.resolve(opt)
-    const protectedVarFallbacks = resolvedOptions.uniAppX
+    // uni-app x 的 WebView/小程序目标也会复用 preserve:false 的 preset，
+    // 需要先保护作者变量，否则主题 fallback 会在生成阶段被静态化。
+    const isUniAppXFramework = resolvedOptions.appType === 'uni-app-x'
+    const protectedVarFallbacks = resolvedOptions.uniAppX || isUniAppXFramework
       ? protectDynamicVarFallbacks(rawSource)
       : {
           css: rawSource,
@@ -161,7 +164,9 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
           finalResult = nextResult
         }
       }
-      if (resolvedOptions.uniAppX && finalResult.root) {
+      const shouldSplitAuthorVariableFallbacks = resolvedOptions.uniAppX
+        && (resolvedOptions.uniAppXCssTarget === 'uvue' || !isUniAppXFramework)
+      if (shouldSplitAuthorVariableFallbacks && finalResult.root) {
         const changed = splitUnresolvedAuthorVariableFallbacks(finalResult.root, new Map())
         if (changed) {
           finalResult.css = finalResult.root.toString()

--- a/packages/postcss/test/color-mix-compat.test.ts
+++ b/packages/postcss/test/color-mix-compat.test.ts
@@ -173,7 +173,7 @@ describe('color-mix compatibility helpers', () => {
         },
       },
     })(source)
-    expect(result.css).toContain('background-color:var(--theme-color, #0957DE)')
+    expect(result.css).toContain('background-color:#0957DE;background-color:var(--theme-color)')
     expect(result.css).toContain('font-size:0.75rem')
     expect(result.css).toContain('color:#fff')
     expect(result.css).not.toContain('var(--text-xs')

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -182,10 +182,56 @@ describe('uni-app-x', () => {
     })
 
     expect(filtered.css).toBe([
-      '.text-brand{color:var(--runtime-brand, #0957DE)}',
+      '.text-brand{color:#0957DE;color:var(--runtime-brand)}',
       '.issue-1002{font-size:0.75rem;color:#fff}',
     ].join('\n'))
     expect(filtered.warnings()).toEqual([])
+  })
+
+  it('splits protected author variable fallbacks after full uvue processing', async () => {
+    const styleHandler = createStyleHandler({
+      appType: 'uni-app-x',
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+      majorVersion: 4,
+      cssPresetEnv: {
+        features: {
+          'custom-properties': { preserve: false },
+        },
+      },
+    })
+    const result = await styleHandler(
+      ':root,:host{--color-brand:var(--runtime-brand, #0957DE)}.text-brand{color:var(--color-brand)}',
+      {
+        isMainChunk: false,
+        postcssOptions: {
+          options: {
+            from: '/src/App.uvue',
+          },
+        },
+      },
+    )
+
+    expect(result.css).toContain('.text-brand{color:#0957DE;color:var(--runtime-brand)}')
+    expect(result.css).not.toContain(':root')
+    expect(result.warnings()).toEqual([])
+  })
+
+  it('splits author variable fallbacks for non-uvue uni-app x targets', async () => {
+    const styleHandler = createStyleHandler({
+      appType: 'uni-app-x',
+      uniAppX: true,
+      majorVersion: 4,
+      cssPresetEnv: {
+        features: {
+          'custom-properties': { preserve: false },
+        },
+      },
+    })
+    const result = await styleHandler('.bg-primary{background-color:var(--theme-color, #0957DE)}')
+
+    expect(result.css).toContain('background-color:#0957DE;background-color:var(--theme-color)')
   })
 
   it('filters unsupported uvue selectors and declarations with warnings', async () => {

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -220,7 +220,6 @@ describe('uni-app-x', () => {
 
   it('splits author variable fallbacks for non-uvue uni-app x targets', async () => {
     const styleHandler = createStyleHandler({
-      appType: 'uni-app-x',
       uniAppX: true,
       majorVersion: 4,
       cssPresetEnv: {
@@ -232,6 +231,23 @@ describe('uni-app-x', () => {
     const result = await styleHandler('.bg-primary{background-color:var(--theme-color, #0957DE)}')
 
     expect(result.css).toContain('background-color:#0957DE;background-color:var(--theme-color)')
+  })
+
+  it('preserves author variable fallbacks when uni-app x uses a WebView target', async () => {
+    const styleHandler = createStyleHandler({
+      appType: 'uni-app-x',
+      uniAppX: false,
+      majorVersion: 4,
+      cssPresetEnv: {
+        features: {
+          'custom-properties': { preserve: false },
+        },
+      },
+    })
+    const result = await styleHandler('.bg-primary{background-color:var(--theme-color, #0957DE)}')
+
+    expect(result.css).toContain('background-color:var(--theme-color, #0957DE)')
+    expect(result.css).not.toContain('background-color:#0957DE;background-color:var(--theme-color)')
   })
 
   it('filters unsupported uvue selectors and declarations with warnings', async () => {


### PR DESCRIPTION
## 变更

- 保护 uni-app x 各 CSS 目标中的作者变量 fallback，避免兼容处理提前静态化。
- 将未解析的 `var(--theme-color, #0957DE)` 输出为 fallback + `var(--theme-color)` 两条声明，兼容 HBuilderX 并保留运行时覆盖。
- 补充 uvue、非 uvue handler 回归和 HBuilderX mp-weixin 产物断言。

## 验证

- `pnpm --filter @weapp-tailwindcss/postcss test -- test/uni-app-x.test.ts test/color-mix-compat.test.ts test/coverage-defensive.test.ts test/v4.test.ts`
- `pnpm build:ci`
- ESLint / `git diff --check`
- HBuilderX 5.15 CLI：实际编译成功并生成 mp-weixin 产物；CLI 在成功后未退出，runner 因此超时，已记录为环境问题。

Closes #902
