### PR TITLE
fix: enforce empty at-rule cleanup across mini-program bundlers

### DIFF
--- a/.changeset/clean-empty-mini-program-at-rules.md
+++ b/.changeset/clean-empty-mini-program-at-rules.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app、Taro、MPX、weapp-vite 与原生 Gulp 小程序在冷构建或增量更新后可能输出空条件规则并导致平台样式解析报错的问题。

--- a/demo/issue-uview-plus-cssentries/src/pages/demonstration/index.vue
+++ b/demo/issue-uview-plus-cssentries/src/pages/demonstration/index.vue
@@ -20,7 +20,10 @@ const message = "Hello uview-plus";
 </template>
 
 <style lang="scss" scoped>
+@reference "../../styles/tailwindcss.css";
+
 .hello-scss {
+  @apply flex bg-[#f1f1f1] dark:bg-[#232323];
   color: #f00;
 }
 </style>

--- a/e2e/issue-uview-plus-cssentries.test.ts
+++ b/e2e/issue-uview-plus-cssentries.test.ts
@@ -3,7 +3,9 @@ import process from 'node:process'
 import { execa } from 'execa'
 import path from 'pathe'
 import { describe, expect, it } from 'vitest'
+import { collectEmptyBlockAtRules } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/css-integrity'
 import { ensureProjectBuilt } from './projectBuild'
+import { hasScopedDarkApplyProbeStyle, initialScopedDarkApplyProbeState } from './scopedDarkApplyProbe'
 
 const demoRoot = path.resolve(__dirname, '../demo/issue-uview-plus-cssentries')
 const expectedUviewCssTokens = [
@@ -122,8 +124,22 @@ async function buildPlatform(platform: 'mp-weixin' | 'mp-alipay') {
 async function expectUviewCssEvidence(platform: 'mp-weixin' | 'mp-alipay') {
   const { assets } = await buildPlatform(platform)
   const css = assets.map(asset => asset.source).join('\n')
+  const ext = platform === 'mp-weixin' ? 'wxss' : 'acss'
+  const pageStyleFile = `pages/demonstration/index.${ext}`
+  const pageStyle = assets.find(asset => asset.file === pageStyleFile)
 
   expect(assets.map(asset => asset.file)).toContain(platform === 'mp-weixin' ? 'app.wxss' : 'app.acss')
+  expect(pageStyle, `${platform} should emit ${pageStyleFile}`).toBeDefined()
+  expect(
+    hasScopedDarkApplyProbeStyle(pageStyle?.source ?? '', initialScopedDarkApplyProbeState),
+    `${platform} should preserve scoped base and dark @apply declarations`,
+  ).toBe(true)
+  for (const asset of assets) {
+    expect(
+      collectEmptyBlockAtRules(asset.source),
+      `${platform} ${asset.file} should not emit empty block at-rules`,
+    ).toEqual([])
+  }
   expect(css).toContain('.u-button')
   expect(css).toContain('var(--up-primary')
   expect(css).toContain('.u-loading-icon')
@@ -141,7 +157,6 @@ async function expectUviewCssEvidence(platform: 'mp-weixin' | 'mp-alipay') {
   expect(evidence).toContain('.u-button')
   expect(evidence).toContain('.u-loading-icon')
 
-  const ext = platform === 'mp-weixin' ? 'wxss' : 'acss'
   const snapshotPath = path.resolve(__dirname, `__snapshots__/issue-uview-plus-cssentries/uview-css-evidence.${ext}`)
   await fs.mkdir(path.dirname(snapshotPath), { recursive: true })
   await expect(evidence).toMatchFileSnapshot(snapshotPath)

--- a/e2e/multiplatform-build-output.test.ts
+++ b/e2e/multiplatform-build-output.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { getMultiplatformBuildOutputCases, MULTIPLATFORM_BUILD_OUTPUT_CASES } from './multiplatform-build-output/cases'
-import { uniqueTargetKey } from './multiplatform-build-output/helpers'
+import { isMiniProgramTarget, uniqueTargetKey } from './multiplatform-build-output/helpers'
 import { verifyBuildOutputCase } from './multiplatform-build-output/runner'
 import { MULTIPLATFORM_TARGETS } from './multiplatform-build-output/targets'
+import { E2E_PROJECTS } from './projectEntries'
 
 describe('multiplatform build output smoke', () => {
   it('keeps full platform matrix covered and local-only cases documented', () => {
@@ -43,6 +44,18 @@ describe('multiplatform build output smoke', () => {
     for (const item of MULTIPLATFORM_BUILD_OUTPUT_CASES.filter(item => item.status === 'ci')) {
       expect(item.styleFileExtensions?.length, `${item.name} should declare expected style output suffixes`).toBeGreaterThan(0)
     }
+
+    const miniProgramCases = MULTIPLATFORM_BUILD_OUTPUT_CASES.filter(isMiniProgramTarget)
+    expect(miniProgramCases.length).toBeGreaterThan(0)
+    for (const item of miniProgramCases) {
+      expect(item.forbidEmptyBlockAtRules, `${item.name} should guard every final style output`).toBe(true)
+    }
+
+    for (const item of MULTIPLATFORM_BUILD_OUTPUT_CASES.filter(item => /^(?:h5|quickapp)/.test(item.platform))) {
+      expect(item.forbidEmptyBlockAtRules, `${item.name} web output should preserve legal empty conditional rules`).not.toBe(true)
+    }
+
+    expect(E2E_PROJECTS.every(item => item.forbidEmptyBlockAtRules)).toBe(true)
   })
 
   it.each(getMultiplatformBuildOutputCases())('$name', async (item) => {

--- a/e2e/multiplatform-build-output/case-factories.ts
+++ b/e2e/multiplatform-build-output/case-factories.ts
@@ -130,7 +130,7 @@ export function uniAppMiniCase(options: {
     styleFileExtensions: [styleFile.slice(styleFile.lastIndexOf('.'))],
     textFiles: options.textFile ? [`${outputDir}/${options.textFile}`] : undefined,
     styleContains: options.styleContains,
-    forbidEmptyBlockAtRules: options.project === 'uni-app-vite-tailwindcss-v4',
+    forbidEmptyBlockAtRules: true,
     textContains: options.textContains,
     notContains: [rawTailwindDirectiveRE],
     env: options.project === 'uni-app-vite-tailwindcss-v4'
@@ -236,6 +236,7 @@ export function uniAppSubpackageMiniCase(options: {
     styleContains: singleEntry
       ? [cssMarker(options.markers.main), cssMarker(options.markers.normal), cssMarker(options.markers.independent)]
       : [cssMarker(options.markers.main), cssMarker(options.markers.normal), cssMarker(options.markers.independent)],
+    forbidEmptyBlockAtRules: true,
     textContains: [options.markers.main, options.markers.normal, options.markers.independent],
     fileAssertions: createSubpackageCssAssertions({
       appStyleFile: `${outputDir}/${mainStyleFile}`,
@@ -348,6 +349,7 @@ export function uniAppHBuilderXMiniCase(options: {
       '.w-_b120px_B',
       '.h-_b6rem_B',
     ],
+    forbidEmptyBlockAtRules: true,
     textContains: [
       'bg-_b_h123456_B',
       'text-_b_h888800_B',
@@ -404,6 +406,7 @@ export function mpxCase(options: {
           '.bg-_b_h123456_B',
           '.before_ccontent',
         ],
+    forbidEmptyBlockAtRules: true,
     textContains: isV4
       ? [
           'bg-_b_h123456_B',
@@ -488,6 +491,7 @@ export function taroMiniCase(options: {
     styleFileExtensions: [options.platform === 'alipay' ? '.acss' : '.ttss'],
     textFiles: [output.pageScript],
     styleContains: options.styleContains,
+    forbidEmptyBlockAtRules: true,
     textContains: options.textContains,
     fileAssertions: options.fileAssertions,
     notContains: [rawTailwindDirectiveRE],
@@ -535,6 +539,7 @@ export function taroSubpackageMiniCase(options: {
     styleFileExtensions: [options.platform === 'alipay' ? '.acss' : '.ttss', extension],
     textFiles: ['dist'],
     styleContains: [cssMarker(options.markers.main), cssMarker(options.markers.normal), cssMarker(options.markers.independent)],
+    forbidEmptyBlockAtRules: true,
     textContains: [options.markers.main, options.markers.normal, options.markers.independent],
     fileAssertions: createSubpackageCssAssertions({
       appStyleFile: output.appStyle,
@@ -607,6 +612,7 @@ export function gulpMiniCase(options: {
     styleFileExtensions: ['.ttss'],
     textFiles: ['dist'],
     styleContains: options.styleContains,
+    forbidEmptyBlockAtRules: true,
     textContains: options.textContains,
     notContains: [rawTailwindDirectiveRE],
     status: 'ci',
@@ -672,6 +678,7 @@ export function styleInjectorUniAppMiniCase(options: {
       '.injector-uni-ali-entry',
       '.injector-uni-independent',
     ],
+    forbidEmptyBlockAtRules: true,
     textContains: [
       'injector-uni-normal',
       'injector-uni-independent',
@@ -861,6 +868,7 @@ export function styleInjectorMpxMiniCase(options: {
       '.injector-mpx-less-entry',
       '.injector-mpx-independent',
     ],
+    forbidEmptyBlockAtRules: true,
     textContains: [
       'injector-mpx-normal',
       'injector-mpx-independent',
@@ -947,6 +955,7 @@ export function styleInjectorTaroMiniCase(options: {
       lessMarker,
       independentMarker,
     ],
+    forbidEmptyBlockAtRules: true,
     textContains: [
       `injector-${options.markerPrefix}-normal`,
       `injector-${options.markerPrefix}-independent`,

--- a/e2e/multiplatform-build-output/helpers.ts
+++ b/e2e/multiplatform-build-output/helpers.ts
@@ -2,6 +2,25 @@ import type { BuildOutputCase } from './types'
 
 export const rawTailwindDirectiveRE = /@(import\s+["']tailwindcss|tailwind|apply|theme|source)\b/
 
+const MINI_PROGRAM_PLATFORM_NAMES = new Set([
+  'ali',
+  'alipay',
+  'dd',
+  'jd',
+  'qq',
+  'swan',
+  'tt',
+  'weapp',
+  'wx',
+])
+
+export function isMiniProgramTarget(target: Pick<BuildOutputCase, 'framework' | 'platform'>) {
+  return target.framework === 'gulp'
+    || target.framework === 'mpx'
+    || target.platform.startsWith('mp-')
+    || MINI_PROGRAM_PLATFORM_NAMES.has(target.platform)
+}
+
 export function createLocalTargetCase(options: {
   name: string
   framework: BuildOutputCase['framework']
@@ -19,6 +38,7 @@ export function createLocalTargetCase(options: {
     requiredFiles: ['package.json'],
     styleFiles: ['package.json'],
     styleContains: [],
+    forbidEmptyBlockAtRules: isMiniProgramTarget(options),
     verifySourceFixtures: false,
     status: 'local',
     reason: options.reason,

--- a/e2e/projectEntries.ts
+++ b/e2e/projectEntries.ts
@@ -1,6 +1,6 @@
 import type { ProjectEntry } from './shared.ts'
 
-export const E2E_PROJECTS = [
+export const E2E_PROJECTS = ([
   {
     name: 'gulp-tailwindcss-v4',
     projectPath: 'gulp-tailwindcss-v4',
@@ -74,7 +74,6 @@ export const E2E_PROJECTS = [
     buildEnv: {
       WEAPP_TW_ISSUE_1005_FINAL_CSS_FIXTURE: '1',
     },
-    forbidEmptyBlockAtRules: true,
   },
   {
     name: 'uni-app-vite-vue3-hbuilderx-tailwindcss-v4',
@@ -96,7 +95,10 @@ export const E2E_PROJECTS = [
       'dist/sub-independent/pages/index.wxss',
     ],
   },
-] satisfies ProjectEntry[]
+] satisfies ProjectEntry[]).map(entry => ({
+  ...entry,
+  forbidEmptyBlockAtRules: true,
+})) satisfies ProjectEntry[]
 
 export const NATIVE_PROJECTS = [] satisfies ProjectEntry[]
 

--- a/e2e/projectTest.ts
+++ b/e2e/projectTest.ts
@@ -13,6 +13,7 @@ import { collectTokenSourceReports, formatTokenSourceFileReport } from './tokenS
 export { ensureProjectBuilt } from './projectBuild'
 
 const EPERM_RE = /EPERM/i
+const MINI_PROGRAM_STYLE_OUTPUT_RE = /\.(?:acss|css|jxss|qss|ttss|wxss)$/i
 const automator = new Launcher()
 const cleanedProjectSnapshotDirs = new Set<string>()
 
@@ -60,6 +61,18 @@ async function safeRm(target: string) {
       throw error
     }
   }
+}
+
+async function collectMiniProgramStyleOutputs(directory: string): Promise<string[]> {
+  const entries = await fs.readdir(directory, { withFileTypes: true }).catch(() => [])
+  const files = await Promise.all(entries.map(async (entry) => {
+    const file = path.resolve(directory, entry.name)
+    if (entry.isDirectory()) {
+      return collectMiniProgramStyleOutputs(file)
+    }
+    return entry.isFile() && MINI_PROGRAM_STYLE_OUTPUT_RE.test(entry.name) ? [file] : []
+  }))
+  return files.flat()
 }
 
 function isUpdatingSnapshots() {
@@ -359,14 +372,18 @@ async function runProjectTest(entry: ProjectEntry, options: ProjectTestOptions) 
     )
   }
 
-  for (const cssEntry of getProjectCssSnapshotFiles(entry)) {
-    if (entry.forbidEmptyBlockAtRules) {
-      const source = await fs.readFile(path.resolve(projectPath, cssEntry.cssFile), 'utf8')
+  if (entry.forbidEmptyBlockAtRules) {
+    const outputStyleRoot = path.dirname(path.resolve(projectPath, entry.cssFile))
+    for (const file of await collectMiniProgramStyleOutputs(outputStyleRoot)) {
+      const source = await fs.readFile(file, 'utf8')
       expect(
         collectEmptyBlockAtRules(source),
-        `${entry.name}/${cssEntry.snapshotName} should not emit empty block at-rules`,
+        `${entry.name}/${path.relative(projectPath, file)} should not emit empty block at-rules`,
       ).toEqual([])
     }
+  }
+
+  for (const cssEntry of getProjectCssSnapshotFiles(entry)) {
     const shouldNormalizeWebpackAppSplitNoise = (
       entry.name === 'taro-webpack-react-tailwindcss-v4'
       || entry.name === 'taro-webpack-vue3-tailwindcss-v4'

--- a/e2e/scopedDarkApplyProbe.ts
+++ b/e2e/scopedDarkApplyProbe.ts
@@ -1,0 +1,85 @@
+import postcss from 'postcss'
+
+export interface ScopedDarkApplyProbeState {
+  darkBackground: string
+  display: 'block' | 'flex' | 'inline-flex'
+}
+
+export const initialScopedDarkApplyProbeState: ScopedDarkApplyProbeState = {
+  darkBackground: '#232323',
+  display: 'flex',
+}
+
+function createApplyDirective(state: ScopedDarkApplyProbeState) {
+  return `@apply ${state.display} bg-[#f1f1f1] dark:bg-[${state.darkBackground}];`
+}
+
+export function replaceScopedDarkApplyProbeState(
+  source: string,
+  from: ScopedDarkApplyProbeState,
+  to: ScopedDarkApplyProbeState,
+) {
+  return source.replace(createApplyDirective(from), createApplyDirective(to))
+}
+
+function collectScopedDarkApplyProbeDeclarations(source: string) {
+  const baseBackgrounds = new Set<string>()
+  const darkBackgrounds = new Set<string>()
+  const displays = new Set<string>()
+  const root = postcss.parse(source)
+  root.walkRules((rule) => {
+    if (!rule.selector.includes('.hello-scss')) {
+      return
+    }
+    let parent = rule.parent
+    let isDark = false
+    while (parent) {
+      if (parent.type === 'atrule'
+        && parent.name === 'media'
+        && parent.params.includes('prefers-color-scheme: dark')) {
+        isDark = true
+        break
+      }
+      parent = parent.parent
+    }
+    rule.walkDecls((declaration) => {
+      const value = declaration.value.toLowerCase()
+      if (declaration.prop === 'background-color') {
+        (isDark ? darkBackgrounds : baseBackgrounds).add(value)
+      }
+      else if (!isDark && declaration.prop === 'display') {
+        displays.add(value)
+      }
+    })
+  })
+  return { baseBackgrounds, darkBackgrounds, displays }
+}
+
+export function hasScopedDarkApplyProbeDisplay(
+  source: string,
+  display: ScopedDarkApplyProbeState['display'],
+) {
+  try {
+    return collectScopedDarkApplyProbeDeclarations(source).displays.has(display)
+  }
+  catch {
+    return false
+  }
+}
+
+export function hasScopedDarkApplyProbeStyle(source: string, options: ScopedDarkApplyProbeState & {
+  staleDarkBackgrounds?: readonly string[] | undefined
+}) {
+  try {
+    const declarations = collectScopedDarkApplyProbeDeclarations(source)
+    return declarations.displays.has(options.display)
+      && declarations.baseBackgrounds.has('#f1f1f1')
+      && declarations.darkBackgrounds.has(options.darkBackground.toLowerCase())
+      && (options.staleDarkBackgrounds ?? []).every(
+        background => !declarations.darkBackgrounds.has(background.toLowerCase()),
+      )
+  }
+  catch {
+    return false
+  }
+}

--- a/e2e/uniAppCssPostHmr.ts
+++ b/e2e/uniAppCssPostHmr.ts
@@ -6,6 +6,7 @@ export interface UniAppCssPostHmrCase {
   projectRoot: string
   devScript: string
   sourceFile: string
+  outputRoot: string
   outputStyleFile: string
   generatedStyleFile: string
 }
@@ -27,6 +28,7 @@ export function createUniAppCssPostHmrCases(repositoryRoot: string): UniAppCssPo
       projectRoot,
       devScript: `dev:${platform}`,
       sourceFile: path.resolve(projectRoot, 'src/pages/demonstration/index.vue'),
+      outputRoot,
       outputStyleFile: path.resolve(outputRoot, `pages/demonstration/index.${extension}`),
       generatedStyleFile: path.resolve(outputRoot, `styles/tailwindcss.${extension}`),
     }

--- a/e2e/watch/uni-app-css-post-hmr.test.ts
+++ b/e2e/watch/uni-app-css-post-hmr.test.ts
@@ -4,28 +4,18 @@ import { describe, expect, it } from 'vitest'
 import { createOutputIntegrityMonitor } from '../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/output-integrity'
 import { createWatchSession } from '../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/session'
 import { readFileIfExists, waitFor, writeFilePreserveEol } from '../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/text'
+import {
+  hasScopedDarkApplyProbeDisplay,
+  hasScopedDarkApplyProbeStyle,
+  initialScopedDarkApplyProbeState,
+  replaceScopedDarkApplyProbeState,
+} from '../scopedDarkApplyProbe'
 import { createUniAppCssPostHmrCases } from '../uniAppCssPostHmr'
 
 const CSS_POST_HMR_TIMEOUT_MS = 180_000
 const CSS_POST_HMR_TEST_TIMEOUT_MS = CSS_POST_HMR_TIMEOUT_MS + 30_000
 const safeIconSelector = '.i-_bmdi--github-circle_B'
 const unsafeSelectorFragments = ['.i-\\[', '.before\\:']
-
-function addScopedTailwindProbe(source: string) {
-  return source
-    .replace(
-      '<style lang="scss" scoped>',
-      '<style lang="scss" scoped>\n@reference "../../styles/tailwindcss.css";',
-    )
-    .replace(
-      '.hello-scss {\n  color: #f00;',
-      '.hello-scss {\n  @apply flex;\n  color: #f00;',
-    )
-}
-
-function hasScopedProbeDisplay(source: string, display: 'block' | 'flex') {
-  return new RegExp(`\\.hello-scss(?:\\.[^{\\s]+)?\\s*\\{\\s*display:\\s*${display};`).test(source)
-}
 
 const enabled = process.env.E2E_UNI_APP_CSS_POST_HMR === '1'
 const repositoryRoot = path.resolve(import.meta.dirname, '../..')
@@ -34,8 +24,24 @@ const cases = createUniAppCssPostHmrCases(repositoryRoot)
 describe.skipIf(!enabled)('uni-app scoped CSS post HMR', () => {
   it.each(cases)('$name never writes raw Tailwind selectors to mini-program styles', async (testCase) => {
     const originalSource = await fs.readFile(testCase.sourceFile, 'utf8')
-    const updatedSource = addScopedTailwindProbe(originalSource)
-    const secondUpdatedSource = updatedSource.replace('@apply flex;', '@apply block;')
+    const firstUpdatedState = {
+      darkBackground: '#242424',
+      display: 'block',
+    } as const
+    const secondUpdatedState = {
+      darkBackground: '#252525',
+      display: 'inline-flex',
+    } as const
+    const updatedSource = replaceScopedDarkApplyProbeState(
+      originalSource,
+      initialScopedDarkApplyProbeState,
+      firstUpdatedState,
+    )
+    const secondUpdatedSource = replaceScopedDarkApplyProbeState(
+      updatedSource,
+      firstUpdatedState,
+      secondUpdatedState,
+    )
     expect(updatedSource).not.toBe(originalSource)
     expect(secondUpdatedSource).not.toBe(updatedSource)
 
@@ -51,7 +57,8 @@ describe.skipIf(!enabled)('uni-app scoped CSS post HMR', () => {
             readFileIfExists(testCase.generatedStyleFile),
           ])
           return session.lastCompileSuccessAt() > sessionStartedAt
-            && pageStyle?.includes('.hello-scss') === true
+            && pageStyle != null
+            && hasScopedDarkApplyProbeStyle(pageStyle, initialScopedDarkApplyProbeState)
             && generatedStyle?.includes(safeIconSelector) === true
         },
         {
@@ -64,12 +71,18 @@ describe.skipIf(!enabled)('uni-app scoped CSS post HMR', () => {
       )
 
       outputIntegrityMonitor = createOutputIntegrityMonitor([
-        testCase.outputStyleFile,
-        testCase.generatedStyleFile,
-      ].map(file => ({
-        file,
-        forbiddenFragments: unsafeSelectorFragments,
-      })))
+        {
+          directory: testCase.outputRoot,
+          forbidEmptyBlockAtRules: true,
+        },
+        ...[
+          testCase.outputStyleFile,
+          testCase.generatedStyleFile,
+        ].map(file => ({
+          file,
+          forbiddenFragments: unsafeSelectorFragments,
+        })),
+      ])
       await outputIntegrityMonitor?.assertClean('initial compile')
 
       const updateStartedAt = Date.now()
@@ -79,7 +92,10 @@ describe.skipIf(!enabled)('uni-app scoped CSS post HMR', () => {
           const pageStyle = await readFileIfExists(testCase.outputStyleFile)
           return session.lastCompileSuccessAt() > updateStartedAt
             && pageStyle != null
-            && hasScopedProbeDisplay(pageStyle, 'flex')
+            && hasScopedDarkApplyProbeStyle(pageStyle, {
+              ...firstUpdatedState,
+              staleDarkBackgrounds: ['#232323', '#252525'],
+            })
             && pageStyle.includes(safeIconSelector)
         },
         {
@@ -99,8 +115,11 @@ describe.skipIf(!enabled)('uni-app scoped CSS post HMR', () => {
           const pageStyle = await readFileIfExists(testCase.outputStyleFile)
           return session.lastCompileSuccessAt() > secondUpdateStartedAt
             && pageStyle != null
-            && hasScopedProbeDisplay(pageStyle, 'block')
-            && !hasScopedProbeDisplay(pageStyle, 'flex')
+            && hasScopedDarkApplyProbeStyle(pageStyle, {
+              ...secondUpdatedState,
+              staleDarkBackgrounds: ['#232323', '#242424'],
+            })
+            && !hasScopedDarkApplyProbeDisplay(pageStyle, 'block')
         },
         {
           timeoutMs: CSS_POST_HMR_TIMEOUT_MS,
@@ -111,14 +130,42 @@ describe.skipIf(!enabled)('uni-app scoped CSS post HMR', () => {
         secondUpdateStartedAt,
       )
       await outputIntegrityMonitor?.assertClean('second scoped style update')
+
+      const rollbackStartedAt = Date.now()
+      await writeFilePreserveEol(testCase.sourceFile, originalSource, secondUpdatedSource)
+      await waitFor(
+        async () => {
+          const pageStyle = await readFileIfExists(testCase.outputStyleFile)
+          return session.lastCompileSuccessAt() > rollbackStartedAt
+            && pageStyle != null
+            && hasScopedDarkApplyProbeStyle(pageStyle, {
+              ...initialScopedDarkApplyProbeState,
+              staleDarkBackgrounds: ['#242424', '#252525'],
+            })
+            && !hasScopedDarkApplyProbeDisplay(pageStyle, 'block')
+            && !hasScopedDarkApplyProbeDisplay(pageStyle, 'inline-flex')
+        },
+        {
+          timeoutMs: CSS_POST_HMR_TIMEOUT_MS,
+          pollMs: 50,
+          message: `[${testCase.name}] scoped Tailwind probe rollback was not emitted`,
+          onTick: session.ensureRunning,
+        },
+        rollbackStartedAt,
+      )
+      await outputIntegrityMonitor?.assertClean('scoped style rollback')
     }
     finally {
-      await session.stop()
-      await outputIntegrityMonitor?.stop()
-      await outputIntegrityMonitor?.assertClean('shutdown')
-      const currentSource = await fs.readFile(testCase.sourceFile, 'utf8').catch(() => originalSource)
-      if (currentSource !== originalSource) {
-        await writeFilePreserveEol(testCase.sourceFile, originalSource, currentSource).catch(() => undefined)
+      try {
+        await session.stop()
+        await outputIntegrityMonitor?.stop()
+        await outputIntegrityMonitor?.assertClean('shutdown')
+      }
+      finally {
+        const currentSource = await fs.readFile(testCase.sourceFile, 'utf8').catch(() => originalSource)
+        if (currentSource !== originalSource) {
+          await writeFilePreserveEol(testCase.sourceFile, originalSource, currentSource).catch(() => undefined)
+        }
       }
     }
   }, CSS_POST_HMR_TEST_TIMEOUT_MS)

--- a/packages/weapp-tailwindcss/src/bundlers/gulp/shared/create-native-framework-plugins/file-transforms.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/gulp/shared/create-native-framework-plugins/file-transforms.ts
@@ -6,6 +6,7 @@ import path from 'node:path'
 import { shouldSkipJsTransform } from '@/js/precheck'
 import { processCachedTask } from '../../../shared/cache'
 import { annotateCssSourceTrace, createCssSourceTraceCacheSignature, createCssTokenSourceMap } from '../../../shared/css-source-trace'
+import { finalizeMiniProgramCssStructure } from '../../../shared/final-css-cleanup'
 import { createBundlerGeneratedCssMarker, hasBundlerGeneratedCssMarker, stripBundlerGeneratedCssMarkers } from '../../../shared/generated-css-marker'
 import { finalizeMiniProgramGeneratorCss } from '../../../shared/generator-css/generation-helpers'
 import { rewriteLocalCssImportRequestsForOutput } from '../../../shared/generator-css/local-imports'
@@ -174,7 +175,11 @@ export function createGulpFileTransforms(context: GulpFileTransformContext) {
                 styleOutputExtension,
               })
           debug('css handle: %s', file.path)
-          return { result: outputCss }
+          return {
+            result: stage === 'transform'
+              ? finalizeMiniProgramCssStructure(outputCss)
+              : outputCss,
+          }
         },
       })
       rememberGulpProcessCacheKey(gulpProcessCacheKeys, file.path)
@@ -209,9 +214,10 @@ export function createGulpFileTransforms(context: GulpFileTransformContext) {
             },
           )
         : handled.css
-      writeGulpFileAsset(file, rewriteLocalCssImportRequestsForOutput(finalized, {
+      const outputCss = rewriteLocalCssImportRequestsForOutput(finalized, {
         styleOutputExtension,
-      }))
+      })
+      writeGulpFileAsset(file, finalizeMiniProgramCssStructure(outputCss))
       debug('css adapt: %s', file.path)
     }, () => resolveGulpTransformTimingDetails('css:adapt'))
 

--- a/packages/weapp-tailwindcss/src/bundlers/shared/final-css-cleanup.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/final-css-cleanup.ts
@@ -1,3 +1,5 @@
+import { postcss, removeEmptyAtRules } from '@weapp-tailwindcss/postcss'
+
 function isAtRuleNameCharacter(code: number) {
   return code === 45
     || (code >= 65 && code <= 90)
@@ -101,4 +103,26 @@ export function hasEmptyAtRuleBlockCandidate(css: string) {
     }
   }
   return false
+}
+
+/**
+ * 在小程序样式进入最终产物图时递归清理空的块级 at-rule。
+ */
+export function finalizeMiniProgramCssStructure(css: string) {
+  if (!hasEmptyAtRuleBlockCandidate(css)) {
+    return css
+  }
+  try {
+    const root = postcss.parse(css)
+    let removed = 0
+    let passRemoved = 0
+    do {
+      passRemoved = removeEmptyAtRules(root)
+      removed += passRemoved
+    } while (passRemoved > 0)
+    return removed > 0 ? root.toString() : css
+  }
+  catch {
+    return css
+  }
 }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/css-finalizer/plugin.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/css-finalizer/plugin.ts
@@ -17,6 +17,7 @@ import { normalizeMiniProgramGeneratorCssSource } from '../../shared/generator-c
 import { generateTailwindV4Css } from '../../shared/v4-generation-core'
 import { resolveMiniProgramStyleOutputExtension, resolveViteCssPipelineOutputFile } from '../generate-bundle'
 import { applyViteAssetEmissionPlan } from '../generate-bundle/asset-emission-plan'
+import { finalizeMiniProgramCssAssetStructures } from '../generate-bundle/final-css-assets'
 import { normalizeRootMiniProgramImportShellAssets } from '../generate-bundle/finalize'
 import { restoreFrameworkRootMiniProgramImportShellAssets } from '../generate-bundle/root-style-output'
 import { collectViteProcessedCssAssetResults, injectViteProcessedCssIntoMainCssAssets } from '../processed-css-assets'
@@ -246,6 +247,13 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
             onUpdate: opts.onUpdate,
             recordCssAssetResult,
           })
+          finalizeMiniProgramCssAssetStructures(bundle, {
+            cssMatcher: opts.cssMatcher,
+            debug,
+            isWebGeneratorTarget,
+            onUpdate: opts.onUpdate,
+            recordCssAssetResult,
+          })
           finalizeCompilerShadowRun(runtimeState)
           return
         }
@@ -408,6 +416,13 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
           cssMatcher: opts.cssMatcher,
           debug,
           enabled: cssPipelineStrategy?.shouldNormalizeRootMiniProgramImportShell?.(createCssPipelineContext('')) === true,
+          onUpdate: opts.onUpdate,
+          recordCssAssetResult,
+        })
+        finalizeMiniProgramCssAssetStructures(bundle, {
+          cssMatcher: opts.cssMatcher,
+          debug,
+          isWebGeneratorTarget,
           onUpdate: opts.onUpdate,
           recordCssAssetResult,
         })

--- a/packages/weapp-tailwindcss/src/bundlers/vite/css-finalizer/plugin.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/css-finalizer/plugin.ts
@@ -102,11 +102,16 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
           : rootDir
         const sourceRoot = resolveWeappViteSourceRoot(resolvedConfig, opts.appType)
           ?? resolveSourceRootFromBundleGraph(resolvedConfig, bundle)
+        const finalCssAssetFiles = new Set<string>()
+        const trackFinalCssAssetUpdate = (file: string, original: string, generated: string) => {
+          finalCssAssetFiles.add(file)
+          opts.onUpdate(file, original, generated)
+        }
         restoreFrameworkRootMiniProgramImportShellAssets(bundle, {
           debug,
           isWebGeneratorTarget,
           matchesCss: opts.cssMatcher,
-          onUpdate: opts.onUpdate,
+          onUpdate: trackFinalCssAssetUpdate,
           recordCssAssetResult,
           shouldKeep: (file, css) => cssPipelineStrategy?.shouldKeepRootMiniProgramStyleAsImportShell?.({
             ...createCssPipelineContext(file),
@@ -132,6 +137,7 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
             markCssAssetProcessed,
             recordCssAssetResult,
             recordViteProcessedCssAssetResult,
+            onAssetWrite: file => finalCssAssetFiles.add(file),
             resolveViteProcessedCssOutputFile: file => resolveViteCssPipelineOutputFile(file, opts, rootDir, isWebGeneratorTarget, isNativeAppStyleTarget, sourceRoot, resolveMiniProgramStyleOutputExtension({
               files: Object.keys(bundle),
             }), Object.keys(bundle)),
@@ -156,7 +162,7 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
               file,
             }, cssPipelineStrategy),
             debug,
-            onUpdate: opts.onUpdate,
+            onUpdate: trackFinalCssAssetUpdate,
           })
         }
 
@@ -244,12 +250,13 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
             cssMatcher: opts.cssMatcher,
             debug,
             enabled: cssPipelineStrategy?.shouldNormalizeRootMiniProgramImportShell?.(createCssPipelineContext('')) === true,
-            onUpdate: opts.onUpdate,
+            onUpdate: trackFinalCssAssetUpdate,
             recordCssAssetResult,
           })
           finalizeMiniProgramCssAssetStructures(bundle, {
             cssMatcher: opts.cssMatcher,
             debug,
+            files: finalCssAssetFiles,
             isWebGeneratorTarget,
             onUpdate: opts.onUpdate,
             recordCssAssetResult,
@@ -272,6 +279,7 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
         const writeTargets = new Map<string, OutputAsset>()
         const writeCssAsset = (file: string, output: OutputAsset, source: string) => {
           emissionPlan.write(file, source)
+          finalCssAssetFiles.add(file)
           writeTargets.set(file, output)
         }
         await Promise.all(entries.map(async ([bundleFile, output]) => {
@@ -416,12 +424,13 @@ export function createViteCssFinalizerOutputPlugin(context: CssFinalizerContext)
           cssMatcher: opts.cssMatcher,
           debug,
           enabled: cssPipelineStrategy?.shouldNormalizeRootMiniProgramImportShell?.(createCssPipelineContext('')) === true,
-          onUpdate: opts.onUpdate,
+          onUpdate: trackFinalCssAssetUpdate,
           recordCssAssetResult,
         })
         finalizeMiniProgramCssAssetStructures(bundle, {
           cssMatcher: opts.cssMatcher,
           debug,
+          files: finalCssAssetFiles,
           isWebGeneratorTarget,
           onUpdate: opts.onUpdate,
           recordCssAssetResult,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/css-transform-decision-plan.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/css-transform-decision-plan.ts
@@ -145,7 +145,7 @@ export function resolveViteCssTransformCachePlan(
 
   return {
     cssCacheKey: options.outputFile,
-    cssHashKey: `${options.outputFile}:css:${cssRuntimeSignature}:${tailwindcssMajorVersion}`,
+    cssHashKey: `${options.outputFile}:css:${tailwindcssMajorVersion}`,
     cssRuntimeSignature,
     cssSharedCacheKey: [
       options.cssShareScope,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/css-transform-decision-plan.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/css-transform-decision-plan.ts
@@ -142,10 +142,11 @@ export function resolveViteCssTransformCachePlan(
     options.cssRuntimeAffectingHash,
   )
   const tailwindcssMajorVersion = options.tailwindcssMajorVersion ?? 'unknown'
+  const cssCacheKey = `${options.outputFile}:css:${cssRuntimeSignature}:${tailwindcssMajorVersion}`
 
   return {
-    cssCacheKey: options.outputFile,
-    cssHashKey: `${options.outputFile}:css:${tailwindcssMajorVersion}`,
+    cssCacheKey,
+    cssHashKey: cssCacheKey,
     cssRuntimeSignature,
     cssSharedCacheKey: [
       options.cssShareScope,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/final-css-assets.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/final-css-assets.ts
@@ -25,6 +25,7 @@ export function finalizeMiniProgramCssAssetStructures(
   bundle: Record<string, OutputAsset | OutputChunk>,
   options: {
     cssMatcher: GenerateBundleContext['opts']['cssMatcher']
+    files?: ReadonlySet<string> | undefined
     isWebGeneratorTarget: boolean
     onUpdate: GenerateBundleContext['opts']['onUpdate']
     recordCssAssetResult: GenerateBundleContext['recordCssAssetResult']
@@ -43,7 +44,7 @@ export function finalizeMiniProgramCssAssetStructures(
       continue
     }
     const file = output.fileName || bundleFile
-    if (!options.cssMatcher(file)) {
+    if (!options.cssMatcher(file) || (options.files && !options.files.has(file))) {
       continue
     }
     const rawSource = readAssetSource(output)

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/final-css-assets.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/final-css-assets.ts
@@ -5,8 +5,8 @@ import {
   hasMiniProgramCssSpecificityPlaceholders,
   stripMiniProgramCssSpecificityPlaceholders,
 } from '@/bundlers/shared/css-cleanup'
+import { finalizeMiniProgramCssStructure } from '@/bundlers/shared/final-css-cleanup'
 import { AssetEmissionPlan } from '@/compiler'
-import { removeEmptyCssAtRules } from '../processed-css-assets/cleanup'
 import { applyViteAssetEmissionPlan } from './asset-emission-plan'
 
 function readAssetSource(output: OutputAsset) {
@@ -19,6 +19,50 @@ function shouldFinalizeMiniProgramCssAsset(source: string) {
   return source.includes(':hover')
     || source.includes('does-not-exist')
     || hasMiniProgramCssSpecificityPlaceholders(source)
+}
+
+export function finalizeMiniProgramCssAssetStructures(
+  bundle: Record<string, OutputAsset | OutputChunk>,
+  options: {
+    cssMatcher: GenerateBundleContext['opts']['cssMatcher']
+    isWebGeneratorTarget: boolean
+    onUpdate: GenerateBundleContext['opts']['onUpdate']
+    recordCssAssetResult: GenerateBundleContext['recordCssAssetResult']
+    debug?: GenerateBundleContext['debug']
+  },
+) {
+  if (options.isWebGeneratorTarget) {
+    return 0
+  }
+
+  const plan = new AssetEmissionPlan()
+  const writeTargets = new Map<string, OutputAsset>()
+  let updated = 0
+  for (const [bundleFile, output] of Object.entries(bundle)) {
+    if (output.type !== 'asset') {
+      continue
+    }
+    const file = output.fileName || bundleFile
+    if (!options.cssMatcher(file)) {
+      continue
+    }
+    const rawSource = readAssetSource(output)
+    const outputCss = finalizeMiniProgramCssStructure(rawSource)
+    if (outputCss === rawSource) {
+      continue
+    }
+    plan.write(file, outputCss)
+    writeTargets.set(file, output)
+    options.recordCssAssetResult?.(file, outputCss)
+    options.onUpdate(file, rawSource, outputCss)
+    options.debug?.('remove final empty mini-program css at-rules: %s bytes=%d', file, outputCss.length)
+    updated++
+  }
+  applyViteAssetEmissionPlan(plan, {
+    bundle,
+    writeTargets,
+  })
+  return updated
 }
 
 export async function finalizeMiniProgramCssAssets(
@@ -55,7 +99,7 @@ export async function finalizeMiniProgramCssAssets(
       continue
     }
     if (options.lastCssResultByFile?.has(file)) {
-      const structurallyCleanSource = removeEmptyCssAtRules(rawSource)
+      const structurallyCleanSource = finalizeMiniProgramCssStructure(rawSource)
       const outputCss = stripMiniProgramCssSpecificityPlaceholders(structurallyCleanSource)
       if (outputCss !== rawSource) {
         plan.write(file, outputCss)
@@ -68,7 +112,7 @@ export async function finalizeMiniProgramCssAssets(
       continue
     }
     if (!shouldFinalizeMiniProgramCssAsset(rawSource)) {
-      const structurallyCleanSource = removeEmptyCssAtRules(rawSource)
+      const structurallyCleanSource = finalizeMiniProgramCssStructure(rawSource)
       if (structurallyCleanSource !== rawSource) {
         plan.write(file, structurallyCleanSource)
         writeTargets.set(file, output)
@@ -91,7 +135,7 @@ export async function finalizeMiniProgramCssAssets(
       },
       cssPresetEnv: {},
     })
-    const structurallyCleanCss = removeEmptyCssAtRules(css)
+    const structurallyCleanCss = finalizeMiniProgramCssStructure(css)
     const outputCss = stripMiniProgramCssSpecificityPlaceholders(structurallyCleanCss)
     if (outputCss === rawSource) {
       continue

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/cleanup.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/cleanup.ts
@@ -1,10 +1,10 @@
 import type { OutputAsset, OutputBundle } from 'rollup'
 import type { CollectViteProcessedCssAssetOptions } from './markers-imports'
 import type { InternalUserDefinedOptions } from '@/types'
-import { isMiniProgramLocalCssImportRequest, parseTailwindCssDirectiveRequest, postcss, removeEmptyAtRules } from '@weapp-tailwindcss/postcss'
+import { isMiniProgramLocalCssImportRequest, parseTailwindCssDirectiveRequest, postcss } from '@weapp-tailwindcss/postcss'
 import path from 'pathe'
+import { hasEmptyAtRuleBlockCandidate } from '../../shared/final-css-cleanup'
 import { normalizeOutputPathKey } from '../../shared/module-graph'
-import { hasEmptyAtRuleBlockCandidate } from './empty-at-rule'
 import { appendCss, collectImportedStyleFiles, createCssAssetPipelineContext, getAssetFile, isStyleImportRequest, readAssetSource } from './markers-imports'
 import { isMiniProgramStyleOutputFile, isRootStyleOutputFile } from './style-files'
 
@@ -90,25 +90,6 @@ export function removeCommentOnlyAtRules(css: string) {
       changed = true
     })
     return changed ? root.toString() : css
-  }
-  catch {
-    return css
-  }
-}
-
-export function removeEmptyCssAtRules(css: string) {
-  if (!hasEmptyAtRuleBlockCandidate(css)) {
-    return css
-  }
-  try {
-    const root = postcss.parse(css)
-    let removed = 0
-    let passRemoved = 0
-    do {
-      passRemoved = removeEmptyAtRules(root)
-      removed += passRemoved
-    } while (passRemoved > 0)
-    return removed > 0 ? root.toString() : css
   }
   catch {
     return css

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/collector.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/collector.ts
@@ -44,6 +44,7 @@ export function collectViteProcessedCssAssetResults(
     nextCss = options.transformCss?.(nextCss, file) ?? nextCss
     if (nextCss !== rawSource) {
       output.source = nextCss
+      options.onAssetWrite?.(file)
     }
     options.markCssAssetProcessed?.(output, file)
     options.recordCssAssetResult?.(file, nextCss)
@@ -75,6 +76,7 @@ export function collectViteProcessedCssAssetResults(
         const targetNextCss = appendCss(targetRawSource, missingCss)
         if (targetNextCss !== targetRawSource) {
           targetAsset.source = targetNextCss
+          options.onAssetWrite?.(resolvedOutputFile)
           options.markCssAssetProcessed?.(targetAsset, resolvedOutputFile)
           options.recordCssAssetResult?.(resolvedOutputFile, targetNextCss)
         }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/markers-imports.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/processed-css-assets/markers-imports.ts
@@ -41,6 +41,7 @@ export interface CollectViteProcessedCssAssetOptions {
   recordCssAssetResult?: CssAssetResultRecorder | undefined
   recordViteProcessedCssAssetResult?: CssAssetResultRecorder | undefined
   resolveViteProcessedCssOutputFile?: ((file: string) => string | undefined) | undefined
+  onAssetWrite?: ((file: string) => void) | undefined
   subpackageRoots?: Set<string> | undefined
   transformCss?: ((css: string, file: string) => string) | undefined
   debug?: ((format: string, ...args: unknown[]) => void) | undefined

--- a/packages/weapp-tailwindcss/src/bundlers/webpack/BaseUnifiedPlugin/v5-assets/pipeline-helpers/finalize.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/webpack/BaseUnifiedPlugin/v5-assets/pipeline-helpers/finalize.ts
@@ -6,6 +6,7 @@ import { dedupeCoveredCssRules } from '@weapp-tailwindcss/postcss'
 import { resolveStyleOptionsFromContext } from '@/context/style-options'
 import { finalizeMiniProgramCss, pruneMiniProgramGeneratedCss, stripMiniProgramCssSpecificityPlaceholders } from '../../../../shared/css-cleanup'
 import { createCssTokenSourceMap, isCssSourceTraceEnabled } from '../../../../shared/css-source-trace'
+import { finalizeMiniProgramCssStructure } from '../../../../shared/final-css-cleanup'
 import { stripBundlerGeneratedCssMarkers } from '../../../../shared/generated-css-marker'
 import { removeTailwindSourceDirectives } from '../../../../shared/generator-css/directives'
 import { hasMiniProgramTailwindV4PreflightReset } from '../../../../shared/generator-css/generation-helpers'
@@ -124,12 +125,13 @@ export function finalizeWebpackCssAssetOutputSource(
     return source
   }
   const styleOptions = resolveStyleOptionsFromContext(compilerOptions)
-  return stripMiniProgramCssSpecificityPlaceholders(
+  const finalized = stripMiniProgramCssSpecificityPlaceholders(
     removeMiniProgramHoverSelectors(
       dedupeCoveredCssRules(dedupeMiniProgramPreflightSelectorRules(source)),
       styleOptions.cssRemoveHoverPseudoClass,
     ),
   )
+  return finalizeMiniProgramCssStructure(finalized)
 }
 
 export function collectWebpackJsRuntimeCandidatesFromAssets(options: {

--- a/packages/weapp-tailwindcss/test/bundlers/final-css-cleanup.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/final-css-cleanup.unit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { finalizeMiniProgramCssStructure, hasEmptyAtRuleBlockCandidate } from '@/bundlers/shared/final-css-cleanup'
+
+describe('final mini-program css cleanup', () => {
+  it('detects empty block at-rules with a linear precheck', () => {
+    expect(hasEmptyAtRuleBlockCandidate('@media screen { /* token */ .keep {} }')).toBe(false)
+    expect(hasEmptyAtRuleBlockCandidate('@media screen { @supports (display: grid) { /* removed */ } }')).toBe(true)
+    expect(hasEmptyAtRuleBlockCandidate('@supports (background: url(data:image/svg+xml;utf8,test)) {}')).toBe(true)
+    expect(hasEmptyAtRuleBlockCandidate('@custom "value;{}"; .keep {}')).toBe(false)
+  })
+
+  it('recursively removes empty and comment-only block at-rules', () => {
+    const source = [
+      '@media (prefers-color-scheme: light) {}',
+      '@media screen { @supports (display: grid) { /* removed declarations */ } }',
+      '@supports (display: flex) { /* removed declarations */ }',
+      '.keep { color: red; }',
+    ].join('\n')
+
+    expect(finalizeMiniProgramCssStructure(source)).toBe('.keep { color: red; }')
+  })
+
+  it('preserves valid dark media and statement at-rules', () => {
+    const source = [
+      '@charset "UTF-8";',
+      '@import "./theme.wxss";',
+      '@media (prefers-color-scheme: dark) { .theme { background-color: #232323; } }',
+    ].join('\n')
+
+    expect(finalizeMiniProgramCssStructure(source)).toBe(source)
+  })
+
+  it('returns css without candidates before parsing', () => {
+    const source = `${'/* generated token */'.repeat(25)}\n.keep { color: red; }`
+    const startedAt = performance.now()
+
+    expect(finalizeMiniProgramCssStructure(source)).toBe(source)
+    expect(performance.now() - startedAt).toBeLessThan(1000)
+  })
+
+  it('returns malformed css unchanged when parsing fails', () => {
+    const source = '@media (prefers-color-scheme: dark) {}\n.broken {'
+
+    expect(finalizeMiniProgramCssStructure(source)).toBe(source)
+  })
+})

--- a/packages/weapp-tailwindcss/test/bundlers/gulp.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/gulp.unit.test.ts
@@ -194,6 +194,28 @@ describe('bundlers/gulp createPlugins', () => {
     expect(tailwindRuntime.extract).not.toHaveBeenCalled()
   })
 
+  it('removes empty at-rules only from final gulp css outputs', async () => {
+    const source = [
+      '@media (prefers-color-scheme: light) {}',
+      '@media screen { @supports (display: grid) { /* removed */ } }',
+      '@media (prefers-color-scheme: dark) { .theme { background: #232323; } }',
+    ].join('\n')
+    styleHandler.mockImplementation(async (css: string) => ({ css }))
+    const plugins = createPlugins()
+
+    const generated = await runTransform(plugins.generateWxss(), createFile('/src/app.wxss', source))
+    const transformed = await runTransform(plugins.transformWxss(), createFile('/src/page.wxss', source))
+    const adapted = await runTransform(plugins.adaptWxss(), createFile('/src/component.wxss', source))
+
+    expect(generated.contents?.toString()).toContain('@media (prefers-color-scheme: light) {}')
+    for (const finalOutput of [transformed, adapted]) {
+      const css = finalOutput.contents?.toString() ?? ''
+      expect(css).not.toContain('prefers-color-scheme: light')
+      expect(css).not.toContain('@supports')
+      expect(css).toContain('@media (prefers-color-scheme: dark) { .theme { background: #232323; } }')
+    }
+  })
+
   it('refreshes gulp runtime candidates before transforming changed js sources', async () => {
     let currentRuntimeSet = new Set(['w-[1px]'])
     tailwindRuntime.getClassSetSync.mockImplementation(() => currentRuntimeSet)

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-cache-task.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-cache-task.unit.test.ts
@@ -81,6 +81,36 @@ describe('vite css cache task', () => {
     expect(onCacheHit).toHaveBeenCalledOnce()
   })
 
+  it('does not replay the latest result when the source rolls back', async () => {
+    const cache = createCache()
+    const applied: string[] = []
+    const transform = vi.fn(async (source: string) => source)
+    const run = (source: string) => processViteCssCacheTask({
+      applyResult: result => applied.push(result),
+      cache,
+      cacheKey: 'pages/index.wxss',
+      hashKey: 'pages/index.wxss:css:4',
+      onCacheHit: vi.fn(),
+      onSharedCacheHit: vi.fn(),
+      onSharedResult: vi.fn(),
+      onTransformResult: vi.fn(),
+      sharedResultCache: new Map<string, Promise<string>>(),
+      taskHash: source,
+      transform: () => transform(source),
+    })
+
+    await run('.probe{display:flex}')
+    await run('.probe{display:block}')
+    await run('.probe{display:flex}')
+
+    expect(applied).toEqual([
+      '.probe{display:flex}',
+      '.probe{display:block}',
+      '.probe{display:flex}',
+    ])
+    expect(transform).toHaveBeenCalledTimes(3)
+  })
+
   it('shares an in-flight transform across distinct process cache keys', async () => {
     const sharedResultCache = new Map<string, Promise<string>>()
     const transform = vi.fn(async () => '.shared {}')

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-cache-task.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-cache-task.unit.test.ts
@@ -5,6 +5,7 @@ import {
   applyViteCssCacheResult,
   processViteCssCacheTask,
 } from '../../src/bundlers/vite/generate-bundle/css-cache-task'
+import { resolveViteCssTransformCachePlan } from '../../src/bundlers/vite/generate-bundle/css-transform-decision-plan'
 
 function createOutputAsset(): OutputAsset {
   return {
@@ -81,23 +82,36 @@ describe('vite css cache task', () => {
     expect(onCacheHit).toHaveBeenCalledOnce()
   })
 
-  it('does not replay the latest result when the source rolls back', async () => {
+  it('restores the exact cached candidate result when the source rolls back', async () => {
     const cache = createCache()
     const applied: string[] = []
     const transform = vi.fn(async (source: string) => source)
-    const run = (source: string) => processViteCssCacheTask({
-      applyResult: result => applied.push(result),
-      cache,
-      cacheKey: 'pages/index.wxss',
-      hashKey: 'pages/index.wxss:css:4',
-      onCacheHit: vi.fn(),
-      onSharedCacheHit: vi.fn(),
-      onSharedResult: vi.fn(),
-      onTransformResult: vi.fn(),
-      sharedResultCache: new Map<string, Promise<string>>(),
-      taskHash: source,
-      transform: () => transform(source),
-    })
+    const run = (source: string) => {
+      const plan = resolveViteCssTransformCachePlan({
+        cssIsMainChunk: false,
+        cssRuntimeAffectingHash: 'source-hash',
+        cssShareScope: 'scope',
+        linkedImpactSignature: '',
+        outputFile: 'pages/index.wxss',
+        runtimeSignature: 'runtime',
+        scopedGeneratorCandidateSignature: source,
+        sourceTraceSignature: 'trace',
+        tailwindcssMajorVersion: 4,
+      })
+      return processViteCssCacheTask({
+        applyResult: result => applied.push(result),
+        cache,
+        cacheKey: plan.cssCacheKey,
+        hashKey: plan.cssHashKey,
+        onCacheHit: vi.fn(),
+        onSharedCacheHit: vi.fn(),
+        onSharedResult: vi.fn(),
+        onTransformResult: vi.fn(),
+        sharedResultCache: new Map<string, Promise<string>>(),
+        taskHash: plan.cssTaskHash,
+        transform: () => transform(source),
+      })
+    }
 
     await run('.probe{display:flex}')
     await run('.probe{display:block}')
@@ -108,7 +122,7 @@ describe('vite css cache task', () => {
       '.probe{display:block}',
       '.probe{display:flex}',
     ])
-    expect(transform).toHaveBeenCalledTimes(3)
+    expect(transform).toHaveBeenCalledTimes(2)
   })
 
   it('shares an in-flight transform across distinct process cache keys', async () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-finalizer.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-finalizer.unit.test.ts
@@ -249,6 +249,7 @@ describe('vite css finalizer output plugin', () => {
       'pages/index.wxss': asset('pages/index.wxss', [
         createBundlerGeneratedCssMarker('vite', 'src/pages/index.css'),
         '.page{color:red}',
+        '@media (prefers-color-scheme: dark) { /* removed */ }',
       ].join('\n')),
     }
 
@@ -256,7 +257,7 @@ describe('vite css finalizer output plugin', () => {
 
     expect(String((bundle['pages/index.wxss'] as OutputAsset).source)).toBe('.page{color:red}')
     expect(context.recordCssAssetResult).toHaveBeenCalledWith('pages/index.wxss', '.page{color:red}')
-    expect(context.debug).toHaveBeenCalledWith('collect vite-processed css asset: %s bytes=%d', 'pages/index.wxss', 16)
+    expect(context.debug).toHaveBeenCalledWith('collect vite-processed css asset: %s bytes=%d', 'pages/index.wxss', 70)
   })
 
   it('strips Vite internal marker-only css assets', async () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-finalizer.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-finalizer.unit.test.ts
@@ -140,6 +140,39 @@ describe('vite css finalizer output plugin', () => {
     )
   })
 
+  it('removes empty at-rules after framework css processing and preserves valid dark media', async () => {
+    const { context } = createContext({
+      opts: {
+        appType: 'uni-app-vite',
+        cssMatcher: (file: string) => file.endsWith('.wxss'),
+        htmlMatcher: (file: string) => file.endsWith('.wxml'),
+        mainCssChunkMatcher: (file: string) => file === 'app.wxss',
+        styleHandler: vi.fn(async (css: string) => ({
+          css: `${css}\n@media (prefers-color-scheme: dark) { /* removed declarations */ }`,
+        })),
+        onUpdate: vi.fn(),
+        generator: {
+          target: 'weapp',
+        },
+      },
+    })
+    const plugin = createViteCssFinalizerOutputPlugin(context as any)
+    const output = asset('app.wxss', [
+      '@media (prefers-color-scheme: light) {}',
+      '@media (prefers-color-scheme: dark) { .theme{background:#232323} }',
+    ].join('\n'))
+    const bundle: OutputBundle = {
+      'app.wxss': output,
+    }
+
+    await getHandler(plugin).call(plugin, {}, bundle)
+
+    const css = String(output.source)
+    expect(css).not.toContain('prefers-color-scheme: light')
+    expect(css).not.toContain('removed declarations')
+    expect(css).toContain('@media (prefers-color-scheme: dark) { .theme{background:#232323} }')
+  })
+
   it('preserves mini-program import shell assets without resolving output imports', async () => {
     const { context } = createContext({
       opts: {
@@ -366,7 +399,10 @@ describe('vite css finalizer output plugin', () => {
       },
     })
     const plugin = createViteCssFinalizerOutputPlugin(context as any)
-    const output = asset('style.css', '@media (hover: hover){.hover\\:bg-red-500:hover{color:red}}')
+    const output = asset('style.css', [
+      '@media (hover: hover){.hover\\:bg-red-500:hover{color:red}}',
+      '@media (prefers-color-scheme: dark) {}',
+    ].join('\n'))
     const bundle: OutputBundle = {
       'style.css': output,
     }
@@ -379,6 +415,7 @@ describe('vite css finalizer output plugin', () => {
     }))
     expect(opts.styleHandler).not.toHaveBeenCalled()
     expect(String(output.source)).toContain('@media (hover: hover)')
+    expect(String(output.source)).toContain('@media (prefers-color-scheme: dark) {}')
     expect(context.markCssAssetProcessed).toHaveBeenCalledWith(output, 'style.css')
   })
 
@@ -409,7 +446,11 @@ describe('vite css finalizer output plugin', () => {
 
   it('runs final injection and taro shell normalization when there are no pending css entries', async () => {
     const records = new Map<string, any>([
-      ['src/app.css', { css: '.generated{color:blue}', injectIntoMain: true, outputFile: 'app.wxss' }],
+      ['src/app.css', {
+        css: '.generated{color:blue}\n@media (prefers-color-scheme: dark) { /* removed */ }',
+        injectIntoMain: true,
+        outputFile: 'app.wxss',
+      }],
     ])
     const { context, opts } = createContext({
       getViteProcessedCssAssetResults: vi.fn(() => records.entries()),
@@ -425,6 +466,7 @@ describe('vite css finalizer output plugin', () => {
 
     expect(context.ensureRuntimeClassSet).not.toHaveBeenCalled()
     expect(String((bundle['app.wxss'] as OutputAsset).source)).toContain('.generated{color:blue}')
+    expect(String((bundle['app.wxss'] as OutputAsset).source)).not.toContain('prefers-color-scheme: dark')
     expect(String((bundle['app.wxss'] as OutputAsset).source)).not.toContain('@source')
     expect(opts.onUpdate).toHaveBeenCalled()
   })

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-transform-decision-plan.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-transform-decision-plan.unit.test.ts
@@ -90,12 +90,32 @@ describe('vite css transform cache plan', () => {
       tailwindcssMajorVersion: 4,
     })).toEqual({
       cssCacheKey: 'app.acss',
-      cssHashKey: 'app.acss:css:runtime:candidates:4',
+      cssHashKey: 'app.acss:css:4',
       cssRuntimeSignature: 'runtime:candidates',
       cssSharedCacheKey: 'scope:runtime:candidates:4:1:raw-hash:candidates:trace',
       cssTaskHash: 'raw-hash:candidates:trace:linked',
       rememberedCssRuntimeSignature: 'runtime:candidates:raw-hash',
     })
+  })
+
+  it('keeps the hash owner stable when scoped candidates roll back', () => {
+    const createPlan = (scopedGeneratorCandidateSignature: string) => resolveViteCssTransformCachePlan({
+      cssIsMainChunk: false,
+      cssRuntimeAffectingHash: 'raw-hash',
+      cssShareScope: 'scope',
+      linkedImpactSignature: '',
+      outputFile: 'pages/index.wxss',
+      runtimeSignature: 'runtime',
+      scopedGeneratorCandidateSignature,
+      sourceTraceSignature: 'trace',
+      tailwindcssMajorVersion: 4,
+    })
+
+    const initial = createPlan('dark:bg-[#232323]')
+    const updated = createPlan('dark:bg-[#242424]')
+
+    expect(updated.cssHashKey).toBe(initial.cssHashKey)
+    expect(updated.cssTaskHash).not.toBe(initial.cssTaskHash)
   })
 
   it('sorts linked html and js changes before resolving signatures', () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-css-transform-decision-plan.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-css-transform-decision-plan.unit.test.ts
@@ -89,8 +89,8 @@ describe('vite css transform cache plan', () => {
       sourceTraceSignature: 'trace',
       tailwindcssMajorVersion: 4,
     })).toEqual({
-      cssCacheKey: 'app.acss',
-      cssHashKey: 'app.acss:css:4',
+      cssCacheKey: 'app.acss:css:runtime:candidates:4',
+      cssHashKey: 'app.acss:css:runtime:candidates:4',
       cssRuntimeSignature: 'runtime:candidates',
       cssSharedCacheKey: 'scope:runtime:candidates:4:1:raw-hash:candidates:trace',
       cssTaskHash: 'raw-hash:candidates:trace:linked',
@@ -98,7 +98,7 @@ describe('vite css transform cache plan', () => {
     })
   })
 
-  it('keeps the hash owner stable when scoped candidates roll back', () => {
+  it('isolates cache ownership when scoped candidates change', () => {
     const createPlan = (scopedGeneratorCandidateSignature: string) => resolveViteCssTransformCachePlan({
       cssIsMainChunk: false,
       cssRuntimeAffectingHash: 'raw-hash',
@@ -114,7 +114,8 @@ describe('vite css transform cache plan', () => {
     const initial = createPlan('dark:bg-[#232323]')
     const updated = createPlan('dark:bg-[#242424]')
 
-    expect(updated.cssHashKey).toBe(initial.cssHashKey)
+    expect(updated.cssCacheKey).not.toBe(initial.cssCacheKey)
+    expect(updated.cssHashKey).not.toBe(initial.cssHashKey)
     expect(updated.cssTaskHash).not.toBe(initial.cssTaskHash)
   })
 

--- a/packages/weapp-tailwindcss/test/bundlers/vite-final-css-assets.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-final-css-assets.unit.test.ts
@@ -1,6 +1,6 @@
 import type { OutputAsset, OutputChunk } from 'rollup'
 import { describe, expect, it, vi } from 'vitest'
-import { finalizeMiniProgramCssAssets } from '@/bundlers/vite/generate-bundle/final-css-assets'
+import { finalizeMiniProgramCssAssets, finalizeMiniProgramCssAssetStructures } from '@/bundlers/vite/generate-bundle/final-css-assets'
 import { createRollupAsset } from './vite-plugin.testkit'
 
 function createBundle(source: string, fileName = 'app.wxss') {
@@ -13,6 +13,35 @@ function createBundle(source: string, fileName = 'app.wxss') {
 }
 
 describe('vite final mini-program css assets', () => {
+  it('limits late structural cleanup to css assets written by the finalizer', () => {
+    const bundle = {
+      'app.wxss': {
+        ...createRollupAsset('@media (prefers-color-scheme: dark) {}\n.app{color:red}'),
+        fileName: 'app.wxss',
+      },
+      'pages/index.wxss': {
+        ...createRollupAsset('@media (prefers-color-scheme: light) {}\n.page{color:blue}'),
+        fileName: 'pages/index.wxss',
+      },
+    } satisfies Record<string, OutputAsset | OutputChunk>
+    const onUpdate = vi.fn()
+    const recordCssAssetResult = vi.fn()
+
+    expect(finalizeMiniProgramCssAssetStructures(bundle, {
+      cssMatcher: file => file.endsWith('.wxss'),
+      files: new Set(['app.wxss']),
+      isWebGeneratorTarget: false,
+      onUpdate,
+      recordCssAssetResult,
+    })).toBe(1)
+
+    expect(String((bundle['app.wxss'] as OutputAsset).source)).toBe('.app{color:red}')
+    expect(String((bundle['pages/index.wxss'] as OutputAsset).source)).toContain('prefers-color-scheme: light')
+    expect(recordCssAssetResult).toHaveBeenCalledOnce()
+    expect(recordCssAssetResult).toHaveBeenCalledWith('app.wxss', '.app{color:red}')
+    expect(onUpdate).toHaveBeenCalledOnce()
+  })
+
   it('removes empty conditional at-rules from cached app styles', async () => {
     const bundle = createBundle([
       '@import "./theme.wxss";',

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -15873,7 +15873,7 @@ const fallback = "bg-[#434332] px-[32px]"
       expect([...currentContext.cache.instance.keys()]).toEqual(expect.arrayContaining([
         expect.stringContaining('index.wxml:html:'),
         'index.js',
-        'index.css',
+        expect.stringContaining('index.css:css:'),
       ]))
 
       const payloads = write.mock.calls

--- a/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-cleanup.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-processed-css-cleanup.unit.test.ts
@@ -1,33 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { removeCommentOnlyAtRules, removeEmptyCssAtRules } from '@/bundlers/vite/processed-css-assets/cleanup'
-import { hasEmptyAtRuleBlockCandidate } from '@/bundlers/vite/processed-css-assets/empty-at-rule'
+import { removeCommentOnlyAtRules } from '@/bundlers/vite/processed-css-assets/cleanup'
 
 describe('vite processed css cleanup', () => {
-  it('detects empty block at-rules with a linear precheck', () => {
-    expect(hasEmptyAtRuleBlockCandidate('@media screen { /* token */ .keep {} }')).toBe(false)
-    expect(hasEmptyAtRuleBlockCandidate('@media screen { @supports (display: grid) { /* removed */ } }')).toBe(true)
-    expect(hasEmptyAtRuleBlockCandidate('@supports (background: url(data:image/svg+xml;utf8,test)) {}')).toBe(true)
-    expect(hasEmptyAtRuleBlockCandidate('@custom "value;{}"; .keep {}')).toBe(false)
-  })
-
-  it('cleans empty at-rules without backtracking on comment-rich css', () => {
-    const source = [
-      '@media screen {',
-      '/* generated token */'.repeat(25),
-      '.keep { color: red; }',
-      '}',
-      '@supports (display: grid) {}',
-    ].join('\n')
-    const startedAt = performance.now()
-
-    const css = removeEmptyCssAtRules(source)
-
-    expect(performance.now() - startedAt).toBeLessThan(1000)
-    expect(css).toContain('@media screen')
-    expect(css).toContain('.keep { color: red; }')
-    expect(css).not.toContain('@supports')
-  })
-
   it('cleans comment-only at-rules without backtracking on comment-rich css', () => {
     const source = [
       '@media screen {',

--- a/packages/weapp-tailwindcss/test/bundlers/webpack.v5.unit/v5-assets.helpers.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/webpack.v5.unit/v5-assets.helpers.ts
@@ -16,6 +16,7 @@ import {
   createWebpackUserCssSourceAppend,
   finalizeMiniProgramUserCssAssetSource,
   finalizeTracedWebpackCssAsset,
+  finalizeWebpackCssAssetOutputSource,
   finalizeWebpackCssAssetSource,
   getRuntimeClassSetSync,
   hasAdditionalWebpackAssetUserCssMarkers,
@@ -834,6 +835,16 @@ describe('bundlers/webpack v5-assets helpers', () => {
       generatedCss: true,
     })).toContain('.card')
     expect(finalizeWebpackCssAssetSource('.card:hover{color:red}', baseContext as any, false)).not.toContain(':hover')
+    const finalAssetSource = [
+      '@media (prefers-color-scheme: light) {}',
+      '@media screen { @supports (display: grid) { /* removed */ } }',
+      '@media (prefers-color-scheme: dark) { .card{background:#232323} }',
+    ].join('\n')
+    const finalizedAsset = finalizeWebpackCssAssetOutputSource(finalAssetSource, baseContext as any, false)
+    expect(finalizedAsset).not.toContain('prefers-color-scheme: light')
+    expect(finalizedAsset).not.toContain('@supports')
+    expect(finalizedAsset).toContain('@media (prefers-color-scheme: dark) { .card{background:#232323} }')
+    expect(finalizeWebpackCssAssetOutputSource(finalAssetSource, baseContext as any, true)).toBe(finalAssetSource)
     const layeredUserCss = finalizeWebpackCssAssetSource('@layer base{wx-button{background:#000}}abc{background:#222}', baseContext as any, false)
     expect(layeredUserCss).not.toContain('@layer')
     expect(layeredUserCss).toContain('wx-button{background:#000}')

--- a/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-regression.unit.test.ts
@@ -3126,17 +3126,24 @@ describe('watch-hmr regression cases', () => {
     }
   })
 
-  it('guards issue 1005 final watch styles against empty block at-rules', () => {
+  it('guards every final mini-program watch style directory against empty block at-rules', () => {
     const baseCwd = '/repo'
-    const watchCase = buildCases(baseCwd, { includeLocalOnly: true })
-      .find(item => item.name === 'uni-app-vite-tailwindcss-v4')
-    const guardedDirectories = watchCase?.outputIntegrityGuards
-      ?.filter(guard => guard.forbidEmptyBlockAtRules)
-      .map(guard => guard.directory?.replace(/\\/g, '/')) ?? []
+    const cases = buildCases(baseCwd, { includeLocalOnly: true })
 
-    expect(guardedDirectories).toEqual([
-      path.resolve(baseCwd, 'demo/uni-app-vite-tailwindcss-v4/dist/dev/mp-weixin').replace(/\\/g, '/'),
-    ])
+    for (const watchCase of cases) {
+      const guardedDirectories = watchCase.outputIntegrityGuards
+        ?.filter(guard => guard.forbidEmptyBlockAtRules && guard.directory)
+        .map(guard => guard.directory!.replace(/\\/g, '/')) ?? []
+      const expectedDirectories = new Set(
+        watchCase.globalStyleCandidates.map(candidate => path.dirname(candidate).replace(/\\/g, '/')),
+      )
+
+      expect(guardedDirectories.length, watchCase.name).toBeGreaterThan(0)
+      expect(new Set(guardedDirectories).size, watchCase.name).toBe(guardedDirectories.length)
+      for (const directory of expectedDirectories) {
+        expect(guardedDirectories, watchCase.name).toContain(directory)
+      }
+    }
   })
 
   it('keeps script read-path HMR checks available for every demo case', () => {

--- a/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases/demo/index.ts
+++ b/tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases/demo/index.ts
@@ -1,4 +1,5 @@
 import type { WatchCase } from '../../types'
+import path from 'node:path'
 import { buildDemoBaseCases } from './base'
 import { buildDemoExtendedCases } from './extended'
 import { buildUniAppHBuilderXCases } from './hbuilderx'
@@ -18,14 +19,40 @@ function withIconifyHmr(cases: WatchCase[]): WatchCase[] {
   }))
 }
 
+function withFinalStyleIntegrity(cases: WatchCase[]): WatchCase[] {
+  return cases.map((watchCase) => {
+    const outputIntegrityGuards = [...(watchCase.outputIntegrityGuards ?? [])]
+    const styleDirectories = new Set(watchCase.globalStyleCandidates.map(candidate => path.dirname(candidate)))
+    for (const directory of styleDirectories) {
+      const existingIndex = outputIntegrityGuards.findIndex(guard => guard.directory === directory)
+      if (existingIndex >= 0) {
+        outputIntegrityGuards[existingIndex] = {
+          ...outputIntegrityGuards[existingIndex],
+          forbidEmptyBlockAtRules: true,
+        }
+      }
+      else {
+        outputIntegrityGuards.push({
+          directory,
+          forbidEmptyBlockAtRules: true,
+        })
+      }
+    }
+    return {
+      ...watchCase,
+      outputIntegrityGuards,
+    }
+  })
+}
+
 export function buildDemoCases(baseCwd: string, options: {
   includeLocalOnly?: boolean
 } = {}): WatchCase[] {
-  return withIconifyHmr([
+  return withIconifyHmr(withFinalStyleIntegrity([
     ...buildDemoBaseCases(baseCwd),
     ...buildDemoExtendedCases(baseCwd),
     ...(options.includeLocalOnly ? buildUniAppHBuilderXCases(baseCwd) : []),
-  ])
+  ]))
 }
 
 export { buildUniAppHBuilderXCases }


### PR DESCRIPTION
## 问题

uni-app Vite 的 scoped SFC 使用 `@apply bg-[#f1f1f1] dark:bg-[#232323]` 时，增量更新可能在最终小程序样式中留下空的 `@media`，导致微信等平台拒绝解析。进一步回归发现，A -> B -> A 回滚时 Vite CSS 缓存也可能复用 B 的旧结果。

## 修复

- 将 Vite 私有的空块 at-rule 清理提取为 bundler 共享的最终 CSS 清理器。
- 在 Vite/Rollup bundle asset、webpack/rspack `PROCESS_ASSETS_STAGE_OPTIMIZE_HASH`、Gulp Vinyl 最终输出边界统一执行清理。
- 仅处理最终小程序产物；保留 Web 合法空条件规则、statement at-rule、解析失败原文和增量阶段占位容器。
- 将 Vite CSS hash 所有权稳定到 output file + Tailwind 主版本，避免 scoped 候选回滚时读取另一运行签名留下的最新缓存值。

## 沉淀的测试

- 共享清理器：空、注释空、嵌套空容器、有效 dark media、statement at-rule、快速路径和非法 CSS 回退。
- bundler 适配：Vite 最终资产/late finalizer、webpack/rspack 最终资产、Gulp transform/adapt Vinyl 输出。
- 缓存回归：scoped 候选与 CSS 结果 A -> B -> A 不得复用旧值。
- 冷构建：最新版 workspace `weapp-tailwindcss@5.2.6` 驱动 uni-app，验证微信 `.wxss`、支付宝 `.acss` 的 scoped 基础背景、dark media 声明和全目录无空 at-rule。
- HMR：微信、支付宝连续执行 A -> B -> C -> A，逐轮断言新值、旧值清除和全目录样式完整性。
- 通用守卫：uni-app、Taro Vite、Taro webpack、MPX、Gulp、weapp-vite 的 static/watch 输出目录覆盖 `.wxss/.acss/.ttss/.qss/.jxss/.css`。

## 验证

- `pnpm --filter @weapp-tailwindcss/postcss test`：646 passed，3 skipped
- `pnpm --filter weapp-tailwindcss test`：3077 passed，29 skipped
- `pnpm e2e:uni-app-css-post-hmr`：mp-weixin / mp-alipay passed
- `pnpm exec vitest run -u -c ./e2e/vitest.e2e.config.ts e2e/issue-uview-plus-cssentries.test.ts`：2 passed
- 六个相关 static 项目：24 passed，70 个快照重写后无差异
- Gulp、MPX、Taro Vite、Taro webpack、uni-app Vite、weapp-vite style-only watch 更新/回滚通过
- mp-weixin、mp-alipay、mp-toutiao 跨平台构建通过
- `pnpm --filter weapp-tailwindcss build`
- `pnpm typecheck`
- ESLint（修改文件）

全套 `e2e:static` 曾在无关的 Taro webpack starter 构建处长时间不退出，已终止；上述相关 static/build/HMR 子集均独立完成。

## 发布

- 增加 `weapp-tailwindcss` 中文 patch changeset。
- 不修改公开 API、配置项或类型。
- 不需要联动 `create-weapp-vite`。
