### PR TITLE
fix: preserve uni-app x scoped styles and native HMR

### DIFF
--- a/.changeset/fresh-uvue-runtime.md
+++ b/.changeset/fresh-uvue-runtime.md
@@ -1,0 +1,6 @@
+---
+'@weapp-tailwindcss/postcss': patch
+'weapp-tailwindcss': patch
+---
+
+修复 uni-app x scoped 作者样式被原生 Tailwind 兼容过滤误删的问题，并让 H5/Web 作者样式继续交由 SFC 预处理链处理；同时在原生 App 的 `.uvue` 类集合扩大时失效 Tailwind CSS 模块并触发自动重载，使新增字体、颜色、间距和任意值类无需手动重新运行到设备即可生效。

--- a/demo/uni-app-x-hbuilderx-tailwindcss-v4/README.md
+++ b/demo/uni-app-x-hbuilderx-tailwindcss-v4/README.md
@@ -37,3 +37,12 @@ pnpm e2e:hbuilderx:local:ios
 ```bash
 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer pnpm e2e:hbuilderx:local:ios
 ```
+
+## Issue 回归
+
+- `components/issue-1019-button/issue-1019-button.uvue` 提炼自
+  [`unibestX` 的 `weapp-tailwindcss` 分支](https://github.com/cq112233/unibestX/tree/9f0366d359002fa1c55e015eba24227a654629cf)，
+  保留 `uview-ultra/components/up-button/up-button.uvue` 中触发 #1019 的 scoped SCSS、嵌套 BEM、伪元素和变量 fallback 结构。
+- `packages/postcss/test/uni-app-x.test.ts` 验证原生兼容转换不会误删上述作者样式，
+  `e2e/hbuilderx-local/cases.ts` 则在 H5 浏览器中验证 scope 属性和 computed style。
+- 同一 demo 也用于 #1021 Android HMR 回归；每一步都同时检查构建产物、页面 marker、截图颜色和元素尺寸。

--- a/demo/uni-app-x-hbuilderx-tailwindcss-v4/components/issue-1019-button/issue-1019-button.uvue
+++ b/demo/uni-app-x-hbuilderx-tailwindcss-v4/components/issue-1019-button/issue-1019-button.uvue
@@ -1,0 +1,39 @@
+<template>
+	<view class="issue-1019-up-button up-button up-button--primary">
+		<text class="up-button__text">
+			<slot />
+		</text>
+	</view>
+</template>
+
+<style lang="scss" scoped>
+	.up-button {
+		// 从 unibestX 的 uview-ultra up-button 提炼 scoped BEM 作者样式
+		box-sizing: border-box;
+		display: flex;
+		/* #ifdef H5 */
+		display: inline-flex;
+		/* #endif */
+		align-items: center;
+		justify-content: center;
+		width: 184px;
+		height: 44px;
+		border: 2px solid var(--issue-1019-border, #073b9a);
+		border-radius: 9px;
+		color: var(--issue-1019-text, #ffffff);
+
+		&--primary {
+			background-color: var(--issue-1019-primary, #0957de);
+		}
+
+		&::after {
+			border: 1px solid var(--issue-1019-after, #dcdfe6);
+			border-radius: 9px;
+		}
+
+		&__text {
+			color: var(--issue-1019-text, #ffffff);
+			font-size: 16px;
+		}
+	}
+</style>

--- a/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
+++ b/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
@@ -1,6 +1,7 @@
 <script lang="uts">
 	import WeappTailwindcss from '../../components/WeappTailwindcss.uvue'
 	import BindClass from '../../components/BindClass.uvue'
+	import Issue1019Button from '../../components/issue-1019-button/issue-1019-button.uvue'
 
 	const buttonColors = [
 		'bg-[#000]',
@@ -25,6 +26,7 @@
 		styleIsolation: 'app',
 		components: {
 			BindClass,
+			Issue1019Button,
 			WeappTailwindcss,
 		},
 		data() {
@@ -55,6 +57,7 @@
 	<view class="content">
 		<WeappTailwindcss />
 		<BindClass />
+		<Issue1019Button>issue 1019 scoped button</Issue1019Button>
 		<view class="w-full bg-[#164e63] p-[12px] issue-1002-probe">
 			<text class="text-xs text-white">issue-1002 text-xs</text>
 			<text class="text-sm text-white">issue-1002 text-sm</text>

--- a/e2e/__snapshots__/issue-uview-plus-cssentries/uview-css-evidence.acss
+++ b/e2e/__snapshots__/issue-uview-plus-cssentries/uview-css-evidence.acss
@@ -1,5 +1,5 @@
 /* node-modules/uview-plus/components/u-button/u-button.acss */
-.u-button.data-v-e43777a0{width:100%;white-space:nowrap}
+.u-button.data-v-e43777a0{width:auto;white-space:nowrap}
 .u-button__text.data-v-e43777a0{white-space:nowrap;line-height:1}
 .u-button.data-v-e43777a0::before{position:absolute;top:50%;left:50%;width:100%;height:100%;border:inherit;border-radius:inherit;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%);opacity:0;content:" ";background-color:#000;border-color:#000}
 .u-button--active.data-v-e43777a0::before{opacity:.15}

--- a/e2e/__snapshots__/issue-uview-plus-cssentries/uview-css-evidence.wxss
+++ b/e2e/__snapshots__/issue-uview-plus-cssentries/uview-css-evidence.wxss
@@ -1,5 +1,5 @@
 /* node-modules/uview-plus/components/u-button/u-button.wxss */
-.u-button.data-v-e43777a0{width:100%;white-space:nowrap}
+.u-button.data-v-e43777a0{width:auto;white-space:nowrap}
 .u-button__text.data-v-e43777a0{white-space:nowrap;line-height:1}
 .u-button.data-v-e43777a0::before{position:absolute;top:50%;left:50%;width:100%;height:100%;border:inherit;border-radius:inherit;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%);opacity:0;content:" ";background-color:#000;border-color:#000}
 .u-button--active.data-v-e43777a0::before{opacity:.15}

--- a/e2e/hbuilderx-local-helpers.test.ts
+++ b/e2e/hbuilderx-local-helpers.test.ts
@@ -1,9 +1,19 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'pathe'
+import { parseHexColorFromClass } from './hbuilderx-local/android-runtime'
 import { collectMiniProgramStyleFiles } from './hbuilderx-local/styles'
 
 describe('HBuilderX local helpers', () => {
+  it('parses arbitrary Tailwind background colors for Android screenshot evidence', () => {
+    expect(parseHexColorFromClass('flex bg-[#102938] text-white')).toEqual({
+      blue: 56,
+      green: 41,
+      red: 16,
+    })
+    expect(parseHexColorFromClass('bg-red-500')).toBeUndefined()
+  })
+
   it('collects platform style files recursively without assuming output filenames', async () => {
     const root = await fs.mkdtemp(path.resolve(os.tmpdir(), 'hbuilderx-styles-'))
     try {

--- a/e2e/hbuilderx-local/android-runtime.ts
+++ b/e2e/hbuilderx-local/android-runtime.ts
@@ -1,0 +1,306 @@
+import { spawnSync } from 'node:child_process'
+import fsSync from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { PNG } from 'pngjs'
+
+export interface AndroidRuntimeStyleExpectation {
+  backgroundColor: string
+  height: number
+  markerText: string
+  textColor?: string
+  width: number
+}
+
+export interface AndroidRuntimeEvidence {
+  background: Awaited<ReturnType<typeof analyzeScreenshotColorPresence>>
+  density: number
+  height: number
+  markerBounds?: AndroidScreenBounds
+  markerTextVisible: boolean
+  screenshot: string
+  text?: Awaited<ReturnType<typeof analyzeScreenshotColorPresence>>
+  uiTextPreview: string
+  width: number
+}
+
+interface AndroidScreenBounds {
+  maxX: number
+  maxY: number
+  minX: number
+  minY: number
+}
+
+interface WaitForAndroidRuntimeEvidenceOptions {
+  deviceId?: string
+  ensureRunning: () => void
+  env: Record<string, string | undefined>
+  expectation: AndroidRuntimeStyleExpectation
+  label: string
+  screenshot: string
+  timeoutMs: number
+}
+
+const screenshotTimeoutMs = 30_000
+
+function createAdbArgs(deviceId?: string) {
+  return deviceId ? ['-s', deviceId] : []
+}
+
+export function resolveAdbCommand(env: Record<string, string | undefined>) {
+  const pathEntries = (env.PATH ?? process.env.PATH ?? '').split(path.delimiter)
+  const candidates = [
+    'adb',
+    ...pathEntries.map(item => path.resolve(item, process.platform === 'win32' ? 'adb.exe' : 'adb')),
+  ]
+  for (const candidate of candidates) {
+    const result = spawnSync(candidate, ['version'], { encoding: 'utf8', env: { ...process.env, ...env } })
+    if (result.status === 0) {
+      return candidate
+    }
+  }
+  return 'adb'
+}
+
+export function resolveAndroidDeviceId(launchArgs: string[] | undefined) {
+  const index = launchArgs?.indexOf('--deviceId') ?? -1
+  return process.env.E2E_HBUILDERX_ANDROID_SCREENSHOT_DEVICE_ID
+    ?? process.env.E2E_HBUILDERX_ANDROID_DEVICE_ID
+    ?? (index >= 0 ? launchArgs?.[index + 1] : undefined)
+}
+
+function readAndroidShellValue(
+  env: Record<string, string | undefined>,
+  deviceId: string | undefined,
+  args: string[],
+) {
+  const result = spawnSync(resolveAdbCommand(env), [
+    ...createAdbArgs(deviceId),
+    'shell',
+    ...args,
+  ], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    timeout: screenshotTimeoutMs,
+  })
+  return result.status === 0 ? result.stdout.trim() : ''
+}
+
+export function collectAndroidRuntimeMetadata(
+  env: Record<string, string | undefined>,
+  deviceId?: string,
+) {
+  const model = readAndroidShellValue(env, deviceId, ['getprop', 'ro.product.model'])
+  const api = readAndroidShellValue(env, deviceId, ['getprop', 'ro.build.version.sdk'])
+  const webview = readAndroidShellValue(env, deviceId, ['dumpsys', 'package', 'com.google.android.webview'])
+    || readAndroidShellValue(env, deviceId, ['dumpsys', 'package', 'com.android.webview'])
+  return {
+    api,
+    deviceId: deviceId ?? 'default',
+    model,
+    webview: webview.match(/versionName=(\S+)/)?.[1] ?? 'unknown',
+  }
+}
+
+export async function captureAndroidScreenshot(
+  screenshot: string,
+  env: Record<string, string | undefined>,
+  deviceId?: string,
+) {
+  await fs.mkdir(path.dirname(screenshot), { recursive: true })
+  const result = spawnSync(resolveAdbCommand(env), [
+    ...createAdbArgs(deviceId),
+    'exec-out',
+    'screencap',
+    '-p',
+  ], {
+    encoding: 'buffer',
+    env: { ...process.env, ...env },
+    killSignal: 'SIGTERM',
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: screenshotTimeoutMs,
+  })
+  if (result.status !== 0 || result.stdout.length === 0) {
+    const timeoutMessage = result.error?.message ? ` error=${result.error.message}` : ''
+    throw new Error(`Android 截图失败：${result.stderr.toString() || `exit=${result.status} signal=${result.signal ?? 'none'}${timeoutMessage}`}`)
+  }
+  await fs.writeFile(screenshot, result.stdout)
+}
+
+export async function readAndroidUiHierarchy(env: Record<string, string | undefined>, deviceId?: string) {
+  const adb = resolveAdbCommand(env)
+  const args = createAdbArgs(deviceId)
+  spawnSync(adb, [...args, 'shell', 'uiautomator', 'dump', '/sdcard/window.xml'], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    killSignal: 'SIGTERM',
+    timeout: screenshotTimeoutMs,
+  })
+  const result = spawnSync(adb, [...args, 'shell', 'cat', '/sdcard/window.xml'], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    killSignal: 'SIGTERM',
+    maxBuffer: 1024 * 1024,
+    timeout: screenshotTimeoutMs,
+  })
+  return result.status === 0 ? result.stdout : ''
+}
+
+export function isAndroidDebugShell(uiHierarchy: string) {
+  return /Connect to HBuilderX successfully|Failed to connect to \/127\.0\.0\.1|io\.dcloud\.uniappx:id\/pull_msg|io\.dcloud\.HBuilder\/io\.dcloud\.PandoraEntryActivity/.test(uiHierarchy)
+}
+
+function parseAndroidBounds(value: string | undefined): AndroidScreenBounds | undefined {
+  const match = value?.match(/^\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]$/)
+  if (!match) {
+    return
+  }
+  return {
+    maxX: Number(match[3]) - 1,
+    maxY: Number(match[4]) - 1,
+    minX: Number(match[1]),
+    minY: Number(match[2]),
+  }
+}
+
+function resolveAndroidMarkerBounds(uiHierarchy: string, markerText: string) {
+  for (const nodeMatch of uiHierarchy.matchAll(/<node\b([^>]*)>/g)) {
+    const attributes = new Map<string, string>()
+    for (const attributeMatch of nodeMatch[1]!.matchAll(/([\w:-]+)="([^"]*)"/g)) {
+      attributes.set(attributeMatch[1]!, attributeMatch[2]!)
+    }
+    const label = `${attributes.get('text') ?? ''} ${attributes.get('content-desc') ?? ''}`
+    if (label.includes(markerText)) {
+      return parseAndroidBounds(attributes.get('bounds'))
+    }
+  }
+}
+
+function parseHexColor(value: string) {
+  const match = value.match(/^#?([\da-f]{6})$/i)
+  if (!match?.[1]) {
+    throw new Error(`无法解析运行时颜色：${value}`)
+  }
+  return {
+    blue: Number.parseInt(match[1].slice(4, 6), 16),
+    green: Number.parseInt(match[1].slice(2, 4), 16),
+    red: Number.parseInt(match[1].slice(0, 2), 16),
+  }
+}
+
+export function parseHexColorFromClass(className: string) {
+  const match = className.match(/\bbg-\[#([\da-f]{6})\]/i)
+  return match?.[1] ? parseHexColor(match[1]) : undefined
+}
+
+export async function analyzeScreenshotColorPresence(
+  screenshot: string,
+  color: { red: number, green: number, blue: number },
+  bounds?: { maxX: number, maxY: number, minX: number, minY: number },
+) {
+  const image = PNG.sync.read(fsSync.readFileSync(screenshot))
+  const data = image.data
+  let matchingPixels = 0
+  let maxX = -1
+  let maxY = -1
+  let minX = image.width
+  let minY = image.height
+  for (let y = bounds?.minY ?? 0; y <= (bounds?.maxY ?? image.height - 1); y++) {
+    for (let x = bounds?.minX ?? 0; x <= (bounds?.maxX ?? image.width - 1); x++) {
+      const index = (y * image.width + x) * 4
+      const alpha = data[index + 3] ?? 255
+      if (alpha < 8) {
+        continue
+      }
+      if (
+        Math.abs((data[index] ?? 255) - color.red) <= 4
+        && Math.abs((data[index + 1] ?? 255) - color.green) <= 4
+        && Math.abs((data[index + 2] ?? 255) - color.blue) <= 4
+      ) {
+        matchingPixels += 1
+        minX = Math.min(minX, x)
+        minY = Math.min(minY, y)
+        maxX = Math.max(maxX, x)
+        maxY = Math.max(maxY, y)
+      }
+    }
+  }
+  return {
+    bounds: matchingPixels > 0 ? { maxX, maxY, minX, minY } : undefined,
+    color,
+    matchingPixels,
+    matched: matchingPixels > 100,
+  }
+}
+
+function readAndroidDensity(env: Record<string, string | undefined>, deviceId?: string) {
+  const result = spawnSync(resolveAdbCommand(env), [
+    ...createAdbArgs(deviceId),
+    'shell',
+    'wm',
+    'density',
+  ], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    timeout: screenshotTimeoutMs,
+  })
+  const density = Number(result.stdout.match(/Override density:\s*(\d+)/)?.[1]
+    ?? result.stdout.match(/Physical density:\s*(\d+)/)?.[1]
+    ?? 160)
+  return density / 160
+}
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function waitForAndroidRuntimeEvidence(options: WaitForAndroidRuntimeEvidenceOptions) {
+  const startedAt = Date.now()
+  let latest: AndroidRuntimeEvidence | undefined
+  const backgroundColor = parseHexColor(options.expectation.backgroundColor)
+  const textColor = options.expectation.textColor ? parseHexColor(options.expectation.textColor) : undefined
+  const density = readAndroidDensity(options.env, options.deviceId)
+
+  while (Date.now() - startedAt < options.timeoutMs) {
+    options.ensureRunning()
+    await captureAndroidScreenshot(options.screenshot, options.env, options.deviceId)
+    const uiHierarchy = await readAndroidUiHierarchy(options.env, options.deviceId)
+    const markerBounds = resolveAndroidMarkerBounds(uiHierarchy, options.expectation.markerText)
+    const background = await analyzeScreenshotColorPresence(options.screenshot, backgroundColor, markerBounds)
+    const presentationBounds = markerBounds ?? background.bounds
+    const width = presentationBounds ? presentationBounds.maxX - presentationBounds.minX + 1 : 0
+    const height = presentationBounds ? presentationBounds.maxY - presentationBounds.minY + 1 : 0
+    const text = textColor && presentationBounds
+      ? await analyzeScreenshotColorPresence(options.screenshot, textColor, presentationBounds)
+      : undefined
+    const markerTextVisible = uiHierarchy.includes(options.expectation.markerText)
+    latest = {
+      background,
+      density,
+      height,
+      markerBounds,
+      markerTextVisible,
+      screenshot: options.screenshot,
+      text,
+      uiTextPreview: uiHierarchy.replace(/\s+/g, ' ').slice(0, 1000),
+      width,
+    }
+    const expectedWidth = options.expectation.width * density
+    const expectedHeight = options.expectation.height * density
+    const sizeReady = Math.abs(width - expectedWidth) <= 14 * density
+      && Math.abs(height - expectedHeight) <= 14 * density
+    if (
+      !isAndroidDebugShell(uiHierarchy)
+      && markerTextVisible
+      && background.matched
+      && sizeReady
+      && (!textColor || (text?.matchingPixels ?? 0) >= 8)
+    ) {
+      return latest
+    }
+    await delay(500)
+  }
+
+  throw new Error(`${options.label} 未在 Android 设备呈现预期 marker/style\nexpected=${JSON.stringify(options.expectation)}\nlatest=${JSON.stringify(latest)}`)
+}

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -34,6 +34,15 @@ export interface AppHmrStep {
   transformedContains: Array<string | RegExp>
   transformedNotContains?: Array<string | RegExp>
   styleContains?: Array<string | RegExp>
+  runtime?: AndroidRuntimeStyleExpectation
+}
+
+export interface AndroidRuntimeStyleExpectation {
+  backgroundColor: string
+  height: number
+  markerText: string
+  textColor?: string
+  width: number
 }
 
 export interface AppCase {
@@ -66,6 +75,7 @@ export interface AppCase {
   styleNotContains?: Array<string | RegExp>
   hmrStyleContains?: Array<string | RegExp>
   runtimeLogContains?: Array<string | RegExp>
+  runtime?: AndroidRuntimeStyleExpectation
   logNotContains?: Array<string | RegExp>
 }
 
@@ -130,6 +140,7 @@ export interface WebHmrStep {
 
 export interface WebRuntimeStyleAssertion {
   selector: string
+  scopeAttribute?: RegExp
   styles: Record<string, string | RegExp>
 }
 
@@ -512,6 +523,13 @@ export const uniAppXAppCases: AppCase[] = [
     markerClass: 'flex h-[41px] w-[173px] items-center justify-center rounded-[9998px] bg-[#102938]',
     markerTextClass: 'text-[39rpx] text-[#f7fbff]',
     markerText: 'hbuilderx-app-dynamic-v4-android',
+    runtime: {
+      backgroundColor: '#102938',
+      height: 41,
+      markerText: 'hbuilderx-app-dynamic-v4-android',
+      textColor: '#f7fbff',
+      width: 173,
+    },
     hmrMarkerClass: 'mt-[19px] flex h-[41px] w-[173px] items-center justify-center rounded-[9997px] bg-[#3b0764] [transform:translate(10px,20px)]',
     hmrMarkerTextClass: 'text-[28rpx] text-blue-600 text-bule-600',
     hmrMarkerText: 'hbuilderx-app-hmr-v4-android',
@@ -570,6 +588,12 @@ export const uniAppXAppCases: AppCase[] = [
         markerClass: 'mt-[19px] flex h-[41px] w-[173px] items-center justify-center rounded-[9997px] bg-[#3b0764] [transform:translate(10px,20px)]',
         markerTextClass: 'text-[28rpx] text-blue-600 text-bule-600',
         markerText: 'hbuilderx-app-hmr-v4-android',
+        runtime: {
+          backgroundColor: '#3b0764',
+          height: 41,
+          markerText: 'hbuilderx-app-hmr-v4-android',
+          width: 173,
+        },
         transformedContains: [
           'hbuilderx-app-hmr-v4-android',
           'text-bule-600',
@@ -590,6 +614,13 @@ export const uniAppXAppCases: AppCase[] = [
         markerClass: 'mt-[23px] flex h-[47px] w-[181px] items-center justify-center rounded-[7777px] bg-[#0f766e]',
         markerTextClass: 'text-[31rpx] text-[#facc15]',
         markerText: 'hbuilderx-app-hmr-v4-android-round-2',
+        runtime: {
+          backgroundColor: '#0f766e',
+          height: 47,
+          markerText: 'hbuilderx-app-hmr-v4-android-round-2',
+          textColor: '#facc15',
+          width: 181,
+        },
         transformedContains: [
           'hbuilderx-app-hmr-v4-android-round-2',
           /\["backgroundColor", "#0f766e"\]/,
@@ -612,6 +643,12 @@ export const uniAppXAppCases: AppCase[] = [
         markerClass: 'mt-[17px] flex h-[43px] w-[179px] items-center justify-center rounded-[6888px] bg-[#123456]',
         markerTextClass: 'text-[30rpx] text-blue-600/50',
         markerText: 'hbuilderx-app-hmr-v4-android-color-opacity',
+        runtime: {
+          backgroundColor: '#123456',
+          height: 43,
+          markerText: 'hbuilderx-app-hmr-v4-android-color-opacity',
+          width: 179,
+        },
         transformedContains: [
           'hbuilderx-app-hmr-v4-android-color-opacity',
           /\["backgroundColor", "#123456"\]/,
@@ -636,6 +673,13 @@ export const uniAppXAppCases: AppCase[] = [
         markerClass: 'flex h-[41px] w-[173px] items-center justify-center rounded-[9998px] bg-[#102938]',
         markerTextClass: 'text-[39rpx] text-[#f7fbff]',
         markerText: 'hbuilderx-app-hmr-v4-android-deleted',
+        runtime: {
+          backgroundColor: '#102938',
+          height: 41,
+          markerText: 'hbuilderx-app-hmr-v4-android-deleted',
+          textColor: '#f7fbff',
+          width: 173,
+        },
         transformedContains: [
           'hbuilderx-app-hmr-v4-android-deleted',
           /\["backgroundColor", "#102938"\]/,
@@ -664,6 +708,12 @@ export const uniAppXAppCases: AppCase[] = [
         markerClass: 'mt-[19px] flex h-[41px] w-[173px] items-center justify-center rounded-[9997px] bg-[#3b0764] [transform:translate(10px,20px)]',
         markerTextClass: 'text-[28rpx] text-blue-600 text-bule-600',
         markerText: 'hbuilderx-app-hmr-v4-android-rollback',
+        runtime: {
+          backgroundColor: '#3b0764',
+          height: 41,
+          markerText: 'hbuilderx-app-hmr-v4-android-rollback',
+          width: 173,
+        },
         transformedContains: [
           'hbuilderx-app-hmr-v4-android-rollback',
           'text-bule-600',
@@ -854,7 +904,6 @@ export const webCases: WebCase[] = [
     initialCssPath: '/main.css?direct',
     hmrCssPath: '/main.css?direct',
     initialCssContains: [
-      /uni-page-body,\s*\.tw-root,\s*wx-root-portal-content,\s*:host/,
       '--text-xl',
       '--color-white',
       /background-color:\s*#f21903/,
@@ -884,6 +933,31 @@ export const webCases: WebCase[] = [
           borderTopColor: 'rgb(124, 58, 237)',
           borderTopStyle: 'solid',
           borderTopWidth: '2px',
+        },
+      },
+      {
+        selector: '.issue-1019-up-button',
+        scopeAttribute: /^data-v-[\da-f]+$/,
+        styles: {
+          alignItems: 'center',
+          backgroundColor: 'rgb(9, 87, 222)',
+          borderBottomColor: 'rgb(7, 59, 154)',
+          borderBottomStyle: 'solid',
+          borderBottomWidth: '2px',
+          borderRadius: '9px',
+          color: 'rgb(255, 255, 255)',
+          display: 'flex',
+          height: '44px',
+          justifyContent: 'center',
+          width: '184px',
+        },
+      },
+      {
+        selector: '.issue-1019-up-button .up-button__text',
+        scopeAttribute: /^data-v-[\da-f]+$/,
+        styles: {
+          color: 'rgb(255, 255, 255)',
+          fontSize: '16px',
         },
       },
     ],
@@ -919,7 +993,11 @@ export const webCases: WebCase[] = [
       {
         markerClass: 'hbuilderx-web-hmr-probe bg-[#0e7490] mt-[10rpx] text-xs',
         markerText: 'hbuilderx-web-hmr-v4-rem-rpx',
-        cssContains: [/background-color:\s*#0e7490/, /\.mt-_b10rpx_B\s*\{[\s\S]*margin-top:\s*0\.3125rem/, /\.text-xs\s*\{[\s\S]*font-size:\s*0\.75rem/],
+        cssContains: [
+          /background-color:\s*#0e7490/,
+          /\.mt-\\\[10rpx\\\]\s*\{[\s\S]*margin-top:\s*0\.3125rem/,
+          /\.text-xs\s*\{[\s\S]*font-size:\s*(?:var\(--text-xs\)|0\.75rem)/,
+        ],
         runtimeStyles: [{
           selector: '.hbuilderx-web-hmr-probe',
           styles: { backgroundColor: 'rgb(14, 116, 144)', fontSize: '12px', marginTop: '5px' },

--- a/e2e/hbuilderx-local/runner.ts
+++ b/e2e/hbuilderx-local/runner.ts
@@ -8,6 +8,11 @@ import process from 'node:process'
 import path from 'pathe'
 import { expect } from 'vitest'
 import { createHBuilderXProjectAlias as createSharedHBuilderXProjectAlias } from '../../scripts/hbuilderx-project-alias.mjs'
+import {
+  collectAndroidRuntimeMetadata,
+  resolveAndroidDeviceId,
+  waitForAndroidRuntimeEvidence,
+} from './android-runtime'
 import { rawTailwindDirectiveRE, resolveAppHmrSteps } from './cases'
 import {
   assertAndroidToolchain,
@@ -591,6 +596,37 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
       throw new Error(`HBuilderX app dev process exited before hot-update mutation: exit=${exit.signal ?? exit.code}\n${logs.join('')}`)
     }
     await waitForAppRuntimeLogs(item, logs, ensureLaunchRunning)
+    const androidDeviceId = item.platform === 'app-android'
+      ? resolveAndroidDeviceId(launchArgs)
+      : undefined
+    const runtimeEvidenceRoot = path.resolve(
+      os.tmpdir(),
+      'weapp-tailwindcss-hbuilderx-runtime',
+      `${process.pid}-${item.name.replace(/[^\w-]+/g, '-')}`,
+    )
+    let previousRuntimeScreenshot: string | undefined
+    if (item.platform === 'app-android') {
+      if (!item.runtime) {
+        throw new Error(`${item.name} 缺少 Android 初始运行时断言`)
+      }
+      const initialScreenshot = path.resolve(runtimeEvidenceRoot, 'initial.png')
+      const evidence = await waitForAndroidRuntimeEvidence({
+        deviceId: androidDeviceId,
+        ensureRunning: ensureLaunchRunning,
+        env: androidEnv,
+        expectation: item.runtime,
+        label: `${item.name} initial`,
+        screenshot: initialScreenshot,
+        timeoutMs: hbuilderxAppTimeoutMs,
+      })
+      previousRuntimeScreenshot = evidence.screenshot
+      process.stdout.write(`${JSON.stringify({
+        hbuilderx: hbuilderx.resolution,
+        outputRoot: initialOutputRoot,
+        runtime: collectAndroidRuntimeMetadata(androidEnv, androidDeviceId),
+        runtimeEvidence: evidence,
+      })}\n`)
+    }
     let hmrOutputRoot = initialOutputRoot
     for (const step of resolveAppHmrSteps(item)) {
       await writeAppMarker(sourceFile, resolveAppMarkerAnchors(item), {
@@ -607,6 +643,28 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
           `recentHBuilderXLogs=${logs.join('').slice(-4000)}`,
         ].join('\n')
       }, step.styleContains, [...(item.transformedNotContains ?? []), ...(step.transformedNotContains ?? [])])
+      if (item.platform === 'app-android') {
+        if (!step.runtime) {
+          throw new Error(`${item.name} ${step.name} 缺少 Android 运行时断言`)
+        }
+        const screenshot = path.resolve(runtimeEvidenceRoot, `${step.name}.png`)
+        const evidence = await waitForAndroidRuntimeEvidence({
+          deviceId: androidDeviceId,
+          ensureRunning: ensureLaunchRunning,
+          env: androidEnv,
+          expectation: step.runtime,
+          label: `${item.name} ${step.name}`,
+          screenshot,
+          timeoutMs: hbuilderxAppTimeoutMs,
+        })
+        process.stdout.write(`${JSON.stringify({
+          outputRoot: hmrOutputRoot,
+          previousRuntimeScreenshot,
+          runtimeEvidence: evidence,
+          step: step.name,
+        })}\n`)
+        previousRuntimeScreenshot = evidence.screenshot
+      }
     }
     await assertAppOutputHasNoUnsupportedContent(item, hmrOutputRoot)
     expectNoContent(logs.join(''), item.logNotContains, `${item.name} HBuilderX 日志`)

--- a/e2e/hbuilderx-local/web.ts
+++ b/e2e/hbuilderx-local/web.ts
@@ -133,14 +133,26 @@ async function waitForCss(url: string, entries: Array<string | RegExp>, child: C
     }
     await wait(pollIntervalMs)
   }
-  throw new Error(`等待 CSS 内容超时：${url}\n${latest.slice(0, 1000)}\n${logs.join('')}`)
+  const missing = entries.filter((entry) => {
+    return typeof entry === 'string' ? !latest.includes(entry) : !entry.test(latest)
+  })
+  throw new Error(`等待 CSS 内容超时：${url}\nmissing=${missing.map(String).join(', ')}\n${latest.slice(0, 1000)}\n${logs.join('')}`)
 }
 
 function formatRuntimeStyleAssertions(assertions: WebRuntimeStyleAssertion[]) {
-  return assertions.map(assertion => `${assertion.selector}: ${Object.keys(assertion.styles).join(', ')}`).join('; ')
+  return assertions.map((assertion) => {
+    const scope = assertion.scopeAttribute ? ` scope=${assertion.scopeAttribute}` : ''
+    return `${assertion.selector}${scope}: ${Object.keys(assertion.styles).join(', ')}`
+  }).join('; ')
 }
 
-function matchRuntimeStyles(actual: Record<string, string>, assertion: WebRuntimeStyleAssertion) {
+function matchRuntimeStyles(actual: Record<string, string | string[]>, assertion: WebRuntimeStyleAssertion) {
+  if (assertion.scopeAttribute) {
+    const attributeNames = actual.__attributeNames
+    if (!Array.isArray(attributeNames) || !attributeNames.some(name => assertion.scopeAttribute!.test(name))) {
+      return false
+    }
+  }
   for (const [property, expected] of Object.entries(assertion.styles)) {
     const value = actual[property]
     if (typeof expected === 'string') {
@@ -148,7 +160,7 @@ function matchRuntimeStyles(actual: Record<string, string>, assertion: WebRuntim
         return false
       }
     }
-    else if (!expected.test(value ?? '')) {
+    else if (!expected.test(typeof value === 'string' ? value : '')) {
       return false
     }
   }
@@ -163,7 +175,10 @@ async function readRuntimeStyles(page: Page, assertion: WebRuntimeStyleAssertion
         return null
       }
       const computed = getComputedStyle(element)
-      return Object.fromEntries(properties.map(property => [property, computed[property as keyof CSSStyleDeclaration]?.toString() ?? '']))
+      return {
+        ...Object.fromEntries(properties.map(property => [property, computed[property as keyof CSSStyleDeclaration]?.toString() ?? ''])),
+        __attributeNames: element.getAttributeNames(),
+      }
     }, {
       properties: Object.keys(assertion.styles),
       selector: assertion.selector,

--- a/packages/postcss/src/compat/uni-app-x-uvue.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue.ts
@@ -203,10 +203,15 @@ export function applyUniAppXUvueCompatibility(
 
   if (sfcStyleRequest) {
     stripScopedTailwindNoise(root)
+
+    const nextResult = root.toResult(result.opts)
+    nextResult.messages.push(...result.messages)
+    nextResult.messages.push(...calcMessages)
+    return nextResult
   }
 
   root.walkRules((rule) => {
-    if (!sfcStyleRequest && !hasOnlyClassSelectors(rule)) {
+    if (!hasOnlyClassSelectors(rule)) {
       reportUnsupportedRule(rule, result, mode, warningCache, 'selector must be class-only')
       rule.remove()
       return

--- a/packages/postcss/src/compat/uni-app-x-uvue/scoped-style.ts
+++ b/packages/postcss/src/compat/uni-app-x-uvue/scoped-style.ts
@@ -152,7 +152,11 @@ function isTailwindPreflightDeclaration(decl: postcss.Declaration) {
   return TAILWIND_PREFLIGHT_DECLARATIONS.has(`${prop}:${value}`)
 }
 
-function isScopedTailwindThemeCarrierRule(rule: Rule) {
+function hasTailwindSourceEvidence(declarations: postcss.Declaration[], hasTailwindBanner: boolean) {
+  return hasTailwindBanner || declarations.some(decl => decl.prop.startsWith('--tw-'))
+}
+
+function isScopedTailwindThemeCarrierRule(rule: Rule, hasTailwindBanner: boolean) {
   const selectors = rule.selectors ?? [rule.selector]
   const declarations = getDeclarations(rule)
   return selectors.length > 0
@@ -162,15 +166,17 @@ function isScopedTailwindThemeCarrierRule(rule: Rule) {
     })
     && declarations.length > 0
     && declarations.every(decl => decl.prop.startsWith('--'))
+    && hasTailwindSourceEvidence(declarations, hasTailwindBanner)
 }
 
-function isScopedUniversalTailwindPreflightRule(rule: Rule) {
+function isScopedUniversalTailwindPreflightRule(rule: Rule, hasTailwindBanner: boolean) {
   const selectors = rule.selectors ?? [rule.selector]
   const declarations = getDeclarations(rule)
   return selectors.length > 0
     && selectors.every(selector => hasVueScopedAttr(selector) && SCOPED_UNIVERSAL_PREFLIGHT_SELECTORS.has(normalizeCssSignatureValue(selector)))
     && declarations.length > 0
     && declarations.every(decl => decl.prop.startsWith('--tw-') || ['box-sizing', 'margin', 'padding', 'border'].includes(decl.prop))
+    && hasTailwindSourceEvidence(declarations, hasTailwindBanner)
 }
 
 function isScopedTailwindElementPreflightRule(rule: Rule, hasTailwindBanner: boolean) {
@@ -185,7 +191,7 @@ function isScopedTailwindElementPreflightRule(rule: Rule, hasTailwindBanner: boo
     && declarations.every(isTailwindPreflightDeclaration)
 }
 
-function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule) {
+function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule, hasTailwindBanner: boolean) {
   const selectors = rule.selectors ?? [rule.selector]
   if (
     selectors.length === 0
@@ -197,7 +203,9 @@ function isUnscopedMiniProgramTailwindPreflightRule(rule: Rule) {
     return false
   }
   const declarations = getDeclarations(rule)
-  return declarations.length > 0 && declarations.every(decl => decl.prop.startsWith('--tw-') || ['box-sizing', 'margin', 'padding', 'border'].includes(decl.prop))
+  return declarations.length > 0
+    && declarations.every(decl => decl.prop.startsWith('--tw-') || ['box-sizing', 'margin', 'padding', 'border'].includes(decl.prop))
+    && hasTailwindSourceEvidence(declarations, hasTailwindBanner)
 }
 
 function isScopedMiniProgramTailwindContentInitRule(rule: Rule) {
@@ -236,10 +244,10 @@ export function stripScopedTailwindNoise(root: postcss.Root) {
   })
   root.walkRules((rule) => {
     if (
-      isScopedTailwindThemeCarrierRule(rule)
-      || isScopedUniversalTailwindPreflightRule(rule)
+      isScopedTailwindThemeCarrierRule(rule, hasTailwindBanner)
+      || isScopedUniversalTailwindPreflightRule(rule, hasTailwindBanner)
       || isScopedTailwindElementPreflightRule(rule, hasTailwindBanner)
-      || isUnscopedMiniProgramTailwindPreflightRule(rule)
+      || isUnscopedMiniProgramTailwindPreflightRule(rule, hasTailwindBanner)
       || isScopedMiniProgramTailwindContentInitRule(rule)
     ) {
       rule.remove()

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -454,6 +454,8 @@ describe('uni-app-x', () => {
       '.card.data-v-abc .title.data-v-abc{font-weight:700}',
       '@media (min-width:640px){button.data-v-abc{color:green}}',
       'text.data-v-abc{display:block}',
+      '.up-button--primary.data-v-abc{display:inline-flex;min-height:100vh;gap:8px;background:var(--up-primary, #0957de)}',
+      '.up-button--primary.data-v-abc::after{border:1px solid var(--up-border, #dcdfe6);border-radius:8px}',
       '@property --tw-content{syntax:"*";initial-value:"";inherits:false}',
     ].join(''), {
       from: '/src/components/ScopedChild.uvue?vue&type=style&index=0&scoped=abc&lang.css',
@@ -485,10 +487,38 @@ describe('uni-app-x', () => {
     expect(filtered.css).not.toContain('margin-inline-end')
     expect(filtered.css).not.toContain('currentcolor')
     expect(filtered.css).not.toContain('padding-block')
-    expect(filtered.css).not.toContain('display:block')
-    expect(warningTexts).toHaveLength(1)
-    expect(warningTexts[0]).toContain('display: block')
-    expect(warningTexts[0]).not.toContain('selector must be class-only')
+    expect(filtered.css).toContain('text.data-v-abc{display:block}')
+    expect(filtered.css).toContain('.up-button--primary.data-v-abc{display:inline-flex;min-height:100vh;gap:8px;')
+    expect(filtered.css).toContain('background:var(--up-primary)')
+    expect(filtered.css).toContain('.up-button--primary.data-v-abc::after{border:1px solid var(--up-border, #dcdfe6);border-radius:8px}')
+    expect(warningTexts).toEqual([])
+  })
+
+  it('preserves ambiguous scoped author reset and theme rules without Tailwind source evidence', async () => {
+    const result = await postcss().process([
+      '[data-v-abc]:root{--brand:#0957de}',
+      '*[data-v-abc]{box-sizing:border-box;margin:0;padding:0}',
+      'view{margin:0}',
+      '[data-v-abc]:host{--tw-author-noise:0}',
+      '*[data-v-abc]{--tw-reset-noise:0}',
+      'text{--tw-mini-noise:0}',
+    ].join(''), {
+      from: '/src/components/ScopedChild.uvue?vue&type=style&index=0&scoped=abc&lang.css',
+    })
+
+    const filtered = applyUniAppXUvueCompatibility(result, {
+      uniAppX: true,
+      uniAppXCssTarget: 'uvue',
+      uniAppXUnsupported: 'warn',
+    })
+
+    expect(filtered.css).toContain('[data-v-abc]:root{--brand:#0957de}')
+    expect(filtered.css).toContain('*[data-v-abc]{box-sizing:border-box;margin:0;padding:0}')
+    expect(filtered.css).toContain('view{margin:0}')
+    expect(filtered.css).not.toContain('--tw-author-noise')
+    expect(filtered.css).not.toContain('--tw-reset-noise')
+    expect(filtered.css).not.toContain('--tw-mini-noise')
+    expect(filtered.warnings()).toEqual([])
   })
 
   it('detects scoped uvue requests from the PostCSS input source when result options lose from', async () => {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/frameworks/uni-app-x/index.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/frameworks/uni-app-x/index.ts
@@ -85,7 +85,9 @@ export function createUniAppXVitePlugins(options: UserDefinedOptions | InternalU
       mainCssChunkMatcher: context.mainCssChunkMatcher,
       runtimeState: context.runtimeState,
       styleHandler: context.styleHandler,
+      tailwindRootCssModuleIds: context.tailwindRootCssModuleIds,
       uniAppX: context.uniAppX,
+      viteProcessedCssSourceFiles: context.viteProcessedCssSourceFiles,
     }),
   })
 }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins-runtime.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins-runtime.ts
@@ -422,7 +422,7 @@ ${tracedCss}`
       await discoverAndRegisterAutoCssSources()
     } await sourceScanSession.sync()
   }
-  const extraPlugins = frameworkBranch.createExtraPlugins?.({ customAttributesEntities, disabledDefaultTemplateHandler, ensureRuntimeClassSet, generateCss: generateTailwindCssForVitePipeline, getResolvedConfig, isEnabled: shouldEnableFrameworkExtraPlugins, isIosPlatform: extraPluginPlatform.isIosPlatform === true, jsHandler, mainCssChunkMatcher, runtimeState, styleHandler, uniAppX }) ?? []
+  const extraPlugins = frameworkBranch.createExtraPlugins?.({ customAttributesEntities, disabledDefaultTemplateHandler, ensureRuntimeClassSet, generateCss: generateTailwindCssForVitePipeline, getResolvedConfig, isEnabled: shouldEnableFrameworkExtraPlugins, isIosPlatform: extraPluginPlatform.isIosPlatform === true, jsHandler, mainCssChunkMatcher, runtimeState, styleHandler, tailwindRootCssModuleIds, uniAppX, viteProcessedCssSourceFiles: processedCssRegistry.sourceFiles }) ?? []
   const installFrameworkWatchCssCacheAdapter = async (config) => {
     if (!shouldAdaptFrameworkWatchCss()) {
       return

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
@@ -39,7 +39,9 @@ export interface ViteFrameworkExtraPluginContext {
   mainCssChunkMatcher: ReturnType<typeof getCompilerContext>['mainCssChunkMatcher']
   runtimeState: ReturnType<typeof createViteRuntimeClassSet>['runtimeState']
   styleHandler: ReturnType<typeof getCompilerContext>['styleHandler']
+  tailwindRootCssModuleIds: Set<string>
   uniAppX: ReturnType<typeof getCompilerContext>['uniAppX']
+  viteProcessedCssSourceFiles: Iterable<string>
 }
 
 function wrapPluginHook(

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
@@ -33,6 +33,7 @@ import {
 } from './style-asset'
 import { resolveUniAppXStyleIsolationEnabled } from './style-isolation'
 import { createUniAppXHarmonyApplyExpander } from './vite/harmony-apply'
+import { createUniAppXNativeHmrReloader } from './vite/native-hmr'
 import { createUniAppXNativeBuildTargetResolver } from './vite/native-target'
 
 type TransformUVue = typeof import('./transform')['transformUVue']
@@ -43,17 +44,14 @@ function loadTransformUVue(): Promise<TransformUVue> {
   return transformUVuePromise
 }
 
-interface UniAppXRuntimeState {
-  readyPromise: Promise<unknown>
-}
-
 interface CreateUniAppXPluginsOptions {
   appType: AppType
   customAttributesEntities: ICustomAttributesEntities
-  disabledDefaultTemplateHandler: boolean
+  disabledDefaultTemplateHandler: boolean | undefined
   mainCssChunkMatcher: NonNullable<InternalUserDefinedOptions['mainCssChunkMatcher']>
-  runtimeState: UniAppXRuntimeState
+  runtimeState: { readyPromise: Promise<unknown> }
   styleHandler: InternalUserDefinedOptions['styleHandler']
+  tailwindRootCssModuleIds?: Iterable<string> | undefined
   generateCss?: ((id: string, code: string, hookContext?: { addWatchFile?: (id: string) => void, transient?: boolean }) => Promise<string | undefined> | string | undefined) | undefined
   jsHandler: JsHandler
   ensureRuntimeClassSet: (force?: boolean) => Promise<Set<string>>
@@ -61,6 +59,7 @@ interface CreateUniAppXPluginsOptions {
   isIosPlatform?: boolean
   isEnabled?: (() => boolean) | undefined
   uniAppX?: InternalUserDefinedOptions['uniAppX']
+  viteProcessedCssSourceFiles?: Iterable<string> | undefined
 }
 
 const preprocessorLangs = new Set(['scss', 'sass', 'less', 'styl', 'stylus'])
@@ -105,12 +104,14 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     mainCssChunkMatcher,
     runtimeState,
     styleHandler,
+    tailwindRootCssModuleIds = [],
     generateCss,
     jsHandler,
     ensureRuntimeClassSet,
     getResolvedConfig,
     isEnabled = () => true,
     uniAppX,
+    viteProcessedCssSourceFiles = [],
   } = options
   const resolvedUniAppXOptions = resolveUniAppXOptions(uniAppX)
   const utsPlatform = resolveUniUtsPlatform()
@@ -132,6 +133,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
   }>()
   let componentLocalStyleEnabled: boolean | undefined
   const isNativeAppBuildTarget = createUniAppXNativeBuildTargetResolver(getResolvedConfig)
+  const nativeHmrReloader = createUniAppXNativeHmrReloader({ ensureRuntimeClassSet, isNativeAppBuildTarget, tailwindRootCssModuleIds, viteProcessedCssSourceFiles })
 
   function shouldEnableComponentLocalStyle() {
     if (!resolvedUniAppXOptions.componentLocalStyles.enabled) {
@@ -167,7 +169,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     if (!styleHandlerOptions) {
       styleHandlerOptions = omitUndefined({
         isMainChunk: mainCssChunkMatcher(id, appType),
-        uniAppXCssTarget: resolveUniAppXCssTarget(id),
+        uniAppXCssTarget: isNativeAppBuildTarget(id) ? resolveUniAppXCssTarget(id) : undefined,
         uniAppXUnsupported: resolvedUniAppXOptions.uvueUnsupported,
         postcssOptions: {
           options: {
@@ -203,6 +205,9 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       }
       const shouldGenerateCss = hasTailwindSourceDirectives(code, { importFallback: true })
         || hasTailwindApplyDirective(code)
+      if (!isNativeAppBuildTarget(id) && !shouldGenerateCss) {
+        return
+      }
       harmonyApply.rememberSource(code, id)
       const generatedCss = (
         shouldGenerateCss
@@ -278,7 +283,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       if (!isEnabled()) {
         return
       }
-      await ensureRuntimeClassSet(true)
+      await nativeHmrReloader.refreshBaseline()
     },
     async transform(code, id) {
       if (!isEnabled()) {
@@ -297,6 +302,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       const currentRuntimeSet: Set<string> = shouldForceRefresh
         ? await ensureRuntimeClassSet(true)
         : await ensureRuntimeClassSet()
+      nativeHmrReloader.remember(currentRuntimeSet)
       const transformUVue = await loadTransformUVue()
       const enableComponentLocalStyle = shouldEnableComponentLocalStyle()
       const enablePageLocalStyle = shouldEnableNativePageLocalStyle(id)
@@ -335,8 +341,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       if (!UVUE_NVUE_RE.test(ctx.file)) {
         return
       }
-      // 热重载新增类名，无需等待完整重建
-      await ensureRuntimeClassSet(true)
+      return nativeHmrReloader.handleHotUpdate(ctx)
     },
     async watchChange(id) {
       if (!isEnabled()) {
@@ -415,7 +420,6 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     stylePlaceholderPlugin,
   ]
 }
-
 type ApplyLinkedResults = (linked: Record<string, LinkedJsModuleResult> | undefined) => void
 
 interface CreateUniAppXAssetTaskOptions {

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite/native-hmr.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite/native-hmr.ts
@@ -1,0 +1,50 @@
+import type { HmrContext } from 'vite'
+import { resolveHotTailwindCssModules, sendFullReloadForUnresolvedHotUpdate } from '@/bundlers/vite/hot-css-modules'
+
+interface CreateUniAppXNativeHmrReloaderOptions {
+  ensureRuntimeClassSet: (force?: boolean) => Promise<Set<string>>
+  isNativeAppBuildTarget: (id?: string) => boolean
+  tailwindRootCssModuleIds: Iterable<string>
+  viteProcessedCssSourceFiles: Iterable<string>
+}
+
+export function createUniAppXNativeHmrReloader(
+  options: CreateUniAppXNativeHmrReloaderOptions,
+) {
+  let previousRuntimeClassSet: Set<string> | undefined
+
+  function remember(runtimeClassSet: Set<string>) {
+    previousRuntimeClassSet = new Set(runtimeClassSet)
+    return runtimeClassSet
+  }
+
+  async function refreshBaseline() {
+    return remember(await options.ensureRuntimeClassSet(true))
+  }
+
+  async function handleHotUpdate(ctx: HmrContext) {
+    if (!options.isNativeAppBuildTarget(ctx.file)) {
+      return
+    }
+    const cssModules = ctx.server?.moduleGraph
+      ? resolveHotTailwindCssModules(ctx, new Set([
+          ...options.tailwindRootCssModuleIds,
+          ...options.viteProcessedCssSourceFiles,
+        ]))
+      : []
+    const currentRuntimeClassSet = await options.ensureRuntimeClassSet(true)
+    const hasAddedClass = previousRuntimeClassSet !== undefined
+      && [...currentRuntimeClassSet].some(candidate => !previousRuntimeClassSet!.has(candidate))
+    remember(currentRuntimeClassSet)
+    if (hasAddedClass) {
+      sendFullReloadForUnresolvedHotUpdate(ctx)
+    }
+    return cssModules.length > 0 ? [...new Set([...ctx.modules, ...cssModules])] : undefined
+  }
+
+  return {
+    handleHotUpdate,
+    refreshBaseline,
+    remember,
+  }
+}

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.uni-app-x.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.uni-app-x.unit.test.ts
@@ -23,6 +23,15 @@ function getGenerateBundleHandler(plugin: Plugin) {
   return typeof hook === 'object' ? hook.handler : hook
 }
 
+function createNativeResolvedConfig() {
+  return {
+    command: 'serve',
+    css: { postcss: { plugins: [] } },
+    build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android' },
+    root: '/project',
+  } as unknown as ResolvedConfig
+}
+
 describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -61,6 +70,8 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
     expect(cssPrePlugin?.transform).toBeTypeOf('function')
     expect(nvuePlugin?.transform).toBeTypeOf('function')
 
+    await (postPlugin.configResolved as any)?.call(postPlugin, createNativeResolvedConfig())
+    currentContext.tailwindRuntime.extract.mockClear()
     const cssTransform = cssPlugin.transform as any
     const cssResult = await cssTransform?.call(cssPlugin, '.foo { color: red; }', 'App.uvue?vue&type=style&index=0') as TransformResult
     expect(cssResult?.code).toBe('css:.foo { color: red; }')
@@ -72,9 +83,15 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
     expect(currentContext.tailwindRuntime.getClassSetSync).not.toHaveBeenCalled()
     const nvueTransform = nvuePlugin.transform as any
     const nvueResult = await nvueTransform?.call(nvuePlugin, 'console.log("x")', 'App.nvue')
-    expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(1)
+    expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(2)
     expect(currentContext.tailwindRuntime.getClassSetSync).not.toHaveBeenCalled()
-    expect(transformUVueMock).toHaveBeenCalledWith('console.log("x")', 'App.nvue', currentContext.jsHandler, runtimeSet)
+    expect(transformUVueMock).toHaveBeenCalledWith(
+      'console.log("x")',
+      'App.nvue',
+      currentContext.jsHandler,
+      runtimeSet,
+      expect.objectContaining({ enablePageLocalStyle: true }),
+    )
     expect(nvueResult).toEqual({ code: 'uvue:App.nvue:console.log("x")' })
 
     const bundle = {
@@ -93,7 +110,7 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
 
     const generateBundle = getGenerateBundleHandler(postPlugin)
     await generateBundle?.call(postPlugin, {} as any, bundle)
-    expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(1)
+    expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(2)
     expect(currentContext.tailwindRuntime.getClassSetSync).not.toHaveBeenCalled()
 
     expect(currentContext.jsHandler).toHaveBeenCalledWith(
@@ -346,8 +363,10 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
 
     const plugins = WeappTailwindcss()
     const cssPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:uni-app-x:css') as Plugin
+    const postPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:post') as Plugin
     expect(cssPlugin).toBeTruthy()
 
+    await (postPlugin.configResolved as any)?.call(postPlugin, createNativeResolvedConfig())
     const cssTransform = cssPlugin.transform as any
     await cssTransform?.call(cssPlugin, '.foo { color: red; }', 'App.uvue?vue&type=style&index=0')
     await cssTransform?.call(cssPlugin, '.foo { color: blue; }', 'App.uvue?vue&type=style&index=0')
@@ -367,8 +386,10 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
 
     const plugins = WeappTailwindcss()
     const cssPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:uni-app-x:css') as Plugin
+    const postPlugin = plugins?.find(plugin => plugin.name === 'weapp-tailwindcss:adaptor:post') as Plugin
     expect(cssPlugin).toBeTruthy()
 
+    await (postPlugin.configResolved as any)?.call(postPlugin, createNativeResolvedConfig())
     const cssTransform = cssPlugin.transform as any
     await cssTransform?.call(cssPlugin, '.foo { color: red; }', 'App.uvue?vue&type=style&index=0')
 
@@ -669,7 +690,7 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
     const config = {
       command: 'serve',
       css: { postcss: { plugins: [] } },
-      build: { outDir: 'dist' },
+      build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android' },
       root: process.cwd(),
     } as unknown as ResolvedConfig
     await (postPlugin.configResolved as any)?.call(postPlugin, config)
@@ -678,14 +699,23 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
     currentContext.tailwindRuntime.extract.mockClear()
     currentContext.tailwindRuntime.getClassSetSync.mockClear()
     runtimeIndex = 1
-    await (nvuePlugin.handleHotUpdate as any)?.call(nvuePlugin, { file: '/src/pages/foo.uvue' } as HmrContext)
+    const server = {
+      config,
+      moduleGraph: {
+        getModuleById: vi.fn(),
+        getModulesByFile: vi.fn(),
+        invalidateModule: vi.fn(),
+      },
+      ws: { send: vi.fn() },
+    }
+    await (nvuePlugin.handleHotUpdate as any)?.call(nvuePlugin, { file: '/src/pages/foo.uvue', modules: [], server } as unknown as HmrContext)
     expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(1)
     expect(currentContext.tailwindRuntime.getClassSetSync).not.toHaveBeenCalled()
 
     currentContext.tailwindRuntime.extract.mockClear()
     currentContext.tailwindRuntime.getClassSetSync.mockClear()
     runtimeIndex = 1
-    await (nvuePlugin.handleHotUpdate as any)?.call(nvuePlugin, { file: '/src/pages/foo.nvue' } as HmrContext)
+    await (nvuePlugin.handleHotUpdate as any)?.call(nvuePlugin, { file: '/src/pages/foo.nvue', modules: [], server } as unknown as HmrContext)
     expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(1)
     expect(currentContext.tailwindRuntime.getClassSetSync).not.toHaveBeenCalled()
 

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
@@ -147,7 +147,10 @@ describe('uni-app-x vite plugins', () => {
       styleHandler,
       jsHandler: vi.fn(),
       ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
-      getResolvedConfig: () => ({ command: 'build', build: { watch: false } } as ResolvedConfig),
+      getResolvedConfig: () => ({
+        command: 'build',
+        build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android', watch: false },
+      } as ResolvedConfig),
     })
     const cssPlugin = plugins.find((p): p is Plugin => Boolean(p.name?.includes(':css')))
     expect(cssPlugin).toBeDefined()
@@ -266,7 +269,10 @@ describe('uni-app-x vite plugins', () => {
       styleHandler,
       jsHandler: vi.fn(),
       ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
-      getResolvedConfig: () => ({ command: 'build', build: { watch: false } } as ResolvedConfig),
+      getResolvedConfig: () => ({
+        command: 'build',
+        build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android', watch: false },
+      } as ResolvedConfig),
     })
     const preCssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
     expect(preCssPlugin).toBeDefined()
@@ -353,7 +359,10 @@ describe('uni-app-x vite plugins', () => {
       styleHandler,
       jsHandler: vi.fn(),
       ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
-      getResolvedConfig: () => ({ command: 'build', build: { watch: false } } as ResolvedConfig),
+      getResolvedConfig: () => ({
+        command: 'build',
+        build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android', watch: false },
+      } as ResolvedConfig),
     })
     const cssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css')
     expect(cssPlugin).toBeDefined()
@@ -376,6 +385,45 @@ describe('uni-app-x vite plugins', () => {
     expect(result?.code).toBe(scopedCss)
     expect(result?.code).toContain('view.data-v-abc{color:red}')
     expect(result?.code).toContain('.card.data-v-abc .title.data-v-abc{font-weight:700}')
+  })
+
+  it('leaves H5 uvue author styles to the Sass and Vue scoped pipeline', async () => {
+    const id = '/src/components/ScopedChild.uvue?vue&type=style&index=0&scoped=abc&lang.css'
+    const styleHandler = vi.fn(async (code: string, options?: Record<string, any>) => ({
+      css: code,
+      map: {
+        toJSON: () => ({
+          version: 3,
+          file: options?.postcssOptions?.options?.from ?? '',
+          sources: [options?.postcssOptions?.options?.from ?? ''],
+          names: [],
+          mappings: '',
+          sourcesContent: [code],
+        }),
+      },
+      warnings: () => [],
+    }))
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      isIosPlatform: false,
+      mainCssChunkMatcher: vi.fn(() => false),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler,
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      getResolvedConfig: () => ({
+        command: 'build',
+        build: { outDir: '/project/unpackage/dist/build/h5', watch: false },
+      } as ResolvedConfig),
+    })
+    const cssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css')
+
+    const result = await cssPlugin!.transform?.('.up-button { &--primary { display: inline-flex; } }', id)
+
+    expect(result).toBeUndefined()
+    expect(styleHandler).not.toHaveBeenCalled()
   })
 
   it('runs nvue transform with runtime set and custom options', async () => {
@@ -421,6 +469,133 @@ describe('uni-app-x vite plugins', () => {
     currentConfig = { command: 'build', build: { watch: true } } as ResolvedConfig
     await nvuePlugin!.watchChange?.('/foo.uvue?vue&type=template')
     expect(ensureRuntimeClassSet).toHaveBeenCalledWith(true)
+  })
+
+  it('reloads a native app when a uvue hot update expands the runtime class set', async () => {
+    const initialRuntimeSet = new Set(['text-red-500'])
+    const expandedRuntimeSet = new Set(['text-red-500', 'bg-blue-500'])
+    const ensureRuntimeClassSet = vi.fn()
+      .mockResolvedValueOnce(initialRuntimeSet)
+      .mockResolvedValueOnce(expandedRuntimeSet)
+      .mockResolvedValueOnce(initialRuntimeSet)
+    const send = vi.fn()
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => true),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet,
+      getResolvedConfig: () => ({
+        command: 'serve',
+        build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android', watch: false },
+      } as ResolvedConfig),
+    })
+    const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
+    const context = {
+      file: '/project/pages/index/index.uvue',
+      modules: [],
+      server: { ws: { send } },
+    } as unknown as HmrContext
+
+    await nvuePlugin!.buildStart?.()
+    await nvuePlugin!.handleHotUpdate?.(context)
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'full-reload',
+      path: '*',
+      triggeredBy: context.file,
+    })
+
+    send.mockClear()
+    await nvuePlugin!.handleHotUpdate?.(context)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('invalidates and returns deduplicated Tailwind CSS modules for uvue hot updates', async () => {
+    const runtimeSet = new Set(['text-red-500'])
+    const sourceModule = { id: '/project/pages/index/index.uvue', url: '/pages/index/index.uvue' }
+    const cssModule = { file: '/project/main.css', id: '/project/main.css?direct', url: '/main.css?direct' }
+    const invalidateModule = vi.fn()
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => true),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet: vi.fn(async () => runtimeSet),
+      getResolvedConfig: () => ({
+        command: 'serve',
+        build: { outDir: '/project/unpackage/dist/dev/.uvue/app-android', watch: false },
+      } as ResolvedConfig),
+      tailwindRootCssModuleIds: new Set(['/project/main.css']),
+      viteProcessedCssSourceFiles: new Set(['/project/main.css']),
+    })
+    const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
+    const context = {
+      file: '/project/pages/index/index.uvue',
+      modules: [sourceModule, cssModule],
+      server: {
+        config: { root: '/project' },
+        moduleGraph: {
+          getModuleById: vi.fn(() => undefined),
+          getModulesByFile: vi.fn((file: string) => file === '/project/main.css' ? new Set([cssModule]) : undefined),
+          invalidateModule,
+        },
+      },
+    } as unknown as HmrContext
+
+    await nvuePlugin!.buildStart?.()
+    const modules = await nvuePlugin!.handleHotUpdate?.(context)
+
+    expect(invalidateModule).toHaveBeenCalledWith(cssModule)
+    expect(modules).toEqual([sourceModule, cssModule])
+  })
+
+  it('leaves web uvue hot updates to the framework source-candidates plugin', async () => {
+    const ensureRuntimeClassSet = vi.fn(async () => new Set(['text-red-500']))
+    const invalidateModule = vi.fn()
+    const send = vi.fn()
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => true),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet,
+      getResolvedConfig: () => ({ command: 'serve', root: '/project' } as ResolvedConfig),
+      tailwindRootCssModuleIds: new Set(['/project/main.css']),
+      viteProcessedCssSourceFiles: new Set(['/project/main.css']),
+    })
+    const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
+    const context = {
+      file: '/project/pages/index/index.uvue',
+      modules: [],
+      server: {
+        config: { root: '/project' },
+        moduleGraph: {
+          getModuleById: vi.fn(),
+          getModulesByFile: vi.fn(),
+          invalidateModule,
+        },
+        ws: { send },
+      },
+    } as unknown as HmrContext
+
+    await nvuePlugin!.buildStart?.()
+    ensureRuntimeClassSet.mockClear()
+    const modules = await nvuePlugin!.handleHotUpdate?.(context)
+
+    expect(modules).toBeUndefined()
+    expect(ensureRuntimeClassSet).not.toHaveBeenCalled()
+    expect(invalidateModule).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
   })
 
   it('enables component local style transform when manifest.json sets styleIsolationVersion=2', async () => {

--- a/scripts/demo-visual-e2e-report/app.ts
+++ b/scripts/demo-visual-e2e-report/app.ts
@@ -9,6 +9,14 @@ import fs from 'node:fs/promises'
 import process from 'node:process'
 import path from 'pathe'
 import { PNG } from 'pngjs'
+import {
+  analyzeScreenshotColorPresence,
+  captureAndroidScreenshot,
+  isAndroidDebugShell,
+  parseHexColorFromClass,
+  readAndroidUiHierarchy,
+  resolveAdbCommand,
+} from '../../e2e/hbuilderx-local/android-runtime.ts'
 import { resolveAppHmrSteps } from '../../e2e/hbuilderx-local/cases.ts'
 import {
   assertAndroidToolchain,
@@ -38,7 +46,6 @@ import {
 const appMarkerRE = /\n[ \t]*<view class="[^"]+">(?:<text class="[^"]+">)?hbuilderx-app-(?:dynamic|hmr)-[^<]+(?:<\/text>)?<\/view>/g
 const appReadyTimeoutMs = Number(process.env['DEMO_VISUAL_APP_READY_TIMEOUT_MS'] ?? 120_000)
 const appOutputTimeoutMs = Number(process.env['DEMO_VISUAL_APP_OUTPUT_TIMEOUT_MS'] ?? Math.min(hbuilderxAppTimeoutMs, 180_000))
-const androidScreenshotTimeoutMs = Number(process.env['DEMO_VISUAL_ANDROID_SCREENSHOT_TIMEOUT_MS'] ?? 30_000)
 const harmonyScreenshotTimeoutMs = Number(process.env['DEMO_VISUAL_HARMONY_SCREENSHOT_TIMEOUT_MS'] ?? 30_000)
 const iosScreenshotTimeoutMs = Number(process.env['DEMO_VISUAL_IOS_SCREENSHOT_TIMEOUT_MS'] ?? 30_000)
 
@@ -252,21 +259,6 @@ async function writeAppMarker(
   await fs.writeFile(file, next, 'utf8')
 }
 
-function resolveAdbCommand(env: Record<string, string | undefined>) {
-  const pathEntries = (env.PATH ?? process.env['PATH'] ?? '').split(path.delimiter)
-  const candidates = [
-    'adb',
-    ...pathEntries.map(item => path.resolve(item, process.platform === 'win32' ? 'adb.exe' : 'adb')),
-  ]
-  for (const candidate of candidates) {
-    const result = spawnSync(candidate, ['version'], { encoding: 'utf8', env: { ...process.env, ...env } })
-    if (result.status === 0) {
-      return candidate
-    }
-  }
-  return 'adb'
-}
-
 function cleanupAndroidAppRuntime(env: Record<string, string | undefined>, deviceId?: string) {
   const adb = resolveAdbCommand(env)
   spawnSync(adb, [...createAndroidAdbArgs(deviceId), 'reverse', '--remove-all'], {
@@ -275,52 +267,10 @@ function cleanupAndroidAppRuntime(env: Record<string, string | undefined>, devic
   })
 }
 
-async function captureAndroidScreenshot(screenshot: string, env: Record<string, string | undefined>, deviceId?: string) {
-  await fs.mkdir(path.dirname(screenshot), { recursive: true })
-  const adb = resolveAdbCommand(env)
-  const args = [
-    ...(deviceId ? ['-s', deviceId] : []),
-    'exec-out',
-    'screencap',
-    '-p',
-  ]
-  const result = spawnSync(adb, args, {
-    encoding: 'buffer',
-    env: { ...process.env, ...env },
-    killSignal: 'SIGTERM',
-    maxBuffer: 20 * 1024 * 1024,
-    timeout: androidScreenshotTimeoutMs,
-  })
-  if (result.status !== 0 || result.stdout.length === 0) {
-    const timeoutMessage = result.error?.message ? ` error=${result.error.message}` : ''
-    throw new Error(`Android 截图失败：${result.stderr.toString() || `exit=${result.status} signal=${result.signal ?? 'none'}${timeoutMessage}`}`)
-  }
-  await fs.writeFile(screenshot, result.stdout)
-}
-
 function createAndroidAdbArgs(deviceId?: string) {
   return [
     ...(deviceId ? ['-s', deviceId] : []),
   ]
-}
-
-async function readAndroidUiHierarchy(env: Record<string, string | undefined>, deviceId?: string) {
-  const adb = resolveAdbCommand(env)
-  const baseArgs = createAndroidAdbArgs(deviceId)
-  spawnSync(adb, [...baseArgs, 'shell', 'uiautomator', 'dump', '/sdcard/window.xml'], {
-    encoding: 'utf8',
-    env: { ...process.env, ...env },
-    killSignal: 'SIGTERM',
-    timeout: androidScreenshotTimeoutMs,
-  })
-  const result = spawnSync(adb, [...baseArgs, 'shell', 'cat', '/sdcard/window.xml'], {
-    encoding: 'utf8',
-    env: { ...process.env, ...env },
-    killSignal: 'SIGTERM',
-    maxBuffer: 1024 * 1024,
-    timeout: androidScreenshotTimeoutMs,
-  })
-  return result.status === 0 ? result.stdout : ''
 }
 
 function resolveIosScreenshotTarget(item: AppCase) {
@@ -453,61 +403,6 @@ async function analyzeAppScreenshot(screenshot: string) {
   }
 }
 
-function parseHexColorFromClass(className: string) {
-  const match = className.match(/\bbg-\[#([0-9a-f]{6})\]/i)
-  if (!match?.[1]) {
-    return undefined
-  }
-  const value = match[1]
-  return {
-    blue: Number.parseInt(value.slice(4, 6), 16),
-    green: Number.parseInt(value.slice(2, 4), 16),
-    red: Number.parseInt(value.slice(0, 2), 16),
-  }
-}
-
-async function analyzeScreenshotColorPresence(
-  screenshot: string,
-  color: { red: number, green: number, blue: number },
-) {
-  const image = PNG.sync.read(fsSync.readFileSync(screenshot))
-  const data = image.data
-  let matchingPixels = 0
-  let maxX = -1
-  let maxY = -1
-  let minX = image.width
-  let minY = image.height
-  for (let index = 0; index < data.length; index += 4) {
-    const alpha = data[index + 3] ?? 255
-    if (alpha < 8) {
-      continue
-    }
-    const red = data[index] ?? 255
-    const green = data[index + 1] ?? 255
-    const blue = data[index + 2] ?? 255
-    if (
-      Math.abs(red - color.red) <= 3
-      && Math.abs(green - color.green) <= 3
-      && Math.abs(blue - color.blue) <= 3
-    ) {
-      matchingPixels += 1
-      const pixel = index / 4
-      const x = pixel % image.width
-      const y = Math.floor(pixel / image.width)
-      minX = Math.min(minX, x)
-      minY = Math.min(minY, y)
-      maxX = Math.max(maxX, x)
-      maxY = Math.max(maxY, y)
-    }
-  }
-  return {
-    bounds: matchingPixels > 0 ? { maxX, maxY, minX, minY } : undefined,
-    color,
-    matchingPixels,
-    matched: matchingPixels > 100,
-  }
-}
-
 async function analyzeIssue1002MarkerPresentation(
   screenshot: string,
   marker: Awaited<ReturnType<typeof analyzeScreenshotColorPresence>>,
@@ -561,10 +456,6 @@ async function analyzeIssue1002MarkerPresentation(
     roundedReady,
     whiteTextReady,
   }
-}
-
-function isAndroidDebugShell(uiHierarchy: string) {
-  return /Connect to HBuilderX successfully|Failed to connect to \/127\.0\.0\.1|io\.dcloud\.uniappx:id\/pull_msg|io\.dcloud\.HBuilder\/io\.dcloud\.PandoraEntryActivity/.test(uiHierarchy)
 }
 
 async function collectAppScreenshotEvidence(


### PR DESCRIPTION
## Summary

- preserve scoped author CSS in uni-app x without applying destructive native filtering to H5/Web
- refresh native runtime candidates and invalidate Tailwind CSS modules during `.uvue` HMR, with full reload only when native class candidates expand
- add a maintained unibestX/uview-ultra regression fixture plus shared Android screenshot, marker, color, and size evidence

## Testing

- `pnpm --filter @weapp-tailwindcss/postcss test`
- `pnpm --filter weapp-tailwindcss test`
- `pnpm --filter @weapp-tailwindcss/postcss build`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm e2e:static`
- stable and alpha HBuilderX H5 runtime
- stable and alpha HBuilderX Android HMR and visual E2E on API 36
- external unibestX published/disabled/local-fixed A/B

## Related Issues

Fixes #1019
Fixes #1021