### PR TITLE
fix(postcss): 修复 unitsToPx 的 CJS 兼容

### DIFF
--- a/.changeset/issue-1021-cjs-units-to-px.md
+++ b/.changeset/issue-1021-cjs-units-to-px.md
@@ -1,0 +1,6 @@
+---
+'@weapp-tailwindcss/postcss': patch
+'weapp-tailwindcss': patch
+---
+
+修复 uni-app x 使用 `unitsToPx` 时 CommonJS 构建无法加载单位转换插件，避免 HBuilderX 编译直接中断。

--- a/.changeset/issue-1021-cjs-units-to-px.md
+++ b/.changeset/issue-1021-cjs-units-to-px.md
@@ -3,4 +3,4 @@
 'weapp-tailwindcss': patch
 ---
 
-修复 uni-app x 使用 `unitsToPx` 时 CommonJS 构建无法加载单位转换插件，避免 HBuilderX 编译直接中断。
+修复 uni-app x 使用 `unitsToPx` 时 CommonJS 构建无法加载单位转换插件，避免 HBuilderX 编译直接中断；升级相关 PostCSS 单位转换插件并使用其兼容的 CommonJS 导出。

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -92,7 +92,7 @@
     "postcss-preset-env": "^11.3.2",
     "postcss-pxtrans": "^1.0.4",
     "postcss-rem-to-responsive-pixel": "catalog:postcssRem",
-    "postcss-rule-unit-converter": "^0.2.2",
+    "postcss-rule-unit-converter": "^0.2.3",
     "postcss-selector-parser": "~7.1.4",
     "postcss-value-parser": "^4.2.0",
     "tailwindcss-config": "workspace:*"

--- a/packages/postcss/test/tsdown-config.test.ts
+++ b/packages/postcss/test/tsdown-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createPostcssTsdownConfigs,
+  postcssCjsBundleDependencies,
   postcssEsmOnlyDependencies,
 } from '../tsdown.config.mts'
 
