### PR TITLE
fix: 修复 uni-app x uvue scoped 作者样式误删

### DIFF
--- a/.changeset/fifty-gorillas-lie.md
+++ b/.changeset/fifty-gorillas-lie.md
@@ -1,0 +1,6 @@
+---
+"@weapp-tailwindcss/postcss": patch
+"weapp-tailwindcss": patch
+---
+
+修复 `uni-app x` 在 `uniAppXCssTarget: 'uvue'` 下误删 `uvue` 组件 `<style scoped>` 作者样式的问题。现在会保留 scoped 组件样式，同时继续清理 `uvue` 不兼容声明和 scoped 请求里的 Tailwind 注入噪音。

--- a/e2e/demo-visual-theme.test.ts
+++ b/e2e/demo-visual-theme.test.ts
@@ -64,9 +64,10 @@ describe('demo visual theme evidence', () => {
     }
   })
 
-  it('uses the issue #822 component-local style probe on Android and iOS without a manual isolation override', async () => {
+  it('uses the issue #822 component-local style probe on every target without a manual isolation override', async () => {
     const android = uniAppXAppCases.find(item => item.platform === 'app-android')
     const ios = uniAppXAppCases.find(item => item.platform === 'app-ios')
+    const harmony = uniAppXAppCases.find(item => item.platform === 'app-harmony')
     const miniProgram = miniProgramCases.find(item => item.name === 'uni-app-x-hbuilderx-tailwindcss-v4')
     const web = webCases.find(item => item.name === 'uni-app-x-hbuilderx-tailwindcss-v4')
     const component = await fs.readFile(path.resolve('demo/uni-app-x-hbuilderx-tailwindcss-v4/components/BindClass.uvue'), 'utf8')
@@ -80,11 +81,17 @@ describe('demo visual theme evidence', () => {
     expect(android?.sourceFile).toBe('components/BindClass.uvue')
     expect(android?.transformedOutputFiles).toContain('components/BindClass.uvue.ts')
     expect(android?.compiledStyleContains?.some(item => item instanceof RegExp && item.source.includes('"issue-822-component-child"'))).toBe(true)
-    expect(android?.compiledStyleContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"\\s*:\\s*"#7c3aed"'))).toBe(true)
+    expect(android?.compiledStyleContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopStyle"') && item.source.includes('solid'))).toBe(true)
+    expect(android?.compiledStyleContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"') && item.source.includes('#7c3aed'))).toBe(true)
     expect(ios?.sourceFile).toBe('components/BindClass.uvue')
     expect(ios?.markerAnchor).toBe('<text :class="flag')
     expect(ios?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"issue-822-component-child"'))).toBe(true)
-    expect(ios?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"\\s*:\\s*"#7c3aed"'))).toBe(true)
+    expect(ios?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"') && item.source.includes('#7c3aed'))).toBe(true)
+    expect(harmony?.requiredFiles).toContain('assets/components/BindClass.js')
+    expect(harmony?.transformedOutputFiles).toContain('assets/components/BindClass.js')
+    expect(harmony?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"issue-822-component-child"'))).toBe(true)
+    expect(harmony?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopStyle"') && item.source.includes('solid'))).toBe(true)
+    expect(harmony?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"') && item.source.includes('#7c3aed'))).toBe(true)
     expect(miniProgram?.outputContains?.['components/BindClass.js']).toEqual(expect.arrayContaining(['__scopeId', 'data-v-']))
     expect(miniProgram?.outputContains?.['components/BindClass.wxml']).toEqual(expect.arrayContaining(['issue-822-component-child']))
     expect(miniProgram?.outputContains?.['components/BindClass.wxml']?.some(item => item instanceof RegExp && item.source.includes('data-v-'))).toBe(true)

--- a/e2e/demo-visual-theme.test.ts
+++ b/e2e/demo-visual-theme.test.ts
@@ -7,7 +7,7 @@ import { createArtifactVisualSeed, createPortAwareCommand, disableDevToolsCompil
 import { parseWechatDevToolsWindowBounds } from '../scripts/demo-visual-e2e-report/ide'
 import { createHmrComparisons, mergeCaseResults } from '../scripts/demo-visual-e2e-report/report'
 import { analyzeThemeCss, countDarkPixels } from '../scripts/demo-visual-e2e-report/theme'
-import { uniAppXAppCases } from './hbuilderx-local/cases'
+import { miniProgramCases, uniAppXAppCases, webCases } from './hbuilderx-local/cases'
 
 describe('demo visual theme evidence', () => {
   it('uses each web case command and resolves its dynamic port', () => {
@@ -67,6 +67,8 @@ describe('demo visual theme evidence', () => {
   it('uses the issue #822 component-local style probe on Android and iOS without a manual isolation override', async () => {
     const android = uniAppXAppCases.find(item => item.platform === 'app-android')
     const ios = uniAppXAppCases.find(item => item.platform === 'app-ios')
+    const miniProgram = miniProgramCases.find(item => item.name === 'uni-app-x-hbuilderx-tailwindcss-v4')
+    const web = webCases.find(item => item.name === 'uni-app-x-hbuilderx-tailwindcss-v4')
     const component = await fs.readFile(path.resolve('demo/uni-app-x-hbuilderx-tailwindcss-v4/components/BindClass.uvue'), 'utf8')
 
     expect(component).toContain('class="issue-822-component-child h-[200px] w-full bg-[#87add3]"')
@@ -77,8 +79,25 @@ describe('demo visual theme evidence', () => {
     expect(android?.requiredFiles).toContain('App.uvue.ts')
     expect(android?.sourceFile).toBe('components/BindClass.uvue')
     expect(android?.transformedOutputFiles).toContain('components/BindClass.uvue.ts')
+    expect(android?.compiledStyleContains?.some(item => item instanceof RegExp && item.source.includes('"issue-822-component-child"'))).toBe(true)
+    expect(android?.compiledStyleContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"\\s*:\\s*"#7c3aed"'))).toBe(true)
     expect(ios?.sourceFile).toBe('components/BindClass.uvue')
     expect(ios?.markerAnchor).toBe('<text :class="flag')
+    expect(ios?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"issue-822-component-child"'))).toBe(true)
+    expect(ios?.transformedContains?.some(item => item instanceof RegExp && item.source.includes('"borderTopColor"\\s*:\\s*"#7c3aed"'))).toBe(true)
+    expect(miniProgram?.outputContains?.['components/BindClass.js']).toEqual(expect.arrayContaining(['__scopeId', 'data-v-']))
+    expect(miniProgram?.outputContains?.['components/BindClass.wxml']).toEqual(expect.arrayContaining(['issue-822-component-child']))
+    expect(miniProgram?.outputContains?.['components/BindClass.wxml']?.some(item => item instanceof RegExp && item.source.includes('data-v-'))).toBe(true)
+    expect(web?.initialRuntimeStyles).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        selector: '.issue-822-component-child',
+        styles: expect.objectContaining({
+          borderTopColor: 'rgb(124, 58, 237)',
+          borderTopStyle: 'solid',
+          borderTopWidth: '2px',
+        }),
+      }),
+    ]))
   })
 
   it('keeps issue #1002 utilities in the uni-app x native runtime probes', async () => {

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -507,8 +507,9 @@ export const uniAppXAppCases: AppCase[] = [
     transformedContains: ['hbuilderx-app-dynamic-v4-android'],
     compiledStyleContains: [
       'issue 822 component child',
-      /"issue-822-component-child"\s*:\s*\{\s*""\s*:\s*\{\s*"borderTopWidth"\s*:\s*2/,
-      /"borderTopColor"\s*:\s*"#7c3aed"/,
+      /\["issue-822-component-child",\s*_pS\(_uM\(\[\["borderTopWidth",\s*2\]/,
+      /\["borderTopStyle",\s*"solid"\]/,
+      /\["borderTopColor",\s*"#7c3aed"\]/,
       '["--theme-color", "#16a34a"]',
       '["backgroundColor", "var(--theme-color)"]',
       /\["wtu-[^"]+", _pS\(_uM\(\[\["width", "100%"\]/,
@@ -613,6 +614,7 @@ export const uniAppXAppCases: AppCase[] = [
     requiredFiles: [
       'manifest.json',
       'app-service.js',
+      'assets/components/BindClass.js',
       'assets/pages/index/index.js',
     ],
     transformedFiles: [
@@ -620,9 +622,15 @@ export const uniAppXAppCases: AppCase[] = [
       'unpackage/dist/dev/.app-harmony/assets/App.js',
       'unpackage/dist/dev/.app-harmony/assets/pages/index/index.js',
     ],
+    transformedOutputFiles: [
+      'assets/components/BindClass.js',
+    ],
     transformedContains: [
       ...harmonyInitialTransformedContains,
       'hbuilderx-app-dynamic-v4-harmony',
+      /"issue-822-component-child"\s*:\s*\{\s*""\s*:\s*\{\s*"borderTopWidth"\s*:\s*2/,
+      /"borderTopStyle"\s*:\s*"solid"/,
+      /"borderTopColor"\s*:\s*"#7c3aed"/,
       /--theme-color["']?\s*[:,]\s*["']?#16a34a/i,
       /backgroundColor["']?\s*[:,]\s*["']var\(--theme-color,\s*#0957DE\)/i,
     ],

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -282,6 +282,8 @@ function createUniAppXHBuilderXMiniProgramCase(options: {
     cssNotContains: [rawTailwindDirectiveRE, ...unsafeMiniProgramSelectorFragments],
     outputContains: {
       'app.json': ['"root": "sub-normal"', '"root": "sub-independent"', '"independent": true'],
+      'components/BindClass.js': ['__scopeId', 'data-v-'],
+      'components/BindClass.wxml': ['issue-822-component-child', /data-v-[\da-f]+/],
       [platformFiles.templateFiles.main]: ['issue-902-theme-probe', 'bg-primary'],
       [platformFiles.templateFiles.independent]: ['bg-independent-subpackage-marker'],
       [platformFiles.templateFiles.normal]: ['bg-normal-subpackage-marker'],
@@ -505,6 +507,8 @@ export const uniAppXAppCases: AppCase[] = [
     transformedContains: ['hbuilderx-app-dynamic-v4-android'],
     compiledStyleContains: [
       'issue 822 component child',
+      /"issue-822-component-child"\s*:\s*\{\s*""\s*:\s*\{\s*"borderTopWidth"\s*:\s*2/,
+      /"borderTopColor"\s*:\s*"#7c3aed"/,
       '["--theme-color", "#16a34a"]',
       '["backgroundColor", "var(--theme-color)"]',
       /\["wtu-[^"]+", _pS\(_uM\(\[\["width", "100%"\]/,
@@ -572,6 +576,8 @@ export const uniAppXAppCases: AppCase[] = [
       'text-_b_hf7fbff_B',
       'w-_b173px_B',
       'hbuilderx-app-dynamic-v4-ios',
+      /"issue-822-component-child"\s*:\s*\{\s*""\s*:\s*\{\s*"borderTopWidth"\s*:\s*2/,
+      /"borderTopColor"\s*:\s*"#7c3aed"/,
       /--theme-color["']?\s*[:,]\s*["']?#16a34a/i,
       /backgroundColor["']?\s*[:,]\s*["']var\(--theme-color\)/i,
       'issue 822 component child',
@@ -715,6 +721,14 @@ export const webCases: WebCase[] = [
         selector: '.issue-902-theme-probe',
         styles: {
           backgroundColor: 'rgb(22, 163, 74)',
+        },
+      },
+      {
+        selector: '.issue-822-component-child',
+        styles: {
+          borderTopColor: 'rgb(124, 58, 237)',
+          borderTopStyle: 'solid',
+          borderTopWidth: '2px',
         },
       },
     ],

--- a/packages/postcss/src/compat/uni-app-x-uvue.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue.ts
@@ -1,4 +1,4 @@
-import type { Result as PostcssResult, Rule } from 'postcss'
+import type { AtRule, Result as PostcssResult, Rule } from 'postcss'
 import type { IStyleHandlerOptions, UniAppXUnsupportedMode } from '../types'
 import postcssCalc from '@weapp-tailwindcss/postcss-calc'
 import postcss from 'postcss'
@@ -10,7 +10,12 @@ import { consumeUniAppXSystemRootTheme } from './uni-app-x-uvue/theme'
 const ALLOWED_DISPLAY_VALUES = new Set(['flex', 'none'])
 const FALLBACK_CLASS_RE = /\.((?:\\.|[\w-])+)/g
 const IMPORTANT_SUFFIX_RE = /\s*!important$/i
+const MINI_PROGRAM_PREFLIGHT_SELECTORS = new Set(['view', 'text', '::after', '::before'])
 const TRANSFORM_PROPERTIES = new Set(['transform', '-webkit-transform'])
+const TAILWIND_VERSION_COMMENT_RE = /tailwindcss v\d/i
+const UVUE_SCOPED_STYLE_REQUEST_RE = /\?(?:[^#]*&)?(?:vue(?:=[^&]*)?&)?type=style(?:&|$)/
+const VUE_SCOPED_ATTR_RE = /\[data-v-[^\]]+\]/gi
+const VUE_SCOPED_CLASS_RE = /\.data-v-[\w-]+/gi
 
 function isUniAppXUvueTarget(
   options?: Pick<IStyleHandlerOptions, 'uniAppX' | 'uniAppXCssTarget'>,
@@ -69,6 +74,26 @@ function getSourceFile(rule: Rule, result: PostcssResult) {
   return rule.source?.input.from ?? result.opts.from ?? 'unknown source'
 }
 
+function hasVueScopedAttr(value: string) {
+  VUE_SCOPED_ATTR_RE.lastIndex = 0
+  VUE_SCOPED_CLASS_RE.lastIndex = 0
+  const matched = VUE_SCOPED_ATTR_RE.test(value) || VUE_SCOPED_CLASS_RE.test(value)
+  VUE_SCOPED_ATTR_RE.lastIndex = 0
+  VUE_SCOPED_CLASS_RE.lastIndex = 0
+  return matched
+}
+
+function normalizeCssSignatureValue(value: string) {
+  return value
+    .replace(VUE_SCOPED_ATTR_RE, '')
+    .replace(VUE_SCOPED_CLASS_RE, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([>+~])\s*/g, '$1')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .trim()
+}
+
 function collectUtilityClassNames(rule: Rule) {
   const classNames = new Set<string>()
 
@@ -108,6 +133,106 @@ function hasOnlyClassSelectors(rule: Rule) {
       return false
     }
   })
+}
+
+function isScopedSfcStyleRequest(result: PostcssResult) {
+  const source = result.opts.from
+  if (typeof source !== 'string' || source.length === 0) {
+    return false
+  }
+  return UVUE_SCOPED_STYLE_REQUEST_RE.test(source) && /(?:^|[?&])scoped(?:=|&|$)/.test(source)
+}
+
+function isLikelyTailwindGlobalSelector(selector: string) {
+  const normalized = normalizeCssSignatureValue(selector)
+  return normalized === '*'
+    || normalized.startsWith('::')
+    || normalized.startsWith(':root')
+    || normalized.startsWith(':host')
+    || /^(?:html|body|hr|abbr|h1|h2|h3|h4|h5|h6|a|b|strong|code|kbd|samp|small|sub|sup|table|button|input|select|optgroup|textarea|summary|blockquote|dl|dd|fieldset|legend|ol|ul|menu|dialog|progress|video|audio|canvas|embed|iframe|img|object|svg|details|template|[uo]ni-progress)(?:$|[:,[\s>+~.#])/.test(normalized)
+}
+
+function hasClassSelector(selector: string) {
+  return /(?:^|[^\\])\.[_a-z\u00A0-\uFFFF-]/i.test(normalizeCssSignatureValue(selector))
+}
+
+function isLikelyTailwindGlobalRule(rule: Rule) {
+  return (rule.selectors ?? [rule.selector]).every(selector =>
+    !hasClassSelector(selector) && isLikelyTailwindGlobalSelector(selector),
+  )
+}
+
+function isLikelyTailwindPropertyAtRule(atRule: AtRule) {
+  return typeof atRule.name === 'string'
+    && atRule.name.toLowerCase() === 'property'
+    && normalizeCssSignatureValue(atRule.params).startsWith('--tw-')
+}
+
+function isMiniProgramTailwindPreflightDeclaration(prop: string) {
+  return prop.startsWith('--tw-') || prop === 'box-sizing' || prop === 'margin' || prop === 'padding' || prop === 'border'
+}
+
+function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  if (
+    selectors.length === 0
+    || !selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return !hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
+    })
+  ) {
+    return false
+  }
+  const declarations = rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
+  return declarations.length > 0 && declarations.every(decl => isMiniProgramTailwindPreflightDeclaration(decl.prop))
+}
+
+function isScopedMiniProgramTailwindContentInitRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  if (
+    selectors.length === 0
+    || !selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
+    })
+  ) {
+    return false
+  }
+  const declarations = rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
+  return declarations.length > 0 && declarations.every(decl => decl.prop === '--tw-content')
+}
+
+function stripScopedTailwindNoise(root: postcss.Root) {
+  let changed = false
+  root.walkComments((comment) => {
+    if (!TAILWIND_VERSION_COMMENT_RE.test(comment.text)) {
+      return
+    }
+    comment.remove()
+    changed = true
+  })
+  root.walkRules((rule) => {
+    if (
+      isLikelyTailwindGlobalRule(rule)
+      || isUnscopedMiniProgramTailwindPreflightRule(rule)
+      || isScopedMiniProgramTailwindContentInitRule(rule)
+    ) {
+      rule.remove()
+      changed = true
+    }
+  })
+  root.walkAtRules((atRule) => {
+    if (isLikelyTailwindPropertyAtRule(atRule)) {
+      atRule.remove()
+      changed = true
+      return
+    }
+    if ((atRule.nodes?.length ?? 0) === 0) {
+      atRule.remove()
+      changed = true
+    }
+  })
+  return changed
 }
 
 function getUnsupportedDeclarationReason(prop: string, value: string) {
@@ -182,6 +307,7 @@ export function applyUniAppXUvueCompatibility(
 
   const mode = normalizeUnsupportedMode(options?.uniAppXUnsupported)
   const warningCache = new Set<string>()
+  const scopedSfcStyleRequest = isScopedSfcStyleRequest(result)
 
   let root = result.root
   let calcMessages: PostcssResult['messages'] = []
@@ -199,8 +325,12 @@ export function applyUniAppXUvueCompatibility(
     calcMessages = calcResult.messages
   }
 
+  if (scopedSfcStyleRequest) {
+    stripScopedTailwindNoise(root)
+  }
+
   root.walkRules((rule) => {
-    if (!hasOnlyClassSelectors(rule)) {
+    if (!scopedSfcStyleRequest && !hasOnlyClassSelectors(rule)) {
       reportUnsupportedRule(rule, result, mode, warningCache, 'selector must be class-only')
       rule.remove()
       return
@@ -222,7 +352,7 @@ export function applyUniAppXUvueCompatibility(
   })
 
   root.walkAtRules((atRule) => {
-    if (atRule.name?.toLowerCase() === 'property') {
+    if (isLikelyTailwindPropertyAtRule(atRule) || atRule.name?.toLowerCase() === 'property') {
       atRule.remove()
       return
     }

--- a/packages/postcss/src/compat/uni-app-x-uvue.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue.ts
@@ -1,21 +1,17 @@
-import type { AtRule, Result as PostcssResult, Rule } from 'postcss'
+import type { Result as PostcssResult, Rule } from 'postcss'
 import type { IStyleHandlerOptions, UniAppXUnsupportedMode } from '../types'
 import postcssCalc from '@weapp-tailwindcss/postcss-calc'
 import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 import valueParser from 'postcss-value-parser'
 import { normalizeTailwindcssV4Declaration } from './tailwindcss-v4'
+import { isUvueSfcStyleRequest, stripScopedTailwindNoise } from './uni-app-x-uvue/scoped-style'
 import { consumeUniAppXSystemRootTheme } from './uni-app-x-uvue/theme'
 
 const ALLOWED_DISPLAY_VALUES = new Set(['flex', 'none'])
 const FALLBACK_CLASS_RE = /\.((?:\\.|[\w-])+)/g
 const IMPORTANT_SUFFIX_RE = /\s*!important$/i
-const MINI_PROGRAM_PREFLIGHT_SELECTORS = new Set(['view', 'text', '::after', '::before'])
 const TRANSFORM_PROPERTIES = new Set(['transform', '-webkit-transform'])
-const TAILWIND_VERSION_COMMENT_RE = /tailwindcss v\d/i
-const UVUE_SCOPED_STYLE_REQUEST_RE = /\?(?:[^#]*&)?(?:vue(?:=[^&]*)?&)?type=style(?:&|$)/
-const VUE_SCOPED_ATTR_RE = /\[data-v-[^\]]+\]/gi
-const VUE_SCOPED_CLASS_RE = /\.data-v-[\w-]+/gi
 
 function isUniAppXUvueTarget(
   options?: Pick<IStyleHandlerOptions, 'uniAppX' | 'uniAppXCssTarget'>,
@@ -74,26 +70,6 @@ function getSourceFile(rule: Rule, result: PostcssResult) {
   return rule.source?.input.from ?? result.opts.from ?? 'unknown source'
 }
 
-function hasVueScopedAttr(value: string) {
-  VUE_SCOPED_ATTR_RE.lastIndex = 0
-  VUE_SCOPED_CLASS_RE.lastIndex = 0
-  const matched = VUE_SCOPED_ATTR_RE.test(value) || VUE_SCOPED_CLASS_RE.test(value)
-  VUE_SCOPED_ATTR_RE.lastIndex = 0
-  VUE_SCOPED_CLASS_RE.lastIndex = 0
-  return matched
-}
-
-function normalizeCssSignatureValue(value: string) {
-  return value
-    .replace(VUE_SCOPED_ATTR_RE, '')
-    .replace(VUE_SCOPED_CLASS_RE, '')
-    .replace(/\s+/g, ' ')
-    .replace(/\s*([>+~])\s*/g, '$1')
-    .replace(/\(\s+/g, '(')
-    .replace(/\s+\)/g, ')')
-    .trim()
-}
-
 function collectUtilityClassNames(rule: Rule) {
   const classNames = new Set<string>()
 
@@ -133,106 +109,6 @@ function hasOnlyClassSelectors(rule: Rule) {
       return false
     }
   })
-}
-
-function isScopedSfcStyleRequest(result: PostcssResult) {
-  const source = result.opts.from
-  if (typeof source !== 'string' || source.length === 0) {
-    return false
-  }
-  return UVUE_SCOPED_STYLE_REQUEST_RE.test(source) && /(?:^|[?&])scoped(?:=|&|$)/.test(source)
-}
-
-function isLikelyTailwindGlobalSelector(selector: string) {
-  const normalized = normalizeCssSignatureValue(selector)
-  return normalized === '*'
-    || normalized.startsWith('::')
-    || normalized.startsWith(':root')
-    || normalized.startsWith(':host')
-    || /^(?:html|body|hr|abbr|h1|h2|h3|h4|h5|h6|a|b|strong|code|kbd|samp|small|sub|sup|table|button|input|select|optgroup|textarea|summary|blockquote|dl|dd|fieldset|legend|ol|ul|menu|dialog|progress|video|audio|canvas|embed|iframe|img|object|svg|details|template|[uo]ni-progress)(?:$|[:,[\s>+~.#])/.test(normalized)
-}
-
-function hasClassSelector(selector: string) {
-  return /(?:^|[^\\])\.[_a-z\u00A0-\uFFFF-]/i.test(normalizeCssSignatureValue(selector))
-}
-
-function isLikelyTailwindGlobalRule(rule: Rule) {
-  return (rule.selectors ?? [rule.selector]).every(selector =>
-    !hasClassSelector(selector) && isLikelyTailwindGlobalSelector(selector),
-  )
-}
-
-function isLikelyTailwindPropertyAtRule(atRule: AtRule) {
-  return typeof atRule.name === 'string'
-    && atRule.name.toLowerCase() === 'property'
-    && normalizeCssSignatureValue(atRule.params).startsWith('--tw-')
-}
-
-function isMiniProgramTailwindPreflightDeclaration(prop: string) {
-  return prop.startsWith('--tw-') || prop === 'box-sizing' || prop === 'margin' || prop === 'padding' || prop === 'border'
-}
-
-function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule) {
-  const selectors = rule.selectors ?? [rule.selector]
-  if (
-    selectors.length === 0
-    || !selectors.every((selector) => {
-      const normalized = normalizeCssSignatureValue(selector)
-      return !hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
-    })
-  ) {
-    return false
-  }
-  const declarations = rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
-  return declarations.length > 0 && declarations.every(decl => isMiniProgramTailwindPreflightDeclaration(decl.prop))
-}
-
-function isScopedMiniProgramTailwindContentInitRule(rule: Rule) {
-  const selectors = rule.selectors ?? [rule.selector]
-  if (
-    selectors.length === 0
-    || !selectors.every((selector) => {
-      const normalized = normalizeCssSignatureValue(selector)
-      return hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
-    })
-  ) {
-    return false
-  }
-  const declarations = rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
-  return declarations.length > 0 && declarations.every(decl => decl.prop === '--tw-content')
-}
-
-function stripScopedTailwindNoise(root: postcss.Root) {
-  let changed = false
-  root.walkComments((comment) => {
-    if (!TAILWIND_VERSION_COMMENT_RE.test(comment.text)) {
-      return
-    }
-    comment.remove()
-    changed = true
-  })
-  root.walkRules((rule) => {
-    if (
-      isLikelyTailwindGlobalRule(rule)
-      || isUnscopedMiniProgramTailwindPreflightRule(rule)
-      || isScopedMiniProgramTailwindContentInitRule(rule)
-    ) {
-      rule.remove()
-      changed = true
-    }
-  })
-  root.walkAtRules((atRule) => {
-    if (isLikelyTailwindPropertyAtRule(atRule)) {
-      atRule.remove()
-      changed = true
-      return
-    }
-    if ((atRule.nodes?.length ?? 0) === 0) {
-      atRule.remove()
-      changed = true
-    }
-  })
-  return changed
 }
 
 function getUnsupportedDeclarationReason(prop: string, value: string) {
@@ -307,7 +183,7 @@ export function applyUniAppXUvueCompatibility(
 
   const mode = normalizeUnsupportedMode(options?.uniAppXUnsupported)
   const warningCache = new Set<string>()
-  const scopedSfcStyleRequest = isScopedSfcStyleRequest(result)
+  const sfcStyleRequest = isUvueSfcStyleRequest(result)
 
   let root = result.root
   let calcMessages: PostcssResult['messages'] = []
@@ -325,12 +201,12 @@ export function applyUniAppXUvueCompatibility(
     calcMessages = calcResult.messages
   }
 
-  if (scopedSfcStyleRequest) {
+  if (sfcStyleRequest) {
     stripScopedTailwindNoise(root)
   }
 
   root.walkRules((rule) => {
-    if (!scopedSfcStyleRequest && !hasOnlyClassSelectors(rule)) {
+    if (!sfcStyleRequest && !hasOnlyClassSelectors(rule)) {
       reportUnsupportedRule(rule, result, mode, warningCache, 'selector must be class-only')
       rule.remove()
       return
@@ -352,7 +228,7 @@ export function applyUniAppXUvueCompatibility(
   })
 
   root.walkAtRules((atRule) => {
-    if (isLikelyTailwindPropertyAtRule(atRule) || atRule.name?.toLowerCase() === 'property') {
+    if (atRule.name?.toLowerCase() === 'property') {
       atRule.remove()
       return
     }

--- a/packages/postcss/src/compat/uni-app-x-uvue/scoped-style.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue/scoped-style.ts
@@ -11,7 +11,11 @@ const TAILWIND_PREFLIGHT_DECLARATIONS = new Set([
   '-moz-tab-size:4',
   '-webkit-appearance:none',
   '-webkit-appearance:button',
+  '-webkit-tap-highlight-color:transparent',
   '-webkit-text-decoration:inherit',
+  '-webkit-text-decoration:underline dotted',
+  '-webkit-text-size-adjust:100%',
+  '-o-tab-size:4',
   'appearance:button',
   'background-color:transparent',
   'border-collapse:collapse',
@@ -36,18 +40,24 @@ const TAILWIND_PREFLIGHT_DECLARATIONS = new Set([
   'height:0',
   'height:auto',
   'letter-spacing:inherit',
+  'line-height:1',
+  'line-height:1.5',
   'line-height:0',
   'line-height:inherit',
   'list-style:none',
+  'margin-inline-end:4px',
   'max-width:100%',
   'min-height:1lh',
   'opacity:1',
   'outline:auto',
+  'padding:0',
+  'padding-block:0',
   'position:relative',
   'resize:vertical',
   'tab-size:4',
   'text-align:inherit',
   'text-decoration:inherit',
+  'text-decoration:underline dotted',
   'text-indent:0',
   'text-transform:none',
   'top:-.5em',
@@ -127,6 +137,16 @@ function isTailwindPreflightDeclaration(decl: postcss.Declaration) {
     return true
   }
   if (prop === 'color' && value.startsWith('color-mix(') && value.includes('currentcolor') && value.includes('transparent')) {
+    return true
+  }
+  if (prop === 'color' && value === 'currentcolor') {
+    return true
+  }
+  if (
+    (prop === 'font-family' && value.startsWith('var(--default-font-family'))
+    || (prop === 'font-feature-settings' && value.startsWith('var(--default-font-feature-settings'))
+    || (prop === 'font-variation-settings' && value.startsWith('var(--default-font-variation-settings'))
+  ) {
     return true
   }
   return TAILWIND_PREFLIGHT_DECLARATIONS.has(`${prop}:${value}`)

--- a/packages/postcss/src/compat/uni-app-x-uvue/scoped-style.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue/scoped-style.ts
@@ -1,0 +1,237 @@
+import type { Result as PostcssResult, Rule } from 'postcss'
+import type postcss from 'postcss'
+
+const MINI_PROGRAM_PREFLIGHT_SELECTORS = new Set(['view', 'text', '::after', '::before'])
+const SCOPED_UNIVERSAL_PREFLIGHT_SELECTORS = new Set(['*', '::after', '::before', '::backdrop', '::file-selector-button'])
+const TAILWIND_VERSION_COMMENT_RE = /tailwindcss v\d/i
+const VUE_SCOPED_ATTR_RE = /\[data-v-[^\]]+\]/gi
+const VUE_SCOPED_CLASS_RE = /\.data-v-[\w-]+/gi
+
+const TAILWIND_PREFLIGHT_DECLARATIONS = new Set([
+  '-moz-tab-size:4',
+  '-webkit-appearance:none',
+  '-webkit-appearance:button',
+  '-webkit-text-decoration:inherit',
+  'appearance:button',
+  'background-color:transparent',
+  'border-collapse:collapse',
+  'border-color:inherit',
+  'border-radius:0',
+  'border-top-width:1px',
+  'bottom:-.25em',
+  'color:inherit',
+  'display:block',
+  'display:inline-flex',
+  'display:list-item',
+  'font:inherit',
+  'font-family:inherit',
+  'font-feature-settings:inherit',
+  'font-size:1em',
+  'font-size:75%',
+  'font-size:80%',
+  'font-size:inherit',
+  'font-variation-settings:inherit',
+  'font-weight:bolder',
+  'font-weight:inherit',
+  'height:0',
+  'height:auto',
+  'letter-spacing:inherit',
+  'line-height:0',
+  'line-height:inherit',
+  'list-style:none',
+  'max-width:100%',
+  'min-height:1lh',
+  'opacity:1',
+  'outline:auto',
+  'position:relative',
+  'resize:vertical',
+  'tab-size:4',
+  'text-align:inherit',
+  'text-decoration:inherit',
+  'text-indent:0',
+  'text-transform:none',
+  'top:-.5em',
+  'vertical-align:baseline',
+  'vertical-align:middle',
+])
+
+function hasVueScopedAttr(value: string) {
+  VUE_SCOPED_ATTR_RE.lastIndex = 0
+  VUE_SCOPED_CLASS_RE.lastIndex = 0
+  const matched = VUE_SCOPED_ATTR_RE.test(value) || VUE_SCOPED_CLASS_RE.test(value)
+  VUE_SCOPED_ATTR_RE.lastIndex = 0
+  VUE_SCOPED_CLASS_RE.lastIndex = 0
+  return matched
+}
+
+function normalizeCssSignatureValue(value: string) {
+  return value
+    .replace(VUE_SCOPED_ATTR_RE, '')
+    .replace(VUE_SCOPED_CLASS_RE, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([>+~])\s*/g, '$1')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .trim()
+}
+
+function isSfcStyleRequestSource(source: unknown) {
+  if (typeof source !== 'string') {
+    return false
+  }
+  const queryIndex = source.indexOf('?')
+  if (queryIndex < 0 || !source.slice(0, queryIndex).toLowerCase().endsWith('.uvue')) {
+    return false
+  }
+  const hashIndex = source.indexOf('#', queryIndex)
+  const query = source.slice(queryIndex + 1, hashIndex < 0 ? undefined : hashIndex)
+  return new URLSearchParams(query).get('type') === 'style'
+}
+
+export function isUvueSfcStyleRequest(result: PostcssResult) {
+  if (isSfcStyleRequestSource(result.opts.from)) {
+    return true
+  }
+
+  if ((result.root.nodes ?? []).some(node => isSfcStyleRequestSource(node.source?.input.from))) {
+    return true
+  }
+
+  let hasScopedSelector = false
+  result.root.walkRules((rule) => {
+    if ((rule.selectors ?? [rule.selector]).some(hasVueScopedAttr)) {
+      hasScopedSelector = true
+      return false
+    }
+  })
+  return hasScopedSelector
+}
+
+function getDeclarations(rule: Rule) {
+  return rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
+}
+
+function isLikelyTailwindGlobalSelector(selector: string) {
+  const normalized = normalizeCssSignatureValue(selector)
+  return normalized === '*'
+    || normalized.startsWith('::')
+    || normalized.startsWith(':root')
+    || normalized.startsWith(':host')
+    || /^(?:html|body|hr|abbr|h1|h2|h3|h4|h5|h6|a|b|strong|code|kbd|samp|pre|small|sub|sup|table|button|input|select|optgroup|textarea|summary|blockquote|dl|dd|fieldset|legend|ol|ul|menu|dialog|progress|video|audio|canvas|embed|iframe|img|object|svg|details|template|[uo]ni-progress)(?:$|[:,[\s>+~.#])/.test(normalized)
+}
+
+function isTailwindPreflightDeclaration(decl: postcss.Declaration) {
+  const prop = decl.prop.trim().toLowerCase()
+  const value = normalizeCssSignatureValue(decl.value.trim().toLowerCase())
+  if (prop.startsWith('--tw-')) {
+    return true
+  }
+  if (prop === 'color' && value.startsWith('color-mix(') && value.includes('currentcolor') && value.includes('transparent')) {
+    return true
+  }
+  return TAILWIND_PREFLIGHT_DECLARATIONS.has(`${prop}:${value}`)
+}
+
+function isScopedTailwindThemeCarrierRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  const declarations = getDeclarations(rule)
+  return selectors.length > 0
+    && selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return hasVueScopedAttr(selector) && (normalized.startsWith(':root') || normalized.startsWith(':host'))
+    })
+    && declarations.length > 0
+    && declarations.every(decl => decl.prop.startsWith('--'))
+}
+
+function isScopedUniversalTailwindPreflightRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  const declarations = getDeclarations(rule)
+  return selectors.length > 0
+    && selectors.every(selector => hasVueScopedAttr(selector) && SCOPED_UNIVERSAL_PREFLIGHT_SELECTORS.has(normalizeCssSignatureValue(selector)))
+    && declarations.length > 0
+    && declarations.every(decl => decl.prop.startsWith('--tw-') || ['box-sizing', 'margin', 'padding', 'border'].includes(decl.prop))
+}
+
+function isScopedTailwindElementPreflightRule(rule: Rule, hasTailwindBanner: boolean) {
+  if (!hasTailwindBanner) {
+    return false
+  }
+  const selectors = rule.selectors ?? [rule.selector]
+  const declarations = getDeclarations(rule)
+  return selectors.length > 0
+    && selectors.every(selector => hasVueScopedAttr(selector) && isLikelyTailwindGlobalSelector(selector))
+    && declarations.length > 0
+    && declarations.every(isTailwindPreflightDeclaration)
+}
+
+function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  if (
+    selectors.length === 0
+    || !selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return !hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
+    })
+  ) {
+    return false
+  }
+  const declarations = getDeclarations(rule)
+  return declarations.length > 0 && declarations.every(decl => decl.prop.startsWith('--tw-') || ['box-sizing', 'margin', 'padding', 'border'].includes(decl.prop))
+}
+
+function isScopedMiniProgramTailwindContentInitRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  if (
+    selectors.length === 0
+    || !selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
+    })
+  ) {
+    return false
+  }
+  const declarations = getDeclarations(rule)
+  return declarations.length > 0 && declarations.every(decl => decl.prop === '--tw-content')
+}
+
+function isLikelyTailwindPropertyAtRule(atRule: postcss.AtRule) {
+  return typeof atRule.name === 'string'
+    && atRule.name.toLowerCase() === 'property'
+    && normalizeCssSignatureValue(atRule.params).startsWith('--tw-')
+}
+
+export function stripScopedTailwindNoise(root: postcss.Root) {
+  let hasTailwindBanner = false
+  root.walkComments((comment) => {
+    if (TAILWIND_VERSION_COMMENT_RE.test(comment.text)) {
+      hasTailwindBanner = true
+    }
+  })
+
+  root.walkComments((comment) => {
+    if (TAILWIND_VERSION_COMMENT_RE.test(comment.text)) {
+      comment.remove()
+    }
+  })
+  root.walkRules((rule) => {
+    if (
+      isScopedTailwindThemeCarrierRule(rule)
+      || isScopedUniversalTailwindPreflightRule(rule)
+      || isScopedTailwindElementPreflightRule(rule, hasTailwindBanner)
+      || isUnscopedMiniProgramTailwindPreflightRule(rule)
+      || isScopedMiniProgramTailwindContentInitRule(rule)
+    ) {
+      rule.remove()
+    }
+  })
+  root.walkAtRules((atRule) => {
+    if (isLikelyTailwindPropertyAtRule(atRule)) {
+      atRule.remove()
+      return
+    }
+    if ((atRule.nodes?.length ?? 0) === 0) {
+      atRule.remove()
+    }
+  })
+}

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -431,6 +431,42 @@ describe('uni-app-x', () => {
     ]))
   })
 
+  it('preserves scoped author css while removing scoped tailwind carriers for uvue requests', async () => {
+    const result = await postcss().process([
+      '/*! tailwindcss v4.3.2 | MIT License | https://tailwindcss.com */',
+      '[data-v-abc]:root,[data-v-abc]:host{--spacing:.25rem}',
+      '*[data-v-abc],[data-v-abc]::after,[data-v-abc]::before{box-sizing:border-box;margin:0;padding:0}',
+      'view.data-v-abc,text.data-v-abc,.data-v-abc::after,.data-v-abc::before{--tw-content:""}',
+      'view.data-v-abc{color:red}',
+      '.card.data-v-abc{padding:16px}',
+      '.card.data-v-abc .title.data-v-abc{font-weight:700}',
+      'text.data-v-abc{display:block}',
+      '@property --tw-content{syntax:"*";initial-value:"";inherits:false}',
+    ].join(''), {
+      from: '/src/components/ScopedChild.uvue?vue&type=style&index=0&scoped=abc&lang.css',
+    })
+
+    const filtered = applyUniAppXUvueCompatibility(result, {
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+    })
+    const warningTexts = filtered.warnings().map(item => item.text)
+
+    expect(filtered.css).toContain('view.data-v-abc{color:red}')
+    expect(filtered.css).toContain('.card.data-v-abc{padding:16px}')
+    expect(filtered.css).toContain('.card.data-v-abc .title.data-v-abc{font-weight:700}')
+    expect(filtered.css).not.toContain('tailwindcss v4.3.2')
+    expect(filtered.css).not.toContain('[data-v-abc]:root')
+    expect(filtered.css).not.toContain('box-sizing:border-box')
+    expect(filtered.css).not.toContain('--tw-content')
+    expect(filtered.css).not.toContain('@property')
+    expect(filtered.css).not.toContain('display:block')
+    expect(warningTexts).toHaveLength(1)
+    expect(warningTexts[0]).toContain('display: block')
+    expect(warningTexts[0]).not.toContain('selector must be class-only')
+  })
+
   it('uses incremental theme values when a uvue utility has no root carrier', async () => {
     const result = await postcss().process([
       '.text-white{color:var(--color-white)}',

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -436,8 +436,14 @@ describe('uni-app-x', () => {
       '/*! tailwindcss v4.3.2 | MIT License | https://tailwindcss.com */',
       '[data-v-abc]:root,[data-v-abc]:host{--spacing:.25rem}',
       '*[data-v-abc],[data-v-abc]::after,[data-v-abc]::before{box-sizing:border-box;margin:0;padding:0}',
+      'html.data-v-abc,.data-v-abc:host{line-height:1.5;-webkit-text-size-adjust:100%;-o-tab-size:4;tab-size:4;font-family:var(--default-font-family,sans-serif);font-feature-settings:var(--default-font-feature-settings,normal);font-variation-settings:var(--default-font-variation-settings,normal);-webkit-tap-highlight-color:transparent}',
+      'abbr:where([title].data-v-abc){text-decoration:underline dotted}',
       'button.data-v-abc,input.data-v-abc{font:inherit;color:inherit;background-color:transparent}',
       'uni-progress.data-v-abc{vertical-align:baseline}',
+      '.data-v-abc::file-selector-button{margin-inline-end:4px}',
+      '.data-v-abc::placeholder{color:currentcolor}',
+      '.data-v-abc::-webkit-datetime-edit{padding-block:0}',
+      '.data-v-abc::-webkit-calendar-picker-indicator{line-height:1}',
       'view.data-v-abc,text.data-v-abc,.data-v-abc::after,.data-v-abc::before{--tw-content:""}',
       'view.data-v-abc{color:red}',
       'button.data-v-abc{color:blue}',
@@ -475,6 +481,10 @@ describe('uni-app-x', () => {
     expect(filtered.css).not.toContain('@property')
     expect(filtered.css).not.toContain('font:inherit')
     expect(filtered.css).not.toContain('vertical-align:baseline')
+    expect(filtered.css).not.toContain('--default-font-family')
+    expect(filtered.css).not.toContain('margin-inline-end')
+    expect(filtered.css).not.toContain('currentcolor')
+    expect(filtered.css).not.toContain('padding-block')
     expect(filtered.css).not.toContain('display:block')
     expect(warningTexts).toHaveLength(1)
     expect(warningTexts[0]).toContain('display: block')

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -436,10 +436,17 @@ describe('uni-app-x', () => {
       '/*! tailwindcss v4.3.2 | MIT License | https://tailwindcss.com */',
       '[data-v-abc]:root,[data-v-abc]:host{--spacing:.25rem}',
       '*[data-v-abc],[data-v-abc]::after,[data-v-abc]::before{box-sizing:border-box;margin:0;padding:0}',
+      'button.data-v-abc,input.data-v-abc{font:inherit;color:inherit;background-color:transparent}',
+      'uni-progress.data-v-abc{vertical-align:baseline}',
       'view.data-v-abc,text.data-v-abc,.data-v-abc::after,.data-v-abc::before{--tw-content:""}',
       'view.data-v-abc{color:red}',
+      'button.data-v-abc{color:blue}',
+      'input.data-v-abc{border-color:#123456}',
+      'img.data-v-abc{width:12px}',
+      '.data-v-abc::before{content:"author"}',
       '.card.data-v-abc{padding:16px}',
       '.card.data-v-abc .title.data-v-abc{font-weight:700}',
+      '@media (min-width:640px){button.data-v-abc{color:green}}',
       'text.data-v-abc{display:block}',
       '@property --tw-content{syntax:"*";initial-value:"";inherits:false}',
     ].join(''), {
@@ -454,17 +461,87 @@ describe('uni-app-x', () => {
     const warningTexts = filtered.warnings().map(item => item.text)
 
     expect(filtered.css).toContain('view.data-v-abc{color:red}')
+    expect(filtered.css).toContain('button.data-v-abc{color:blue}')
+    expect(filtered.css).toContain('input.data-v-abc{border-color:#123456}')
+    expect(filtered.css).toContain('img.data-v-abc{width:12px}')
+    expect(filtered.css).toContain('.data-v-abc::before{content:"author"}')
     expect(filtered.css).toContain('.card.data-v-abc{padding:16px}')
     expect(filtered.css).toContain('.card.data-v-abc .title.data-v-abc{font-weight:700}')
+    expect(filtered.css).toContain('@media (min-width:640px){button.data-v-abc{color:green}}')
     expect(filtered.css).not.toContain('tailwindcss v4.3.2')
     expect(filtered.css).not.toContain('[data-v-abc]:root')
     expect(filtered.css).not.toContain('box-sizing:border-box')
     expect(filtered.css).not.toContain('--tw-content')
     expect(filtered.css).not.toContain('@property')
+    expect(filtered.css).not.toContain('font:inherit')
+    expect(filtered.css).not.toContain('vertical-align:baseline')
     expect(filtered.css).not.toContain('display:block')
     expect(warningTexts).toHaveLength(1)
     expect(warningTexts[0]).toContain('display: block')
     expect(warningTexts[0]).not.toContain('selector must be class-only')
+  })
+
+  it('detects scoped uvue requests from the PostCSS input source when result options lose from', async () => {
+    const id = '/src/components/ScopedChild.uvue?vue&type=style&index=0&scoped=abc&lang.css'
+    const result = postcss.parse('button.data-v-abc{color:red}', { from: id }).toResult()
+
+    expect(result.opts.from).toBeUndefined()
+    expect(result.root.first?.source?.input.from).toBe(id)
+
+    const filtered = applyUniAppXUvueCompatibility(result, {
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+    })
+
+    expect(filtered.css).toBe('button.data-v-abc{color:red}')
+    expect(filtered.warnings()).toEqual([])
+  })
+
+  it('preserves author selectors for uvue SFC style requests that omit the scoped query', async () => {
+    const result = await postcss().process('button{color:red}', {
+      from: '/src/components/ScopedChild.uvue?vue&type=style&index=0&lang.css',
+    })
+
+    const filtered = applyUniAppXUvueCompatibility(result, {
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+    })
+
+    expect(filtered.css).toBe('button{color:red}')
+    expect(filtered.warnings()).toEqual([])
+  })
+
+  it('detects compiled scoped selectors when all uvue request metadata is lost', async () => {
+    const result = await postcss().process('button[data-v-abc]{color:red}', {
+      from: undefined,
+    })
+
+    const filtered = applyUniAppXUvueCompatibility(result, {
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+    })
+
+    expect(filtered.css).toBe('button[data-v-abc]{color:red}')
+    expect(filtered.warnings()).toEqual([])
+  })
+
+  it('does not classify non-uvue Vue style requests as uvue author styles', async () => {
+    const result = await postcss().process('button{color:red}', {
+      from: '/src/components/ScopedChild.vue?vue&type=style&index=0&scoped=abc&lang.css',
+    })
+
+    const filtered = applyUniAppXUvueCompatibility(result, {
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+    })
+
+    expect(filtered.css).toBe('')
+    expect(filtered.warnings()).toHaveLength(1)
+    expect(filtered.warnings()[0]?.text).toContain('selector must be class-only')
   })
 
   it('uses incremental theme values when a uvue utility has no root carrier', async () => {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/coverage.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/coverage.ts
@@ -4,30 +4,10 @@ import { postcss } from '@weapp-tailwindcss/postcss'
 import { parseBundlerGeneratedCssMarkerBlocks, stripBundlerGeneratedCssMarkers } from '../../shared/generated-css-marker'
 import { isSubpackageOutputFile } from '../generate-bundle/subpackages'
 import { collectRootStyleBundleCssSources, getAssetFile, hasNonCommentCss, isCssOutputFile, isMatchingGeneratedCssMarkerFile, normalizeMarkerOutputFile, readAssetSource } from './markers-imports'
+import { hasScopedMiniProgramTailwindContentInitRule, hasUnscopedMiniProgramTailwindPreflightRule, hasVueScopedAttr, isLikelyTailwindGlobalRule, isLikelyTailwindPropertyAtRule, isScopedMiniProgramTailwindContentInitRule, isUnscopedMiniProgramTailwindPreflightRule, normalizeCssSignatureValue } from './scoped-tailwind-noise'
 import { isMiniProgramStyleOutputFile, isRootStyleOutputFile } from './style-files'
 
-const VUE_SCOPED_ATTR_RE = /\[data-v-[^\]]+\]/gi
-const VUE_SCOPED_CLASS_RE = /\.data-v-[\w-]+/gi
-
-function hasVueScopedAttr(value: string) {
-  VUE_SCOPED_ATTR_RE.lastIndex = 0
-  VUE_SCOPED_CLASS_RE.lastIndex = 0
-  const matched = VUE_SCOPED_ATTR_RE.test(value) || VUE_SCOPED_CLASS_RE.test(value)
-  VUE_SCOPED_ATTR_RE.lastIndex = 0
-  VUE_SCOPED_CLASS_RE.lastIndex = 0
-  return matched
-}
-
-export function normalizeCssSignatureValue(value: string) {
-  return value
-    .replace(VUE_SCOPED_ATTR_RE, '')
-    .replace(VUE_SCOPED_CLASS_RE, '')
-    .replace(/\s+/g, ' ')
-    .replace(/\s*([>+~])\s*/g, '$1')
-    .replace(/\(\s+/g, '(')
-    .replace(/\s+\)/g, ')')
-    .trim()
-}
+export { normalizeCssSignatureValue } from './scoped-tailwind-noise'
 
 function createDeclarationSignature(rule: postcss.Rule) {
   return createDeclarationKeys(rule).sort().join(';')
@@ -45,75 +25,6 @@ function createDeclarationKeys(rule: postcss.Rule) {
 
 function createAtRuleCoverageKey(atRule: postcss.AtRule) {
   return `${atRule.name}\0${normalizeCssSignatureValue(atRule.params)}\0${normalizeCssSignatureValue(atRule.toString())}`
-}
-
-function hasClassSelector(selector: string) {
-  return /(?:^|[^\\])\.[_a-z\u00A0-\uFFFF-]/i.test(normalizeCssSignatureValue(selector))
-}
-
-function isLikelyTailwindGlobalSelector(selector: string) {
-  const normalized = normalizeCssSignatureValue(selector)
-  return normalized === '*'
-    || normalized.startsWith('::')
-    || normalized.startsWith(':root')
-    || normalized.startsWith(':host')
-    || /^(?:html|body|hr|abbr|h1|h2|h3|h4|h5|h6|a|b|strong|code|kbd|samp|small|sub|sup|table|button|input|select|optgroup|textarea|summary|blockquote|dl|dd|fieldset|legend|ol|ul|menu|dialog|progress|video|audio|canvas|embed|iframe|img|object|svg|details|template|[uo]ni-progress)(?:$|[:,[\s>+~.#])/.test(normalized)
-}
-
-function isLikelyTailwindGlobalRule(rule: postcss.Rule) {
-  return (rule.selectors ?? [rule.selector]).every(selector =>
-    !hasClassSelector(selector) && isLikelyTailwindGlobalSelector(selector),
-  )
-}
-
-function isLikelyTailwindPropertyAtRule(atRule: postcss.AtRule) {
-  return atRule.name.toLowerCase() === 'property'
-    && normalizeCssSignatureValue(atRule.params).startsWith('--tw-')
-}
-
-const MINI_PROGRAM_PREFLIGHT_SELECTORS = new Set(['view', 'text', '::after', '::before'])
-const MINI_PROGRAM_PREFLIGHT_DECLARATIONS = new Set(['box-sizing', 'margin', 'padding', 'border'])
-
-function isMiniProgramTailwindPreflightDeclaration(decl: postcss.Declaration) {
-  return decl.prop.startsWith('--tw-') || MINI_PROGRAM_PREFLIGHT_DECLARATIONS.has(decl.prop)
-}
-
-function isUnscopedMiniProgramTailwindPreflightRule(rule: postcss.Rule) {
-  const selectors = rule.selectors ?? [rule.selector]
-  if (
-    selectors.length === 0
-    || !selectors.every((selector) => {
-      const normalized = normalizeCssSignatureValue(selector)
-      return !hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
-    })
-  ) {
-    return false
-  }
-  const declarations = rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
-  return declarations.length > 0 && declarations.every(isMiniProgramTailwindPreflightDeclaration)
-}
-
-function isScopedMiniProgramTailwindContentInitRule(rule: postcss.Rule) {
-  const selectors = rule.selectors ?? [rule.selector]
-  if (
-    selectors.length === 0
-    || !selectors.every((selector) => {
-      const normalized = normalizeCssSignatureValue(selector)
-      return hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
-    })
-  ) {
-    return false
-  }
-  const declarations = rule.nodes?.filter((node): node is postcss.Declaration => node.type === 'decl') ?? []
-  return declarations.length > 0 && declarations.every(decl => decl.prop === '--tw-content')
-}
-
-function hasUnscopedMiniProgramTailwindPreflightRule(css: string) {
-  return /(?:^|[{}])\s*view\s*,\s*text\s*,\s*::after\s*,\s*::before\s*\{/.test(css)
-}
-
-function hasScopedMiniProgramTailwindContentInitRule(css: string) {
-  return /(?:^|[{}])[^{}]*\.data-v-[\w-][^{}]*\{\s*--tw-content\s*:/.test(css)
 }
 
 export function collectRootScopedComparableCssCoverage(cssSources: string[]) {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/scoped-tailwind-noise.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/scoped-tailwind-noise.ts
@@ -9,7 +9,11 @@ const TAILWIND_PREFLIGHT_DECLARATIONS = new Set([
   '-moz-tab-size:4',
   '-webkit-appearance:none',
   '-webkit-appearance:button',
+  '-webkit-tap-highlight-color:transparent',
   '-webkit-text-decoration:inherit',
+  '-webkit-text-decoration:underline dotted',
+  '-webkit-text-size-adjust:100%',
+  '-o-tab-size:4',
   'appearance:button',
   'background-color:transparent',
   'border-collapse:collapse',
@@ -34,18 +38,24 @@ const TAILWIND_PREFLIGHT_DECLARATIONS = new Set([
   'height:0',
   'height:auto',
   'letter-spacing:inherit',
+  'line-height:1',
+  'line-height:1.5',
   'line-height:0',
   'line-height:inherit',
   'list-style:none',
+  'margin-inline-end:4px',
   'max-width:100%',
   'min-height:1lh',
   'opacity:1',
   'outline:auto',
+  'padding:0',
+  'padding-block:0',
   'position:relative',
   'resize:vertical',
   'tab-size:4',
   'text-align:inherit',
   'text-decoration:inherit',
+  'text-decoration:underline dotted',
   'text-indent:0',
   'text-transform:none',
   'top:-.5em',
@@ -93,6 +103,16 @@ function isTailwindPreflightDeclaration(decl: Declaration) {
     return true
   }
   if (prop === 'color' && value.startsWith('color-mix(') && value.includes('currentcolor') && value.includes('transparent')) {
+    return true
+  }
+  if (prop === 'color' && value === 'currentcolor') {
+    return true
+  }
+  if (
+    (prop === 'font-family' && value.startsWith('var(--default-font-family'))
+    || (prop === 'font-feature-settings' && value.startsWith('var(--default-font-feature-settings'))
+    || (prop === 'font-variation-settings' && value.startsWith('var(--default-font-variation-settings'))
+  ) {
     return true
   }
   return TAILWIND_PREFLIGHT_DECLARATIONS.has(`${prop}:${value}`)

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/scoped-tailwind-noise.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/scoped-tailwind-noise.ts
@@ -1,0 +1,180 @@
+import type { AtRule, Declaration, Rule } from 'postcss'
+
+const VUE_SCOPED_ATTR_RE = /\[data-v-[^\]]+\]/gi
+const VUE_SCOPED_CLASS_RE = /\.data-v-[\w-]+/gi
+const SCOPED_UNIVERSAL_PREFLIGHT_SELECTORS = new Set(['*', '::after', '::before', '::backdrop', '::file-selector-button'])
+const MINI_PROGRAM_PREFLIGHT_SELECTORS = new Set(['view', 'text', '::after', '::before'])
+const MINI_PROGRAM_PREFLIGHT_DECLARATIONS = new Set(['box-sizing', 'margin', 'padding', 'border'])
+const TAILWIND_PREFLIGHT_DECLARATIONS = new Set([
+  '-moz-tab-size:4',
+  '-webkit-appearance:none',
+  '-webkit-appearance:button',
+  '-webkit-text-decoration:inherit',
+  'appearance:button',
+  'background-color:transparent',
+  'border-collapse:collapse',
+  'border-color:inherit',
+  'border-radius:0',
+  'border-top-width:1px',
+  'bottom:-.25em',
+  'color:inherit',
+  'display:block',
+  'display:inline-flex',
+  'display:list-item',
+  'font:inherit',
+  'font-family:inherit',
+  'font-feature-settings:inherit',
+  'font-size:1em',
+  'font-size:75%',
+  'font-size:80%',
+  'font-size:inherit',
+  'font-variation-settings:inherit',
+  'font-weight:bolder',
+  'font-weight:inherit',
+  'height:0',
+  'height:auto',
+  'letter-spacing:inherit',
+  'line-height:0',
+  'line-height:inherit',
+  'list-style:none',
+  'max-width:100%',
+  'min-height:1lh',
+  'opacity:1',
+  'outline:auto',
+  'position:relative',
+  'resize:vertical',
+  'tab-size:4',
+  'text-align:inherit',
+  'text-decoration:inherit',
+  'text-indent:0',
+  'text-transform:none',
+  'top:-.5em',
+  'vertical-align:baseline',
+  'vertical-align:middle',
+])
+
+export function hasVueScopedAttr(value: string) {
+  VUE_SCOPED_ATTR_RE.lastIndex = 0
+  VUE_SCOPED_CLASS_RE.lastIndex = 0
+  const matched = VUE_SCOPED_ATTR_RE.test(value) || VUE_SCOPED_CLASS_RE.test(value)
+  VUE_SCOPED_ATTR_RE.lastIndex = 0
+  VUE_SCOPED_CLASS_RE.lastIndex = 0
+  return matched
+}
+
+export function normalizeCssSignatureValue(value: string) {
+  return value
+    .replace(VUE_SCOPED_ATTR_RE, '')
+    .replace(VUE_SCOPED_CLASS_RE, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([>+~])\s*/g, '$1')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .trim()
+}
+
+function hasClassSelector(selector: string) {
+  return /(?:^|[^\\])\.[_a-z\u00A0-\uFFFF-]/i.test(normalizeCssSignatureValue(selector))
+}
+
+function isLikelyTailwindGlobalSelector(selector: string) {
+  const normalized = normalizeCssSignatureValue(selector)
+  return normalized === '*'
+    || normalized.startsWith('::')
+    || normalized.startsWith(':root')
+    || normalized.startsWith(':host')
+    || /^(?:html|body|hr|abbr|h1|h2|h3|h4|h5|h6|a|b|strong|code|kbd|samp|pre|small|sub|sup|table|button|input|select|optgroup|textarea|summary|blockquote|dl|dd|fieldset|legend|ol|ul|menu|dialog|progress|video|audio|canvas|embed|iframe|img|object|svg|details|template|[uo]ni-progress)(?:$|[:,[\s>+~.#])/.test(normalized)
+}
+
+function isTailwindPreflightDeclaration(decl: Declaration) {
+  const prop = decl.prop.trim().toLowerCase()
+  const value = normalizeCssSignatureValue(decl.value.trim().toLowerCase())
+  if (prop.startsWith('--tw-')) {
+    return true
+  }
+  if (prop === 'color' && value.startsWith('color-mix(') && value.includes('currentcolor') && value.includes('transparent')) {
+    return true
+  }
+  return TAILWIND_PREFLIGHT_DECLARATIONS.has(`${prop}:${value}`)
+}
+
+function getRuleDeclarations(rule: Rule) {
+  return rule.nodes?.filter((node): node is Declaration => node.type === 'decl') ?? []
+}
+
+function isScopedTailwindThemeCarrierRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  const declarations = getRuleDeclarations(rule)
+  return selectors.length > 0
+    && selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return hasVueScopedAttr(selector) && (normalized.startsWith(':root') || normalized.startsWith(':host'))
+    })
+    && declarations.length > 0
+    && declarations.every(decl => decl.prop.startsWith('--'))
+}
+
+function isScopedUniversalTailwindPreflightRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  const declarations = getRuleDeclarations(rule)
+  return selectors.length > 0
+    && selectors.every(selector => hasVueScopedAttr(selector) && SCOPED_UNIVERSAL_PREFLIGHT_SELECTORS.has(normalizeCssSignatureValue(selector)))
+    && declarations.length > 0
+    && declarations.every(decl => decl.prop.startsWith('--tw-') || MINI_PROGRAM_PREFLIGHT_DECLARATIONS.has(decl.prop))
+}
+
+export function isLikelyTailwindGlobalRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  const declarations = getRuleDeclarations(rule)
+  return isScopedTailwindThemeCarrierRule(rule)
+    || isScopedUniversalTailwindPreflightRule(rule)
+    || (
+      selectors.every(selector => !hasClassSelector(selector) && isLikelyTailwindGlobalSelector(selector))
+      && declarations.length > 0
+      && declarations.every(isTailwindPreflightDeclaration)
+    )
+}
+
+export function isLikelyTailwindPropertyAtRule(atRule: AtRule) {
+  return atRule.name.toLowerCase() === 'property'
+    && normalizeCssSignatureValue(atRule.params).startsWith('--tw-')
+}
+
+export function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  if (
+    selectors.length === 0
+    || !selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return !hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
+    })
+  ) {
+    return false
+  }
+  const declarations = getRuleDeclarations(rule)
+  return declarations.length > 0
+    && declarations.every(decl => decl.prop.startsWith('--tw-') || MINI_PROGRAM_PREFLIGHT_DECLARATIONS.has(decl.prop))
+}
+
+export function isScopedMiniProgramTailwindContentInitRule(rule: Rule) {
+  const selectors = rule.selectors ?? [rule.selector]
+  if (
+    selectors.length === 0
+    || !selectors.every((selector) => {
+      const normalized = normalizeCssSignatureValue(selector)
+      return hasVueScopedAttr(selector) && MINI_PROGRAM_PREFLIGHT_SELECTORS.has(normalized)
+    })
+  ) {
+    return false
+  }
+  const declarations = getRuleDeclarations(rule)
+  return declarations.length > 0 && declarations.every(decl => decl.prop === '--tw-content')
+}
+
+export function hasUnscopedMiniProgramTailwindPreflightRule(css: string) {
+  return /(?:^|[{}])\s*view\s*,\s*text\s*,\s*::after\s*,\s*::before\s*\{/.test(css)
+}
+
+export function hasScopedMiniProgramTailwindContentInitRule(css: string) {
+  return /(?:^|[{}])[^{}]*\.data-v-[\w-][^{}]*\{\s*--tw-content\s*:/.test(css)
+}

--- a/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-assets.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-assets.unit.test.ts
@@ -902,7 +902,13 @@ describe('vite processed css assets', () => {
       '/*! tailwindcss v4.3.2 | MIT License | https://tailwindcss.com */',
       '[data-v-04bcf89b]:root,[data-v-04bcf89b]:host{--spacing:.25rem}',
       '*[data-v-04bcf89b],[data-v-04bcf89b]::after,[data-v-04bcf89b]::before{box-sizing:border-box;margin:0;padding:0}',
+      'html[data-v-04bcf89b],[data-v-04bcf89b]:host{line-height:1.5;-webkit-text-size-adjust:100%;-o-tab-size:4;tab-size:4;font-family:var(--default-font-family,sans-serif);font-feature-settings:var(--default-font-feature-settings,normal);font-variation-settings:var(--default-font-variation-settings,normal);-webkit-tap-highlight-color:transparent}',
+      'abbr:where([title][data-v-04bcf89b]){text-decoration:underline dotted}',
       'button[data-v-04bcf89b],input[data-v-04bcf89b]{font:inherit;color:inherit;background-color:transparent}',
+      '[data-v-04bcf89b]::file-selector-button{margin-inline-end:4px}',
+      '[data-v-04bcf89b]::placeholder{color:currentcolor}',
+      '[data-v-04bcf89b]::-webkit-datetime-edit{padding-block:0}',
+      '[data-v-04bcf89b]::-webkit-calendar-picker-indicator{line-height:1}',
       'uni-button[data-v-04bcf89b]{font:inherit}',
       'view[data-v-04bcf89b]{color:red}',
       'button[data-v-04bcf89b]{color:red}',
@@ -926,6 +932,10 @@ describe('vite processed css assets', () => {
     expect(nextCss).not.toContain(':host')
     expect(nextCss).not.toContain('box-sizing:border-box')
     expect(nextCss).not.toContain('button[data-v-04bcf89b],input[data-v-04bcf89b]')
+    expect(nextCss).not.toContain('--default-font-family')
+    expect(nextCss).not.toContain('margin-inline-end')
+    expect(nextCss).not.toContain('currentcolor')
+    expect(nextCss).not.toContain('padding-block')
   })
 
   it('removes unscoped mini-program preflight from scoped generated css without a Tailwind banner', () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-assets.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-assets.unit.test.ts
@@ -902,8 +902,12 @@ describe('vite processed css assets', () => {
       '/*! tailwindcss v4.3.2 | MIT License | https://tailwindcss.com */',
       '[data-v-04bcf89b]:root,[data-v-04bcf89b]:host{--spacing:.25rem}',
       '*[data-v-04bcf89b],[data-v-04bcf89b]::after,[data-v-04bcf89b]::before{box-sizing:border-box;margin:0;padding:0}',
+      'button[data-v-04bcf89b],input[data-v-04bcf89b]{font:inherit;color:inherit;background-color:transparent}',
       'uni-button[data-v-04bcf89b]{font:inherit}',
       'view[data-v-04bcf89b]{color:red}',
+      'button[data-v-04bcf89b]{color:red}',
+      'input[data-v-04bcf89b]{border-color:#123456}',
+      'img[data-v-04bcf89b]{width:12px}',
       '.card[data-v-04bcf89b]{padding:16px}',
       '@media (min-width: 640px){text[data-v-04bcf89b]{display:block}.card[data-v-04bcf89b]{display:flex}}',
     ].join('\n')
@@ -911,6 +915,9 @@ describe('vite processed css assets', () => {
     const nextCss = removeScopedTailwindPreflightCss(css)
 
     expect(nextCss).toContain('view[data-v-04bcf89b]{color:red}')
+    expect(nextCss).toContain('button[data-v-04bcf89b]{color:red}')
+    expect(nextCss).toContain('input[data-v-04bcf89b]{border-color:#123456}')
+    expect(nextCss).toContain('img[data-v-04bcf89b]{width:12px}')
     expect(nextCss).toContain('uni-button[data-v-04bcf89b]{font:inherit}')
     expect(nextCss).toContain('.card[data-v-04bcf89b]{padding:16px}')
     expect(nextCss).toContain('@media (min-width: 640px)')
@@ -918,6 +925,7 @@ describe('vite processed css assets', () => {
     expect(nextCss).not.toContain('tailwindcss v4.3.2')
     expect(nextCss).not.toContain(':host')
     expect(nextCss).not.toContain('box-sizing:border-box')
+    expect(nextCss).not.toContain('button[data-v-04bcf89b],input[data-v-04bcf89b]')
   })
 
   it('removes unscoped mini-program preflight from scoped generated css without a Tailwind banner', () => {

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
@@ -323,6 +323,61 @@ describe('uni-app-x vite plugins', () => {
     expect(result?.code).toBe('css:.content{display:flex}')
   })
 
+  it('passes scoped uvue style request ids into styleHandler without dropping author css output', async () => {
+    const scopedCss = [
+      'view.data-v-abc{color:red}',
+      '.card.data-v-abc{padding:16px}',
+      '.card.data-v-abc .title.data-v-abc{font-weight:700}',
+    ].join('')
+    const styleHandler = vi.fn(async (_code: string, options?: Record<string, any>) => ({
+      css: scopedCss,
+      map: {
+        toJSON: () => ({
+          version: 3,
+          file: options?.postcssOptions?.options?.from ?? '',
+          sources: [options?.postcssOptions?.options?.from ?? ''],
+          names: [],
+          mappings: '',
+          sourcesContent: [scopedCss],
+        }),
+      },
+      warnings: () => [],
+    }))
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      isIosPlatform: false,
+      mainCssChunkMatcher: vi.fn(() => false),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler,
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      getResolvedConfig: () => ({ command: 'build', build: { watch: false } } as ResolvedConfig),
+    })
+    const cssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css')
+    expect(cssPlugin).toBeDefined()
+
+    const id = '/src/components/ScopedChild.uvue?vue&type=style&index=0&scoped=abc&lang.css'
+    const result = await cssPlugin!.transform?.('.card { padding: 16px; }', id)
+
+    expect(styleHandler).toHaveBeenCalledWith(
+      '.card { padding: 16px; }',
+      expect.objectContaining({
+        uniAppXCssTarget: 'uvue',
+        uniAppXUnsupported: 'warn',
+        postcssOptions: expect.objectContaining({
+          options: expect.objectContaining({
+            from: id,
+          }),
+        }),
+      }),
+    )
+    expect(result?.code).toBe(scopedCss)
+    expect(result?.code).toContain('view.data-v-abc{color:red}')
+    expect(result?.code).toContain('.card.data-v-abc .title.data-v-abc{font-weight:700}')
+  })
+
   it('runs nvue transform with runtime set and custom options', async () => {
     const runtimeSet = new Set(['alpha'])
     const ensureRuntimeClassSet = vi.fn(async () => runtimeSet)


### PR DESCRIPTION
## 问题与根因

- 修复 #1019 中 `uni-app x 5.2.2` 的 `uvue` 组件启用 `<style scoped>` 后，作者自定义样式被误删的问题。
- 第一层根因是 `applyUniAppXUvueCompatibility()` 把整份 SFC 作者样式当成只允许纯 class selector 的 Tailwind utility 产物，导致 `view[data-v-*]`、`.card[data-v-*] .title[data-v-*]` 等规则被删除，并产生 `selector must be class-only` 告警。
- 进一步回归发现，原先 scoped Tailwind 去噪只按标签名判断，还会把 `button`、`input`、`img` 等合法作者样式误认为 preflight。最终修复改为结合请求来源、selector 和 declaration 特征判断。

## 修复内容

- 将 uvue SFC 样式识别和 scoped Tailwind 噪音处理拆成独立内部模块。
- 从 `result.opts.from`、PostCSS AST 的 `source.input.from` 识别真实 `.uvue?type=style` 请求；request 元数据丢失时使用 `data-v-*` selector 作为回退。
- SFC 作者样式不再执行 utility 专用的 class-only selector 限制；`display: block`、`gap`、`grid-*`、无法静态化的 `calc(...)` 等 declaration 级兼容清理仍然保留。
- scoped theme carrier、universal preflight、mini-program `--tw-content` 初始化和 `@property --tw-*` 继续删除。
- Vite 二次去噪同步改为 declaration-aware 判定，避免放宽 PostCSS 后又在 bundler 阶段误删元素作者样式。
- 不修改 `transformUVue()`、`classNameSet`、bundler module graph 或组件样式注入数据流。

## CI 反馈修复

- 首轮 CI 的 `E2E Static Gate (3/3)` 暴露了 Tailwind CSS 4.3.3 新增 preflight 声明族未被完整识别的问题，导致每份 scoped CSS 泄漏 16 个 selector。
- 已补齐 `html/:host`、`abbr`、`::file-selector-button`、`::placeholder`、`::-webkit-datetime-*`、`::-webkit-calendar-picker-indicator` 对应声明特征，并在 PostCSS 与 Vite 两层加入回归断言。
- 作者自定义的 `button`、`input`、`img` 规则继续保留；`e2e:apps-generator` 的 129 份既有静态快照保持完全一致，不接受噪音泄漏造成的快照更新。

## 回归覆盖

- PostCSS 覆盖元素、属性、后代、伪元素、媒体查询、request 来源丢失、非 uvue 边界、Tailwind 噪音删除和不兼容 declaration 清理。
- Vite 入口覆盖原始 uvue scoped request id 传递；processed CSS 覆盖 `button/input/img` 作者样式不会被 preflight 清理误伤。
- HBuilderX e2e 覆盖 Web、微信小程序、Android、iOS 和鸿蒙。Web 锁定运行时计算样式，小程序锁定 scoped 组件输出标记，三套 Native 端锁定作者样式编译产物。

## 本地验证

- `@weapp-tailwindcss/postcss`：59 个测试文件通过，639 项通过，3 项跳过。
- `weapp-tailwindcss`：302 个测试文件通过，3055 项通过，29 项跳过。
- 两个包的 lint 和 build 均通过。
- `e2e:apps-generator`：10 项通过，129 份现有静态快照完全匹配。
- HBuilderX Web 页面与 HMR 通过。
- HBuilderX 微信小程序编译通过。
- HBuilderX Android 模拟器与 HMR 通过。
- HBuilderX iOS 模拟器与 HMR 通过。
- HBuilderX 鸿蒙模拟器 `127.0.0.1:5557` 与 HMR 通过。

## 发布说明

- 已为 `@weapp-tailwindcss/postcss` 和 `weapp-tailwindcss` 添加中文 patch changeset。
- 本次不涉及 `create-weapp-vite` 或模板联动。
