### PR TITLE
fix: remove empty PostCSS fallback declarations

### DIFF
--- a/.changeset/clean-uni-filter-fallbacks.md
+++ b/.changeset/clean-uni-filter-fallbacks.md
@@ -1,0 +1,6 @@
+---
+'@weapp-tailwindcss/postcss': patch
+'weapp-tailwindcss': patch
+---
+
+修复 uni-app 的 PostCSS 兼容链展开 Tailwind CSS v4 空变量回退值后生成 `filter: ;` 与 `backdrop-filter: ;` 的问题；最终小程序样式会移除无效的普通空属性，同时保留 Tailwind 运行时所需的空自定义属性初始化。

--- a/packages/postcss/src/compat/mini-program-css/finalize.ts
+++ b/packages/postcss/src/compat/mini-program-css/finalize.ts
@@ -14,6 +14,7 @@ import { collectPreflightRules, createPreflightResetRule } from './preflight'
 import {
   removeDisplayP3Declarations,
   removeEmptyAtRules,
+  removeEmptyStandardPropertyFallbacks,
   removeRootSpecificityPlaceholders,
   removeSpecificityPlaceholders,
   removeSpecificityPlaceholdersFromSource,
@@ -44,6 +45,7 @@ function finalizeMiniProgramCssRoot(root: postcss.Root, options: FinalizeMiniPro
   removeRootSpecificityPlaceholders(root)
   removeUnsupportedBrowserSelectors(root)
   removeDisplayP3Declarations(root)
+  removeEmptyStandardPropertyFallbacks(root)
   removeTailwindContainerMaxWidthMediaRules(root)
   removeTailwindContainerWidthRules(root, { generatedOnly: true })
   removeUnsupportedModernColorDeclarations(root)

--- a/packages/postcss/src/compat/mini-program-css/root-cleanups.ts
+++ b/packages/postcss/src/compat/mini-program-css/root-cleanups.ts
@@ -163,6 +163,23 @@ function removeDeclarationAndEmptyRule(decl: postcss.Declaration) {
   }
 }
 
+export function removeEmptyStandardPropertyFallbacks(root: postcss.Root) {
+  root.walkDecls((decl) => {
+    if (
+      !decl.prop.startsWith('--')
+      && decl.value.trim().length === 0
+      && decl.parent?.nodes.some(node => (
+        node !== decl
+        && node.type === 'decl'
+        && node.prop === decl.prop
+        && node.value.trim().length > 0
+      ))
+    ) {
+      removeDeclarationAndEmptyRule(decl)
+    }
+  })
+}
+
 export function removeDisplayP3Declarations(root: postcss.Root) {
   root.walkAtRules((atRule) => {
     if (isDisplayP3MediaRule(atRule)) {

--- a/packages/postcss/test/mini-program-generated-css.test.ts
+++ b/packages/postcss/test/mini-program-generated-css.test.ts
@@ -120,6 +120,22 @@ describe('mini-program generated css cleanup', () => {
     expect(css).toContain('.keep{color:red}')
   })
 
+  it('removes empty standard declarations generated from Tailwind v4 custom property fallbacks', () => {
+    const css = finalizeMiniProgramCss([
+      ':host,page,.tw-root,wx-root-portal-content{--tw-blur: ;--tw-backdrop-blur: ;}',
+      '.blur-3xl{--tw-blur:blur(64px);filter: ;filter:var(--tw-blur,) var(--tw-brightness,)}',
+      '.backdrop-blur-sm{--tw-backdrop-blur:blur(8px);backdrop-filter: ;backdrop-filter:var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,)}',
+      '.legacy{legacy:/* uni variables */}',
+    ].join('\n'), { isTailwindcssV4: true })
+
+    expect(css).toMatch(/--tw-blur:\s*;/)
+    expect(css).toMatch(/--tw-backdrop-blur:\s*;/)
+    expect(css).toMatch(/filter:var\(--tw-blur,\s*\) var\(--tw-brightness,\s*\)/)
+    expect(css).toMatch(/backdrop-filter:var\(--tw-backdrop-blur,\s*\) var\(--tw-backdrop-brightness,\s*\)/)
+    expect(css).not.toMatch(/(?:^|[;{])\s*(?:backdrop-)?filter:\s*;/)
+    expect(css).toContain('legacy:/* uni variables */')
+  })
+
   it('preserves user page custom properties that use Tailwind v4 theme namespaces', async () => {
     const styleHandler = createStyleHandler({
       majorVersion: 4,

--- a/packages/weapp-tailwindcss/test/bundlers/framework-postcss.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/framework-postcss.unit.test.ts
@@ -113,6 +113,44 @@ describe('framework PostCSS pipeline', () => {
     expect(new Set(files)).toEqual(new Set(['/workspace/src/theme.css']))
   })
 
+  it('removes empty standard fallbacks emitted by the framework PostCSS pipeline', async () => {
+    const currentOwner = owner()
+    captureFrameworkPostcssOptions(currentOwner, {
+      plugins: [{
+        postcssPlugin: 'framework-custom-property-fallback',
+        Declaration(decl: postcss.Declaration) {
+          if (decl.prop === 'filter' && decl.value.includes('var(')) {
+            decl.cloneBefore({ value: ' ' })
+          }
+        },
+      }],
+    })
+    const styleHandler = vi.fn(async (css: string, options: any) => {
+      return postcss(options.postcssOptions.plugins).process(css, options.postcssOptions.options)
+    })
+
+    const css = await adaptGeneratedCssWithFrameworkPipeline(currentOwner, {
+      css: ':host,page,.tw-root,wx-root-portal-content{--tw-blur: }.blur-3xl{--tw-blur:blur(64px);filter:var(--tw-blur,) var(--tw-brightness,)}',
+      classSet: new Set(['blur-3xl']),
+      dependencies: [],
+      source: 'generator',
+      target: 'weapp',
+      metadata: {
+        file: '/workspace/src/theme.css',
+        preflightMode: { inject: false, preserve: true },
+      },
+    }, {
+      cssHandlerOptions: { isMainChunk: true } as any,
+      file: '/workspace/src/theme.css',
+      majorVersion: 4,
+      styleHandler: styleHandler as any,
+    })
+
+    expect(css).toContain('--tw-blur:')
+    expect(css).toMatch(/filter:var\(--tw-blur,\s*\) var\(--tw-brightness,\s*\)/)
+    expect(css).not.toMatch(/(?:^|[;{])\s*filter:\s*;/)
+  })
+
   it('clears the captured pipeline when the framework has no PostCSS config', () => {
     const currentOwner = owner()
     expect(captureFrameworkPostcssOptions(currentOwner, {


### PR DESCRIPTION
## Summary

- 修复 uni-app PostCSS 兼容链展开 Tailwind CSS v4 空变量回退值后生成空 filter 和 backdrop-filter 声明的问题
- 仅清理同一规则中已有有效同名声明的空 fallback，保留 Tailwind 空自定义属性初始化和内部 legacy 标记
- 补充 PostCSS 最终化与框架 PostCSS 回放回归测试，并增加中文 changeset

## Root cause

postcss-preset-env 的 custom-properties 转换在 preserve 模式下会同时输出展开声明和原始声明。Tailwind CSS v4 空 fallback 被展开为空普通属性，最终进入小程序样式产物。

## Verification

- pnpm --filter @weapp-tailwindcss/postcss test
- pnpm --filter weapp-tailwindcss test
- pnpm --filter @weapp-tailwindcss/postcss lint
- pnpm --filter weapp-tailwindcss lint
- pnpm --filter @weapp-tailwindcss/postcss build
- pnpm --filter weapp-tailwindcss build
- uni-app 3.0.0-5010520260709002 mp-weixin 精确构建验证