@@ -9,7 +10,7 @@ function matchesDependency(patterns: Array<RegExp | string>, id: string) {
 }
 
 describe('postcss tsdown config', () => {
-  it('externalizes ESM dependencies and bundles synchronous ESM-only CJS dependencies', () => {
+  it('keeps ESM externals separate from CJS bundle dependencies', () => {
     const [esm, cjs] = createPostcssTsdownConfigs()
 
     expect(esm.format).toEqual(['esm'])
@@ -19,9 +20,11 @@ describe('postcss tsdown config', () => {
     expect(cjs.format).toEqual(['cjs'])
     expect(cjs.clean).toBe(false)
     expect(cjs.dts).toBe(false)
-    expect(cjs.deps?.alwaysBundle).toBe(postcssEsmOnlyDependencies)
+    expect(cjs.deps?.alwaysBundle).toBe(postcssCjsBundleDependencies)
     expect(matchesDependency(postcssEsmOnlyDependencies, '@csstools/css-color-parser')).toBe(true)
     expect(matchesDependency(postcssEsmOnlyDependencies, 'postcss-preset-env')).toBe(true)
+    expect(matchesDependency(postcssEsmOnlyDependencies, 'postcss-rule-unit-converter')).toBe(false)
+    expect(matchesDependency(postcssCjsBundleDependencies, 'postcss-rule-unit-converter')).toBe(true)
   })
 
   it('emits .js/.cjs and disables clean while watching', () => {

--- a/packages/postcss/test/tsdown-config.test.ts
+++ b/packages/postcss/test/tsdown-config.test.ts
@@ -1,7 +1,7 @@
+import { createRequire } from 'node:module'
 import { describe, expect, it } from 'vitest'
 import {
   createPostcssTsdownConfigs,
-  postcssCjsBundleDependencies,
   postcssEsmOnlyDependencies,
 } from '../tsdown.config.mts'
 
@@ -9,8 +9,10 @@ function matchesDependency(patterns: Array<RegExp | string>, id: string) {
   return patterns.some(pattern => typeof pattern === 'string' ? pattern === id : pattern.test(id))
 }
 
+const require = createRequire(import.meta.url)
+
 describe('postcss tsdown config', () => {
-  it('keeps ESM externals separate from CJS bundle dependencies', () => {
+  it('keeps the same external dependencies in ESM and CJS builds', () => {
     const [esm, cjs] = createPostcssTsdownConfigs()
 
     expect(esm.format).toEqual(['esm'])
@@ -20,11 +22,11 @@ describe('postcss tsdown config', () => {
     expect(cjs.format).toEqual(['cjs'])
     expect(cjs.clean).toBe(false)
     expect(cjs.dts).toBe(false)
-    expect(cjs.deps?.alwaysBundle).toBe(postcssCjsBundleDependencies)
+    expect(cjs.deps?.neverBundle).toBe(postcssEsmOnlyDependencies)
     expect(matchesDependency(postcssEsmOnlyDependencies, '@csstools/css-color-parser')).toBe(true)
     expect(matchesDependency(postcssEsmOnlyDependencies, 'postcss-preset-env')).toBe(true)
     expect(matchesDependency(postcssEsmOnlyDependencies, 'postcss-rule-unit-converter')).toBe(false)
-    expect(matchesDependency(postcssCjsBundleDependencies, 'postcss-rule-unit-converter')).toBe(true)
+    expect(cjs.deps?.alwaysBundle).toBeUndefined()
   })
 
   it('emits .js/.cjs and disables clean while watching', () => {
@@ -33,5 +35,21 @@ describe('postcss tsdown config', () => {
     expect(esm.outExtensions?.({ format: 'es' } as never).js).toBe('.js')
     expect(esm.outExtensions?.({ format: 'cjs' } as never).js).toBe('.cjs')
     expect(createPostcssTsdownConfigs({ watch: true }).every(config => config.clean === false)).toBe(true)
+  })
+
+  it('loads the bundled PostCSS unit plugins as CJS functions', () => {
+    for (const packageName of [
+      'postcss-rule-unit-converter',
+      'postcss-rem-to-responsive-pixel',
+      'postcss-pxtrans',
+    ]) {
+      const plugin = require(packageName)
+
+      expect(typeof plugin, packageName).toBe('function')
+      expect(plugin.__esModule, packageName).toBeUndefined()
+    }
+
+    const unitConverter = require('postcss-rule-unit-converter')
+    expect(unitConverter.default).toBe(unitConverter)
   })
 })

--- a/packages/postcss/test/units-to-px.test.ts
+++ b/packages/postcss/test/units-to-px.test.ts
@@ -30,6 +30,29 @@ describe('unitsToPx', () => {
     expect(css).not.toContain('2rpx')
   })
 
+  it('converts units in uni-app x uvue output without leaving infinity calc values', async () => {
+    const styleHandler = createStyleHandler({
+      appType: 'uni-app-x',
+      majorVersion: 4,
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+      unitsToPx: true,
+    })
+
+    const result = await styleHandler(
+      '.rounded-full{border-radius:calc(infinity * 1px)}.a{margin:2rem;padding:2rpx;width:10vw}',
+      { isMainChunk: true },
+    )
+
+    expect(result.css).toContain('border-radius:9999px')
+    expect(result.css).toContain('margin:32px')
+    expect(result.css).toContain('padding:1px')
+    expect(result.css).toContain('width:37.5px')
+    expect(result.css).not.toContain('calc(infinity')
+    expect(result.warnings()).toEqual([])
+  })
+
   it('preserves custom unitMap and transform fallback behavior', async () => {
     const styleHandler = createStyleHandler({
       unitsToPx: {

--- a/packages/postcss/tsdown.config.mts
+++ b/packages/postcss/tsdown.config.mts
@@ -13,11 +13,6 @@ export const postcssEsmOnlyDependencies = [
   'postcss-preset-env',
 ]
 
-export const postcssCjsBundleDependencies = [
-  ...postcssEsmOnlyDependencies,
-  'postcss-rule-unit-converter',
-]
-
 const sharedOptions = {
   entry: ['src/index.ts', 'src/types.ts', 'src/html-transform.ts', 'src/css-macro/postcss.ts'],
   shims: true,
@@ -49,7 +44,7 @@ export function createPostcssTsdownConfigs(options: WatchAwareOptions = {}) {
       format: ['cjs'],
       clean: false,
       deps: {
-        alwaysBundle: postcssCjsBundleDependencies,
+        neverBundle: postcssEsmOnlyDependencies,
         onlyBundle: false,
       },
     },

--- a/packages/postcss/tsdown.config.mts
+++ b/packages/postcss/tsdown.config.mts
@@ -13,6 +13,11 @@ export const postcssEsmOnlyDependencies = [
   'postcss-preset-env',
 ]
 
+export const postcssCjsBundleDependencies = [
+  ...postcssEsmOnlyDependencies,
+  'postcss-rule-unit-converter',
+]
+
 const sharedOptions = {
   entry: ['src/index.ts', 'src/types.ts', 'src/html-transform.ts', 'src/css-macro/postcss.ts'],
   shims: true,
@@ -44,7 +49,7 @@ export function createPostcssTsdownConfigs(options: WatchAwareOptions = {}) {
       format: ['cjs'],
       clean: false,
       deps: {
-        alwaysBundle: postcssEsmOnlyDependencies,
+        alwaysBundle: postcssCjsBundleDependencies,
         onlyBundle: false,
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ catalogs:
       version: 8.5.22
   postcssRem:
     postcss-rem-to-responsive-pixel:
-      specifier: ^7.0.4
-      version: 7.0.4
+      specifier: ^7.0.5
+      version: 7.0.5
   postcssRpx:
     postcss-rpx-transform:
       specifier: ^1.0.1
@@ -1135,7 +1135,7 @@ importers:
         version: 4.2.1(postcss@8.5.22)
       postcss-rem-to-responsive-pixel:
         specifier: catalog:postcssRem
-        version: 7.0.4(postcss@8.5.22)
+        version: 7.0.5(postcss@8.5.22)
       postcss-rpx-transform:
         specifier: catalog:postcssRpx
         version: 1.0.1
@@ -4133,7 +4133,7 @@ importers:
         version: 1.0.4(postcss@8.5.22)
       postcss-rem-to-responsive-pixel:
         specifier: catalog:postcssRem
-        version: 7.0.4(postcss@8.5.22)
+        version: 7.0.5(postcss@8.5.22)
       postcss-rule-unit-converter:
         specifier: ^0.2.3
         version: 0.2.3(postcss@8.5.22)
@@ -27474,8 +27474,8 @@ packages:
     peerDependencies:
       postcss: ^8.5.15
 
-  postcss-rem-to-responsive-pixel@7.0.4:
-    resolution: {integrity: sha512-KLWSuwZotO0RBRboavb1Ui0W1EjempzgnvvNJqQ2BOduTBIiJJhrizZpglVBkcwF3EXqhRv/kER0zHi+Wxr5Mg==}
+  postcss-rem-to-responsive-pixel@7.0.5:
+    resolution: {integrity: sha512-EDXfF/U0jzcK2ojeQB5SuB0SUwyX0Wc9ilvmpbW86Vxgq0wv98e1PclxDR/IPFPyDbJdkaBQJ1XewnuaOFA51w==}
     engines: {node: '>=16.6.0'}
     peerDependencies:
       postcss: ^8
@@ -65539,10 +65539,10 @@ snapshots:
       postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
-  postcss-rem-to-responsive-pixel@7.0.4(postcss@8.5.22):
+  postcss-rem-to-responsive-pixel@7.0.5(postcss@8.5.22):
     dependencies:
       postcss: 8.5.22
-      postcss-plugin-shared: 1.1.4(postcss@8.5.22)
+      postcss-plugin-shared: 1.1.5(postcss@8.5.22)
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.5.22):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4135,8 +4135,8 @@ importers:
         specifier: catalog:postcssRem
         version: 7.0.4(postcss@8.5.22)
       postcss-rule-unit-converter:
-        specifier: ^0.2.2
-        version: 0.2.2(postcss@8.5.22)
+        specifier: ^0.2.3
+        version: 0.2.3(postcss@8.5.22)
       postcss-selector-parser:
         specifier: ~7.1.4
         version: 7.1.4
@@ -27497,8 +27497,8 @@ packages:
   postcss-rpx-transform@1.0.1:
     resolution: {integrity: sha512-BYEUOUWwzsBJChvGJYRDEiJ8IErhNrO4G4hnBgDtSub9KM529iVE4mlli3iFeyU2k8gPPNFnqrLrFv5OjtNZnQ==}
 
-  postcss-rule-unit-converter@0.2.2:
-    resolution: {integrity: sha512-6+/zbOOPLLThV/8hBz8tU8ftcGw6VEpwdtpdJMyfUZllsinmRc1cUDI5B9AWkkOThCI+IcnJS8he4zkERQnEOA==}
+  postcss-rule-unit-converter@0.2.3:
+    resolution: {integrity: sha512-FCcbnjkWkIMP/9ZRAjuYMza6wkpnJ476F8R5cSSFwI46qVZQ2wGmpYkEFxMTatp2pk8uvPTOlk1bfR2gI45Sjg==}
     peerDependencies:
       postcss: ^8
 
@@ -65558,7 +65558,7 @@ snapshots:
 
   postcss-rpx-transform@1.0.1: {}
 
-  postcss-rule-unit-converter@0.2.2(postcss@8.5.22):
+  postcss-rule-unit-converter@0.2.3(postcss@8.5.22):
     dependencies:
       postcss: 8.5.22
       postcss-plugin-shared: 1.1.5(postcss@8.5.22)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalogs:
   postcssComment2:
     postcss-comment: ^2.0.0
   postcssRem:
-    postcss-rem-to-responsive-pixel: ^7.0.4
+    postcss-rem-to-responsive-pixel: ^7.0.5
   postcssRpx:
     postcss-rpx-transform: ^1.0.1
   prettier371:


### PR DESCRIPTION
## 关联问题

Fixes #1021

## 问题

在 HBuilderX 的 uni-app x CommonJS 同步 `require()` 链路中，`unitsToPx: true` 会导致 `postcss-rule-unit-converter` 被错误包装，最终出现 `default is not a function`，使编译直接中断。

## 根因

旧版 `postcss-rule-unit-converter` 的 CommonJS 产物带有 `__esModule`，而 `@weapp-tailwindcss/postcss` 的 CJS 构建又通过 `__toESM(require(...), 1)` 包装该依赖，导致 `.default` 指向模块对象而不是插件函数。

上游已发布兼容的 `postcss-rule-unit-converter@0.2.3`，其 CommonJS 入口直接返回可调用的插件函数，因此不再需要在本包 CJS 产物中强制内联该依赖。

## 变更内容

- 移除 `postcss-rule-unit-converter` 的 CJS `alwaysBundle` 配置。
- 让 ESM 和 CJS 构建统一使用外置依赖策略，继续外置 ESM-only 依赖。
- 将 `postcss-rem-to-responsive-pixel` 升级至 `7.0.5`；`postcss-pxtrans` 已是当前最新版本 `1.0.4`。
- 增加构建配置回归测试，确认三个单位转换插件均可通过 CommonJS 加载为函数。
- 增加 uni-app x / UVUE `unitsToPx` 回归覆盖，验证 `calc(infinity * 1px)`、`rem`、`rpx` 和 `vw` 转换。
- 更新中文 changeset 和锁文件。

## 本地验证

- `pnpm --filter @weapp-tailwindcss/postcss exec vitest run test/tsdown-config.test.ts test/units-to-px.test.ts`
- `pnpm --filter @weapp-tailwindcss/postcss test`（634 passed，3 skipped）
- `pnpm --filter @weapp-tailwindcss/postcss lint`
- `pnpm --filter @weapp-tailwindcss/postcss build`
- 真实 CJS smoke test：`require('./packages/postcss/dist/index.cjs')` 成功处理 uni-app x UVUE 样式。

## CI

GitHub Actions 已触发完整的 Release、CI、Benchmark 和 E2E Watch 矩阵。首次 Benchmark 仅 `taro-vite-react` 的 `buildPeakRssMb` 样本触发门禁（`1830.77 -> 1966.80 MB`，`+7.43%`）；其余 Benchmark shard 通过，构建耗时、插件耗时和 HMR 指标无对应回归。该失败任务已启动 failure-only 重跑，当前等待 GitHub runner 调度。
