### PR TITLE
refactor(style-injector): consolidate framework preset pipelines

### DIFF
--- a/packages/weapp-style-injector/src/mpx.ts
+++ b/packages/weapp-style-injector/src/mpx.ts
@@ -1,10 +1,15 @@
-import type { ResolvedSubpackageStyleScope, ResolvedSubpackageTargetSourceFile, SubpackageStyleGenerator, SubpackageStyleRules } from './subpackage'
+import type { ResolvedSubpackageStyleScope, SubpackageStyleGenerator, SubpackageStyleRules } from './subpackage'
 
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { normalizeSubpackageStyleRules } from './subpackage'
-import { ensurePosix, normalizeRoot, toArray } from './utils'
+import {
+  collectPageTargets,
+  createDefaultStyleEntry,
+  resolveSubpackageStyleScopes,
+} from './subpackage-resolution'
+import { toArray } from './utils'
 
 export interface MpxSubPackageConfig {
   appPath: string
@@ -70,133 +75,6 @@ function loadAppConfig(filePath: string): Record<string, unknown> | null {
   }
 }
 
-function ensureArray<T>(value: T | T[] | undefined): T[] {
-  return Array.isArray(value) ? value : (typeof value === 'undefined' ? [] : [value])
-}
-
-function normalizePagePath(value: unknown): string | undefined {
-  const raw = typeof value === 'string'
-    ? value
-    : value && typeof value === 'object' && 'path' in value && typeof (value as { path?: unknown }).path === 'string'
-      ? (value as { path: string }).path
-      : undefined
-  if (!raw) {
-    return undefined
-  }
-  const normalized = ensurePosix(raw).replace(/^[./\\]+/, '')
-  return normalized.length > 0 ? normalized : undefined
-}
-
-function resolvePageStyleFiles(entry: { root?: string, pages?: unknown }): string[] {
-  const root = entry.root ? normalizeRoot(entry.root) : ''
-  if (!root || !Array.isArray(entry.pages)) {
-    return []
-  }
-  return entry.pages
-    .map(normalizePagePath)
-    .filter((page): page is string => Boolean(page))
-    .map(page => ensurePosix(path.posix.join(root, page)))
-}
-
-function resolvePageStyleSourceFiles(
-  entry: { root?: string, pages?: unknown },
-  baseDir: string,
-): ResolvedSubpackageTargetSourceFile[] {
-  const root = entry.root ? normalizeRoot(entry.root) : ''
-  if (!root || !Array.isArray(entry.pages)) {
-    return []
-  }
-
-  return entry.pages
-    .map(normalizePagePath)
-    .filter((page): page is string => Boolean(page))
-    .flatMap((page) => {
-      const sourceAbsolutePath = path.resolve(baseDir, root, `${page}.css`)
-      if (!fs.existsSync(sourceAbsolutePath) || !fs.statSync(sourceAbsolutePath).isFile()) {
-        return []
-      }
-      return [{
-        fileName: ensurePosix(path.posix.join(root, `${page}.css`)),
-        sourceAbsolutePath,
-      }]
-    })
-}
-
-function resolveReferenceOutputName(fileName: string): string {
-  const normalized = ensurePosix(fileName)
-  return path.posix.basename(normalized, path.posix.extname(normalized)) || 'app'
-}
-
-function shouldUseAppStyleReference(styleEntry: MpxSubPackageStyleEntry): boolean {
-  return (
-    styleEntry.appStyle === true
-    || Boolean(styleEntry.referenceFileName)
-    || (
-      styleEntry.sourceFileName === undefined
-      && styleEntry.outputName === undefined
-      && styleEntry.generate === undefined
-      && (
-        Object.keys(styleEntry).length === 0
-        || styleEntry.preprocess !== undefined
-        || styleEntry.files !== undefined
-        || styleEntry.include !== undefined
-        || styleEntry.exclude !== undefined
-        || styleEntry.sourceInclude !== undefined
-        || styleEntry.sourceExclude !== undefined
-      )
-    )
-  )
-}
-
-function applyStyleEntryOptions(
-  resolvedEntry: ResolvedMpxSubPackage,
-  styleEntry: MpxSubPackageStyleEntry,
-) {
-  if (toArray(styleEntry.files).length > 0) {
-    resolvedEntry.files = toArray(styleEntry.files)
-  }
-  if (styleEntry.include !== undefined) {
-    resolvedEntry.include = styleEntry.include
-  }
-  if (styleEntry.exclude !== undefined) {
-    resolvedEntry.exclude = styleEntry.exclude
-  }
-  if (styleEntry.sourceInclude !== undefined) {
-    resolvedEntry.sourceInclude = styleEntry.sourceInclude
-  }
-  if (styleEntry.sourceExclude !== undefined) {
-    resolvedEntry.sourceExclude = styleEntry.sourceExclude
-  }
-  if (styleEntry.generate) {
-    resolvedEntry.generate = styleEntry.generate
-  }
-}
-
-function createDefaultStyleEntry(config: MpxSubPackageConfig): MpxSubPackageStyleEntry {
-  const entry: MpxSubPackageStyleEntry = {
-    sourceFileName: ensureArray(config.sourceFileName),
-  }
-  if (config.outputName !== undefined) {
-    entry.outputName = config.outputName
-  }
-  if (config.files !== undefined) {
-    entry.files = config.files
-  }
-  if (config.include !== undefined) {
-    entry.include = config.include
-  }
-  if (config.exclude !== undefined) {
-    entry.exclude = config.exclude
-  }
-  if (config.generate !== undefined) {
-    entry.generate = config.generate
-  }
-  if (config.preprocess !== undefined) {
-    entry.preprocess = config.preprocess
-  }
-  return entry
-}
-
 export function resolveMpxSubPackages(config: MpxSubPackageConfig): ResolvedMpxSubPackage[] {
   const appPath = path.resolve(config.appPath)
   const appConfig = loadAppConfig(appPath)
@@ -205,8 +83,8 @@ export function resolveMpxSubPackages(config: MpxSubPackageConfig): ResolvedMpxS
     return []
   }
 
-  const primary = ensureArray((appConfig as Record<string, unknown>)['subPackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
-  const secondary = ensureArray((appConfig as Record<string, unknown>)['subpackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
+  const primary = toArray((appConfig as Record<string, unknown>)['subPackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
+  const secondary = toArray((appConfig as Record<string, unknown>)['subpackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
   const subPackagesInput = [...primary, ...secondary]
 
   if (subPackagesInput.length === 0) {
@@ -217,65 +95,17 @@ export function resolveMpxSubPackages(config: MpxSubPackageConfig): ResolvedMpxS
   const entries = normalizeSubpackageStyleRules(config.rules)
   const styleRules: MpxSubPackageStyleEntry[] = entries.length > 0
     ? entries
-    : [createDefaultStyleEntry(config)]
+    : [createDefaultStyleEntry<MpxSubPackageStyleEntry>(config, toArray(config.sourceFileName))]
 
-  const resolved: ResolvedMpxSubPackage[] = []
-
-  for (const entry of subPackagesInput) {
-    if (!entry?.root) {
-      continue
-    }
-
-    const normalizedRoot = normalizeRoot(entry.root)
-    if (!normalizedRoot) {
-      continue
-    }
-
-    for (const styleEntry of styleRules) {
-      if (shouldUseAppStyleReference(styleEntry)) {
-        const referenceFileName = ensurePosix(styleEntry.referenceFileName ?? 'app.css')
-        const resolvedEntry: ResolvedMpxSubPackage = {
-          root: ensurePosix(normalizedRoot),
-          sourceRelativePath: referenceFileName,
-          sourceAbsolutePath: path.resolve(sourceRoot, referenceFileName),
-          referenceFileName,
-          outputName: styleEntry.outputName ?? resolveReferenceOutputName(referenceFileName),
-          preprocess: false,
-          framework: 'mpx',
-          targetFiles: resolvePageStyleFiles(entry),
-          targetSourceFiles: resolvePageStyleSourceFiles(entry, sourceRoot),
-        }
-        applyStyleEntryOptions(resolvedEntry, styleEntry)
-        resolved.push(resolvedEntry)
-        continue
-      }
-
-      const styleFileNames = ensureArray(styleEntry.sourceFileName).flatMap(name => (typeof name === 'string' && name.length > 0 ? [name] : []))
-      const styleCandidates = styleFileNames.length > 0 ? styleFileNames : DEFAULT_STYLE_FILENAMES
-      const stylePath = styleCandidates
-        .map(candidate => path.resolve(sourceRoot, normalizedRoot, candidate))
-        .find(candidatePath => fs.existsSync(candidatePath))
-
-      if (!stylePath) {
-        continue
-      }
-
-      const resolvedEntry: ResolvedMpxSubPackage = {
-        root: ensurePosix(normalizedRoot),
-        sourceRelativePath: ensurePosix(path.relative(sourceRoot, stylePath)),
-        sourceAbsolutePath: stylePath,
-        outputName: styleEntry.outputName ?? path.basename(stylePath, path.extname(stylePath)),
-        preprocess: (styleEntry.preprocess ?? config.preprocess) !== false,
-        framework: 'mpx',
-        targetFiles: resolvePageStyleFiles(entry),
-        targetSourceFiles: resolvePageStyleSourceFiles(entry, sourceRoot),
-      }
-      applyStyleEntryOptions(resolvedEntry, styleEntry)
-      resolved.push(resolvedEntry)
-    }
-  }
-
-  return resolved
+  return resolveSubpackageStyleScopes({
+    framework: 'mpx',
+    sourceRoot,
+    subPackages: subPackagesInput,
+    styleEntries: styleRules,
+    defaultStyleCandidates: DEFAULT_STYLE_FILENAMES,
+    preprocess: config.preprocess,
+    collectTargets: collectPageTargets,
+  })
 }
 
 export function resolveDefaultMpxAppPaths(): string[] {

--- a/packages/weapp-style-injector/src/preset-resolution.ts
+++ b/packages/weapp-style-injector/src/preset-resolution.ts
@@ -1,0 +1,103 @@
+import type {
+  ResolvedSubpackageStyleScope,
+  SubpackageStyleGenerateContext,
+  SubpackageStyleRuleTargets,
+} from './subpackage'
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { toArray } from './utils'
+
+interface CollectPresetConfigsOptions<Config> {
+  explicitConfigs: Config | Config[] | null | undefined
+  requestedPaths: string | string[] | null | undefined
+  defaultPaths: string[]
+  getConfigPath: (config: Config) => string
+  createDiscoveredConfig: (filePath: string) => Config
+}
+
+function findScope(
+  scopes: ResolvedSubpackageStyleScope[],
+  context: SubpackageStyleGenerateContext,
+) {
+  return scopes.find(scope => scope.root === context.root && scope.sourceAbsolutePath === context.sourcePath)
+}
+
+export function collectPresetConfigs<Config>(
+  options: CollectPresetConfigsOptions<Config>,
+): Config[] {
+  const configs = new Map<string, Config>()
+  for (const config of toArray(options.explicitConfigs)) {
+    configs.set(path.resolve(options.getConfigPath(config)), config)
+  }
+
+  const candidatePaths = options.requestedPaths
+    ? toArray(options.requestedPaths).map((filePath: string) => path.resolve(filePath))
+    : options.defaultPaths
+  for (const candidate of candidatePaths) {
+    if (!configs.has(candidate) && fs.existsSync(candidate)) {
+      configs.set(candidate, options.createDiscoveredConfig(candidate))
+    }
+  }
+  return [...configs.values()]
+}
+
+export function assignDefined<Config extends object>(
+  config: Config,
+  values: { [Key in keyof Config]?: Config[Key] | undefined },
+) {
+  for (const key of Object.keys(values) as Array<keyof Config>) {
+    const value = values[key]
+    if (value !== undefined) {
+      config[key] = value
+    }
+  }
+  return config
+}
+
+export function createStyleRuleTargets(
+  files: string | string[] | undefined,
+  include: string | string[] | undefined,
+  exclude: string | string[] | undefined,
+): SubpackageStyleRuleTargets {
+  return assignDefined<SubpackageStyleRuleTargets>({}, { files, include, exclude })
+}
+
+export function createSyncScopeGenerator(scopes: ResolvedSubpackageStyleScope[]) {
+  return (context: SubpackageStyleGenerateContext) => {
+    const scope = findScope(scopes, context)
+    if (!scope) {
+      return undefined
+    }
+    if (scope.generate) {
+      return scope.generate(context)
+    }
+    if (!fs.existsSync(scope.sourceAbsolutePath)) {
+      return undefined
+    }
+    return fs.readFileSync(scope.sourceAbsolutePath, 'utf8')
+  }
+}
+
+export function createAsyncScopeGenerator(scopes: ResolvedSubpackageStyleScope[]) {
+  return async (context: SubpackageStyleGenerateContext) => {
+    const scope = findScope(scopes, context)
+    if (!scope) {
+      return undefined
+    }
+    if (scope.generate) {
+      return scope.generate(context)
+    }
+    if (!fs.existsSync(scope.sourceAbsolutePath)) {
+      return undefined
+    }
+    return fs.promises.readFile(scope.sourceAbsolutePath, 'utf8')
+  }
+}
+
+export function loadSubpackageTargetStyle(_fileName: string, sourceAbsolutePath: string) {
+  if (!fs.existsSync(sourceAbsolutePath)) {
+    return undefined
+  }
+  return fs.readFileSync(sourceAbsolutePath, 'utf8')
+}

--- a/packages/weapp-style-injector/src/subpackage-resolution.ts
+++ b/packages/weapp-style-injector/src/subpackage-resolution.ts
@@ -1,0 +1,317 @@
+import type {
+  ResolvedSubpackageStyleScope,
+  ResolvedSubpackageTargetSourceFile,
+  ResolvedSubpackageTargetSourceModule,
+  SubpackageStyleFramework,
+  SubpackageStyleGenerator,
+} from './subpackage'
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { ensurePosix, normalizeRoot, toArray } from './utils'
+
+export interface SharedSubpackageEntry {
+  root?: string
+  pages?: unknown
+}
+
+export interface SharedStyleEntry {
+  sourceFileName?: string | string[]
+  appStyle?: boolean
+  referenceFileName?: string
+  outputName?: string
+  files?: string | string[]
+  include?: string | string[]
+  exclude?: string | string[]
+  sourceInclude?: string | string[]
+  sourceExclude?: string | string[]
+  generate?: SubpackageStyleGenerator
+  preprocess?: boolean | undefined
+}
+
+interface SubpackageTargets {
+  targetFiles?: string[]
+  targetSourceFiles?: ResolvedSubpackageTargetSourceFile[]
+  sourceModules?: ResolvedSubpackageTargetSourceModule[]
+}
+
+interface ResolveSubpackageScopesOptions<Entry extends SharedStyleEntry> {
+  framework: SubpackageStyleFramework
+  sourceRoot: string
+  subPackages: SharedSubpackageEntry[]
+  styleEntries: Entry[]
+  defaultStyleCandidates: string[]
+  preprocess?: boolean | undefined
+  collectTargets?: (root: string, entry: SharedSubpackageEntry, sourceRoot: string) => SubpackageTargets
+  normalizeStyleCandidates?: (value: string | string[] | undefined) => string[]
+  resolveOutputName?: (stylePath: string, outputName: string | undefined) => string
+  resolveSourceRelativePath?: (root: string, candidate: string, stylePath: string) => string
+  isStyleFile?: (filePath: string) => boolean
+}
+
+const LEADING_DOTS_SLASHES_RE = /^[./\\]+/
+const SOURCE_MODULE_RE = /\.[^.]+\.(?:vue|tsx|jsx|ts|js)$/
+
+function normalizePagePath(value: unknown): string | undefined {
+  const raw = typeof value === 'string'
+    ? value
+    : value && typeof value === 'object' && 'path' in value && typeof (value as { path?: unknown }).path === 'string'
+      ? (value as { path: string }).path
+      : undefined
+  if (!raw) {
+    return undefined
+  }
+  const normalized = ensurePosix(raw).replace(LEADING_DOTS_SLASHES_RE, '')
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function resolvePageStyleFiles(entry: SharedSubpackageEntry): string[] {
+  const root = entry.root ? normalizeRoot(entry.root) : ''
+  if (!root || !Array.isArray(entry.pages)) {
+    return []
+  }
+  return entry.pages
+    .map(normalizePagePath)
+    .filter((page): page is string => Boolean(page))
+    .map(page => ensurePosix(path.posix.join(root, page)))
+}
+
+function resolvePageStyleSourceFiles(
+  entry: SharedSubpackageEntry,
+  sourceRoot: string,
+): ResolvedSubpackageTargetSourceFile[] {
+  const root = entry.root ? normalizeRoot(entry.root) : ''
+  if (!root || !Array.isArray(entry.pages)) {
+    return []
+  }
+
+  return entry.pages
+    .map(normalizePagePath)
+    .filter((page): page is string => Boolean(page))
+    .flatMap((page) => {
+      const sourceAbsolutePath = path.resolve(sourceRoot, root, `${page}.css`)
+      if (!fs.existsSync(sourceAbsolutePath) || !fs.statSync(sourceAbsolutePath).isFile()) {
+        return []
+      }
+      return [{
+        fileName: ensurePosix(path.posix.join(root, `${page}.css`)),
+        sourceAbsolutePath,
+      }]
+    })
+}
+
+function removeStyleExt(fileName: string): string {
+  const ext = path.posix.extname(fileName)
+  return ext ? fileName.slice(0, -ext.length) : fileName
+}
+
+function walkFiles(directory: string, predicate: (fileName: string) => boolean): string[] {
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    return []
+  }
+
+  const files: string[] = []
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(absolutePath, predicate))
+    }
+    else if (entry.isFile() && predicate(entry.name)) {
+      files.push(absolutePath)
+    }
+  }
+  return files
+}
+
+function resolveComponentStyleSourceFiles(
+  root: string,
+  sourceRoot: string,
+): ResolvedSubpackageTargetSourceFile[] {
+  const componentsDir = path.resolve(sourceRoot, root, 'components')
+  return walkFiles(componentsDir, fileName => fileName.endsWith('.css')).map(sourceAbsolutePath => ({
+    fileName: ensurePosix(path.relative(sourceRoot, sourceAbsolutePath)),
+    sourceAbsolutePath,
+  }))
+}
+
+function resolveSourceModules(
+  root: string,
+  sourceRoot: string,
+): ResolvedSubpackageTargetSourceModule[] {
+  const directories = [
+    path.resolve(sourceRoot, root, 'pages'),
+    path.resolve(sourceRoot, root, 'components'),
+  ]
+  return directories.flatMap(directory =>
+    walkFiles(directory, fileName => SOURCE_MODULE_RE.test(fileName)).map((sourceAbsolutePath) => {
+      const fileName = ensurePosix(path.relative(sourceRoot, sourceAbsolutePath))
+      return {
+        fileName,
+        styleFileName: removeStyleExt(fileName),
+        sourceAbsolutePath,
+      }
+    }),
+  )
+}
+
+function resolveReferenceOutputName(fileName: string): string {
+  const normalized = ensurePosix(fileName)
+  return path.posix.basename(normalized, path.posix.extname(normalized)) || 'app'
+}
+
+function shouldUseAppStyleReference(styleEntry: SharedStyleEntry): boolean {
+  return (
+    styleEntry.appStyle === true
+    || Boolean(styleEntry.referenceFileName)
+    || (
+      styleEntry.sourceFileName === undefined
+      && styleEntry.outputName === undefined
+      && styleEntry.generate === undefined
+      && (
+        Object.keys(styleEntry).length === 0
+        || styleEntry.preprocess !== undefined
+        || styleEntry.files !== undefined
+        || styleEntry.include !== undefined
+        || styleEntry.exclude !== undefined
+        || styleEntry.sourceInclude !== undefined
+        || styleEntry.sourceExclude !== undefined
+      )
+    )
+  )
+}
+
+function applyStyleEntryOptions(
+  resolvedEntry: ResolvedSubpackageStyleScope,
+  styleEntry: SharedStyleEntry,
+) {
+  if (toArray(styleEntry.files).length > 0) {
+    resolvedEntry.files = toArray(styleEntry.files)
+  }
+  if (styleEntry.include !== undefined) {
+    resolvedEntry.include = styleEntry.include
+  }
+  if (styleEntry.exclude !== undefined) {
+    resolvedEntry.exclude = styleEntry.exclude
+  }
+  if (styleEntry.sourceInclude !== undefined) {
+    resolvedEntry.sourceInclude = styleEntry.sourceInclude
+  }
+  if (styleEntry.sourceExclude !== undefined) {
+    resolvedEntry.sourceExclude = styleEntry.sourceExclude
+  }
+  if (styleEntry.generate) {
+    resolvedEntry.generate = styleEntry.generate
+  }
+}
+
+export function createDefaultStyleEntry<Entry extends SharedStyleEntry>(
+  config: SharedStyleEntry,
+  sourceFileName: string[],
+): Entry {
+  const entry: SharedStyleEntry = { sourceFileName }
+  for (const key of ['outputName', 'files', 'include', 'exclude', 'generate', 'preprocess'] as const) {
+    if (config[key] !== undefined) {
+      entry[key] = config[key] as never
+    }
+  }
+  return entry as Entry
+}
+
+export function collectPageTargets(
+  _root: string,
+  entry: SharedSubpackageEntry,
+  sourceRoot: string,
+): SubpackageTargets {
+  return {
+    targetFiles: resolvePageStyleFiles(entry),
+    targetSourceFiles: resolvePageStyleSourceFiles(entry, sourceRoot),
+  }
+}
+
+export function collectFrameworkTargets(
+  root: string,
+  entry: SharedSubpackageEntry,
+  sourceRoot: string,
+): SubpackageTargets {
+  const componentStyleSourceFiles = resolveComponentStyleSourceFiles(root, sourceRoot)
+  return {
+    targetFiles: [
+      ...resolvePageStyleFiles(entry),
+      ...componentStyleSourceFiles.map(file => removeStyleExt(file.fileName)),
+    ],
+    targetSourceFiles: [
+      ...resolvePageStyleSourceFiles(entry, sourceRoot),
+      ...componentStyleSourceFiles,
+    ],
+    sourceModules: resolveSourceModules(root, sourceRoot),
+  }
+}
+
+export function resolveSubpackageStyleScopes<Entry extends SharedStyleEntry>(
+  options: ResolveSubpackageScopesOptions<Entry>,
+): ResolvedSubpackageStyleScope[] {
+  const resolved: ResolvedSubpackageStyleScope[] = []
+
+  for (const subPackage of options.subPackages) {
+    const root = subPackage.root ? normalizeRoot(subPackage.root) : ''
+    if (!root) {
+      continue
+    }
+    const targets = options.collectTargets?.(root, subPackage, options.sourceRoot) ?? {}
+
+    for (const styleEntry of options.styleEntries) {
+      if (shouldUseAppStyleReference(styleEntry)) {
+        const referenceFileName = ensurePosix(styleEntry.referenceFileName ?? 'app.css')
+        const resolvedEntry: ResolvedSubpackageStyleScope = {
+          root: ensurePosix(root),
+          sourceRelativePath: referenceFileName,
+          sourceAbsolutePath: path.resolve(options.sourceRoot, referenceFileName),
+          referenceFileName,
+          outputName: styleEntry.outputName ?? resolveReferenceOutputName(referenceFileName),
+          preprocess: false,
+          framework: options.framework,
+          ...targets,
+        }
+        applyStyleEntryOptions(resolvedEntry, styleEntry)
+        resolved.push(resolvedEntry)
+        continue
+      }
+
+      const configuredCandidates: string[] = options.normalizeStyleCandidates
+        ? options.normalizeStyleCandidates(styleEntry.sourceFileName)
+        : toArray(styleEntry.sourceFileName)
+            .filter((candidate: unknown): candidate is string => typeof candidate === 'string' && candidate.length > 0)
+      const candidates = configuredCandidates.length > 0
+        ? configuredCandidates
+        : options.defaultStyleCandidates
+      const matchedStyle = candidates
+        .map((candidate: string) => ({
+          candidate,
+          stylePath: path.resolve(options.sourceRoot, root, candidate),
+        }))
+        .find(({ stylePath }) => options.isStyleFile?.(stylePath) ?? fs.existsSync(stylePath))
+      if (!matchedStyle) {
+        continue
+      }
+
+      const { candidate, stylePath } = matchedStyle
+      const defaultOutputName = path.basename(stylePath, path.extname(stylePath))
+      const resolvedEntry: ResolvedSubpackageStyleScope = {
+        root: ensurePosix(root),
+        sourceRelativePath: options.resolveSourceRelativePath?.(root, candidate, stylePath)
+          ?? ensurePosix(path.relative(options.sourceRoot, stylePath)),
+        sourceAbsolutePath: stylePath,
+        outputName: options.resolveOutputName?.(stylePath, styleEntry.outputName)
+          ?? styleEntry.outputName
+          ?? defaultOutputName,
+        preprocess: (styleEntry.preprocess ?? options.preprocess) !== false,
+        framework: options.framework,
+        ...targets,
+      }
+      applyStyleEntryOptions(resolvedEntry, styleEntry)
+      resolved.push(resolvedEntry)
+    }
+  }
+
+  return resolved
+}

--- a/packages/weapp-style-injector/src/taro.ts
+++ b/packages/weapp-style-injector/src/taro.ts
@@ -1,5 +1,5 @@
 import type { PerFileImportResolver } from './core'
-import type { ResolvedSubpackageStyleScope, ResolvedSubpackageTargetSourceFile, ResolvedSubpackageTargetSourceModule, SubpackageStyleGenerator, SubpackageStyleRules } from './subpackage'
+import type { ResolvedSubpackageStyleScope, SubpackageStyleGenerator, SubpackageStyleRules } from './subpackage'
 
 import fs from 'node:fs'
 import path from 'node:path'
@@ -9,9 +9,13 @@ import {
   normalizeSubpackageStyleRules,
 } from './subpackage'
 import {
+  collectFrameworkTargets,
+  createDefaultStyleEntry,
+  resolveSubpackageStyleScopes,
+} from './subpackage-resolution'
+import {
   ensurePosix,
   normalizeRelativeImport,
-  normalizeRoot,
   toArray,
 } from './utils'
 
@@ -126,191 +130,6 @@ function loadAppConfigModule(filePath: string): Record<string, unknown> | null {
   }
 }
 
-function ensureArray<T>(value: T | T[] | undefined): T[] {
-  return Array.isArray(value) ? value : (typeof value === 'undefined' ? [] : [value])
-}
-
-function normalizePagePath(value: unknown): string | undefined {
-  const raw = typeof value === 'string'
-    ? value
-    : value && typeof value === 'object' && 'path' in value && typeof (value as { path?: unknown }).path === 'string'
-      ? (value as { path: string }).path
-      : undefined
-  if (!raw) {
-    return undefined
-  }
-  const normalized = ensurePosix(raw).replace(/^[./\\]+/, '')
-  return normalized.length > 0 ? normalized : undefined
-}
-
-function resolvePageStyleFiles(entry: { root?: string, pages?: unknown }): string[] {
-  const root = entry.root ? normalizeRoot(entry.root) : ''
-  if (!root || !Array.isArray(entry.pages)) {
-    return []
-  }
-  return entry.pages
-    .map(normalizePagePath)
-    .filter((page): page is string => Boolean(page))
-    .map(page => ensurePosix(path.posix.join(root, page)))
-}
-
-function resolvePageStyleSourceFiles(
-  entry: { root?: string, pages?: unknown },
-  baseDir: string,
-): ResolvedSubpackageTargetSourceFile[] {
-  const root = entry.root ? normalizeRoot(entry.root) : ''
-  if (!root || !Array.isArray(entry.pages)) {
-    return []
-  }
-
-  return entry.pages
-    .map(normalizePagePath)
-    .filter((page): page is string => Boolean(page))
-    .flatMap((page) => {
-      const sourceAbsolutePath = path.resolve(baseDir, root, `${page}.css`)
-      if (!fs.existsSync(sourceAbsolutePath) || !fs.statSync(sourceAbsolutePath).isFile()) {
-        return []
-      }
-      return [{
-        fileName: ensurePosix(path.posix.join(root, `${page}.css`)),
-        sourceAbsolutePath,
-      }]
-    })
-}
-
-function removeStyleExt(fileName: string): string {
-  const ext = path.posix.extname(fileName)
-  return ext ? fileName.slice(0, -ext.length) : fileName
-}
-
-function walkFiles(directory: string, predicate: (fileName: string) => boolean): string[] {
-  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
-    return []
-  }
-
-  const files: string[] = []
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    const absolutePath = path.join(directory, entry.name)
-    if (entry.isDirectory()) {
-      files.push(...walkFiles(absolutePath, predicate))
-    }
-    else if (entry.isFile() && predicate(entry.name)) {
-      files.push(absolutePath)
-    }
-  }
-  return files
-}
-
-function resolveComponentStyleSourceFiles(
-  root: string,
-  baseDir: string,
-): ResolvedSubpackageTargetSourceFile[] {
-  const componentsDir = path.resolve(baseDir, root, 'components')
-  return walkFiles(componentsDir, fileName => fileName.endsWith('.css')).map((sourceAbsolutePath) => {
-    const fileName = ensurePosix(path.relative(baseDir, sourceAbsolutePath))
-    return {
-      fileName,
-      sourceAbsolutePath,
-    }
-  })
-}
-
-function resolveSourceModules(
-  root: string,
-  baseDir: string,
-): ResolvedSubpackageTargetSourceModule[] {
-  const directories = [
-    path.resolve(baseDir, root, 'pages'),
-    path.resolve(baseDir, root, 'components'),
-  ]
-  return directories.flatMap(directory =>
-    walkFiles(directory, fileName => /\.[^.]+\.(?:vue|tsx|jsx|ts|js)$/.test(fileName)).map((sourceAbsolutePath) => {
-      const fileName = ensurePosix(path.relative(baseDir, sourceAbsolutePath))
-      const styleFileName = removeStyleExt(fileName)
-      return {
-        fileName,
-        styleFileName,
-        sourceAbsolutePath,
-      }
-    }),
-  )
-}
-
-function resolveReferenceOutputName(fileName: string): string {
-  const normalized = ensurePosix(fileName)
-  return path.posix.basename(normalized, path.posix.extname(normalized)) || 'app'
-}
-
-function shouldUseAppStyleReference(styleEntry: TaroSubPackageStyleEntry): boolean {
-  return (
-    styleEntry.appStyle === true
-    || Boolean(styleEntry.referenceFileName)
-    || (
-      styleEntry.sourceFileName === undefined
-      && styleEntry.outputName === undefined
-      && styleEntry.generate === undefined
-      && (
-        Object.keys(styleEntry).length === 0
-        || styleEntry.preprocess !== undefined
-        || styleEntry.files !== undefined
-        || styleEntry.include !== undefined
-        || styleEntry.exclude !== undefined
-        || styleEntry.sourceInclude !== undefined
-        || styleEntry.sourceExclude !== undefined
-      )
-    )
-  )
-}
-
-function applyStyleEntryOptions(
-  resolvedEntry: ResolvedTaroSubPackage,
-  styleEntry: TaroSubPackageStyleEntry,
-) {
-  if (toArray(styleEntry.files).length > 0) {
-    resolvedEntry.files = toArray(styleEntry.files)
-  }
-  if (styleEntry.include !== undefined) {
-    resolvedEntry.include = styleEntry.include
-  }
-  if (styleEntry.exclude !== undefined) {
-    resolvedEntry.exclude = styleEntry.exclude
-  }
-  if (styleEntry.sourceInclude !== undefined) {
-    resolvedEntry.sourceInclude = styleEntry.sourceInclude
-  }
-  if (styleEntry.sourceExclude !== undefined) {
-    resolvedEntry.sourceExclude = styleEntry.sourceExclude
-  }
-  if (styleEntry.generate) {
-    resolvedEntry.generate = styleEntry.generate
-  }
-}
-
-function createDefaultStyleEntry(config: TaroSubPackageConfig): TaroSubPackageStyleEntry {
-  const entry: TaroSubPackageStyleEntry = {
-    sourceFileName: ensureArray(config.sourceFileName ?? config.indexFileNames),
-  }
-  if (config.outputName !== undefined) {
-    entry.outputName = config.outputName
-  }
-  if (config.files !== undefined) {
-    entry.files = config.files
-  }
-  if (config.include !== undefined) {
-    entry.include = config.include
-  }
-  if (config.exclude !== undefined) {
-    entry.exclude = config.exclude
-  }
-  if (config.generate !== undefined) {
-    entry.generate = config.generate
-  }
-  if (config.preprocess !== undefined) {
-    entry.preprocess = config.preprocess
-  }
-  return entry
-}
-
 export function resolveTaroSubPackages(config: TaroSubPackageConfig): ResolvedTaroSubPackage[] {
   const appConfigPath = path.resolve(config.appConfigPath)
   const appConfig = loadAppConfigModule(appConfigPath)
@@ -319,9 +138,9 @@ export function resolveTaroSubPackages(config: TaroSubPackageConfig): ResolvedTa
     return []
   }
 
-  const primary = ensureArray((appConfig as Record<string, unknown>)['subPackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
+  const primary = toArray((appConfig as Record<string, unknown>)['subPackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
 
-  const secondary = ensureArray((appConfig as Record<string, unknown>)['subpackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
+  const secondary = toArray((appConfig as Record<string, unknown>)['subpackages'] as Array<{ root?: string, pages?: unknown }> | undefined)
   const subPackagesInput = [...primary, ...secondary]
 
   if (subPackagesInput.length === 0) {
@@ -332,81 +151,20 @@ export function resolveTaroSubPackages(config: TaroSubPackageConfig): ResolvedTa
   const entries = normalizeSubpackageStyleRules(config.rules)
   const styleRules: TaroSubPackageStyleEntry[] = entries.length > 0
     ? entries
-    : [createDefaultStyleEntry(config)]
+    : [createDefaultStyleEntry<TaroSubPackageStyleEntry>(
+        config,
+        toArray(config.sourceFileName ?? config.indexFileNames),
+      )]
 
-  const resolved: ResolvedTaroSubPackage[] = []
-
-  for (const entry of subPackagesInput) {
-    if (!entry?.root) {
-      continue
-    }
-
-    const normalizedRoot = normalizeRoot(entry.root)
-    if (!normalizedRoot) {
-      continue
-    }
-
-    for (const styleEntry of styleRules) {
-      const componentStyleSourceFiles = resolveComponentStyleSourceFiles(normalizedRoot, baseDir)
-
-      if (shouldUseAppStyleReference(styleEntry)) {
-        const referenceFileName = ensurePosix(styleEntry.referenceFileName ?? 'app.css')
-        const resolvedEntry: ResolvedTaroSubPackage = {
-          root: ensurePosix(normalizedRoot),
-          sourceRelativePath: referenceFileName,
-          sourceAbsolutePath: path.resolve(baseDir, referenceFileName),
-          referenceFileName,
-          outputName: styleEntry.outputName ?? resolveReferenceOutputName(referenceFileName),
-          preprocess: false,
-          framework: 'taro',
-        }
-        resolvedEntry.targetFiles = [
-          ...resolvePageStyleFiles(entry),
-          ...componentStyleSourceFiles.map(file => removeStyleExt(file.fileName)),
-        ]
-        resolvedEntry.targetSourceFiles = [
-          ...resolvePageStyleSourceFiles(entry, baseDir),
-          ...componentStyleSourceFiles,
-        ]
-        resolvedEntry.sourceModules = resolveSourceModules(normalizedRoot, baseDir)
-        applyStyleEntryOptions(resolvedEntry, styleEntry)
-        resolved.push(resolvedEntry)
-        continue
-      }
-
-      const styleFileNames = ensureArray(styleEntry.sourceFileName).flatMap(name => (typeof name === 'string' && name.length > 0 ? [name] : []))
-      const styleCandidates = styleFileNames.length > 0 ? styleFileNames : DEFAULT_STYLE_FILENAMES
-      const stylePath = styleCandidates
-        .map(candidate => path.resolve(baseDir, normalizedRoot, candidate))
-        .find(candidatePath => fs.existsSync(candidatePath))
-
-      if (!stylePath) {
-        continue
-      }
-
-      const resolvedEntry: ResolvedTaroSubPackage = {
-        root: ensurePosix(normalizedRoot),
-        sourceRelativePath: ensurePosix(path.relative(baseDir, stylePath)),
-        sourceAbsolutePath: stylePath,
-        outputName: styleEntry.outputName ?? path.basename(stylePath, path.extname(stylePath)),
-        preprocess: (styleEntry.preprocess ?? config.preprocess) !== false,
-        framework: 'taro',
-      }
-      resolvedEntry.targetFiles = [
-        ...resolvePageStyleFiles(entry),
-        ...componentStyleSourceFiles.map(file => removeStyleExt(file.fileName)),
-      ]
-      resolvedEntry.targetSourceFiles = [
-        ...resolvePageStyleSourceFiles(entry, baseDir),
-        ...componentStyleSourceFiles,
-      ]
-      resolvedEntry.sourceModules = resolveSourceModules(normalizedRoot, baseDir)
-      applyStyleEntryOptions(resolvedEntry, styleEntry)
-      resolved.push(resolvedEntry)
-    }
-  }
-
-  return resolved
+  return resolveSubpackageStyleScopes({
+    framework: 'taro',
+    sourceRoot: baseDir,
+    subPackages: subPackagesInput,
+    styleEntries: styleRules,
+    defaultStyleCandidates: DEFAULT_STYLE_FILENAMES,
+    preprocess: config.preprocess,
+    collectTargets: collectFrameworkTargets,
+  })
 }
 
 export function createTaroSubPackageImportResolver(

--- a/packages/weapp-style-injector/src/uni-app.ts
+++ b/packages/weapp-style-injector/src/uni-app.ts
@@ -1,10 +1,15 @@
 import type { PerFileImportResolver } from './core'
-import type { ResolvedSubpackageStyleScope, ResolvedSubpackageTargetSourceFile, ResolvedSubpackageTargetSourceModule, SubpackageStyleGenerator, SubpackageStyleRules } from './subpackage'
+import type { ResolvedSubpackageStyleScope, SubpackageStyleGenerator, SubpackageStyleRules } from './subpackage'
 
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { normalizeSubpackageStyleRules } from './subpackage'
+import {
+  collectFrameworkTargets,
+  createDefaultStyleEntry,
+  resolveSubpackageStyleScopes,
+} from './subpackage-resolution'
 import {
   ensurePosix,
   normalizeRelativeImport,
@@ -140,8 +145,8 @@ function normalizeCandidateList(candidate: UniAppSubPackageConfig['sourceFileNam
     : FALLBACK_INDEX_FILE_NAMES
 
   return list
-    .map(entry => entry?.trim())
-    .filter((entry): entry is string => Boolean(entry && entry.length > 0))
+    .map((entry: string) => entry?.trim())
+    .filter((entry: string | undefined): entry is string => Boolean(entry && entry.length > 0))
 }
 
 function resolveOutputName(fileName: string, outputName?: string): string {
@@ -150,187 +155,6 @@ function resolveOutputName(fileName: string, outputName?: string): string {
   }
 
   return path.basename(fileName, path.extname(fileName))
-}
-
-function resolveReferenceOutputName(fileName: string): string {
-  const normalized = ensurePosix(fileName)
-  return path.posix.basename(normalized, path.posix.extname(normalized)) || 'app'
-}
-
-function shouldUseAppStyleReference(styleEntry: UniAppSubPackageStyleEntry): boolean {
-  return (
-    styleEntry.appStyle === true
-    || Boolean(styleEntry.referenceFileName)
-    || (
-      styleEntry.sourceFileName === undefined
-      && styleEntry.outputName === undefined
-      && styleEntry.generate === undefined
-      && (
-        Object.keys(styleEntry).length === 0
-        || styleEntry.preprocess !== undefined
-        || styleEntry.files !== undefined
-        || styleEntry.include !== undefined
-        || styleEntry.exclude !== undefined
-        || styleEntry.sourceInclude !== undefined
-        || styleEntry.sourceExclude !== undefined
-      )
-    )
-  )
-}
-
-function applyStyleEntryOptions(
-  resolvedEntry: ResolvedSubPackage,
-  styleEntry: UniAppSubPackageStyleEntry,
-) {
-  if (toArray(styleEntry.files).length > 0) {
-    resolvedEntry.files = toArray(styleEntry.files)
-  }
-  if (styleEntry.include !== undefined) {
-    resolvedEntry.include = styleEntry.include
-  }
-  if (styleEntry.exclude !== undefined) {
-    resolvedEntry.exclude = styleEntry.exclude
-  }
-  if (styleEntry.sourceInclude !== undefined) {
-    resolvedEntry.sourceInclude = styleEntry.sourceInclude
-  }
-  if (styleEntry.sourceExclude !== undefined) {
-    resolvedEntry.sourceExclude = styleEntry.sourceExclude
-  }
-  if (styleEntry.generate) {
-    resolvedEntry.generate = styleEntry.generate
-  }
-}
-
-function createDefaultStyleEntry(config: UniAppSubPackageConfig): UniAppSubPackageStyleEntry {
-  const entry: UniAppSubPackageStyleEntry = {
-    sourceFileName: normalizeCandidateList(config.sourceFileName ?? config.indexFileName),
-  }
-  if (config.outputName !== undefined) {
-    entry.outputName = config.outputName
-  }
-  if (config.files !== undefined) {
-    entry.files = config.files
-  }
-  if (config.include !== undefined) {
-    entry.include = config.include
-  }
-  if (config.exclude !== undefined) {
-    entry.exclude = config.exclude
-  }
-  if (config.generate !== undefined) {
-    entry.generate = config.generate
-  }
-  if (config.preprocess !== undefined) {
-    entry.preprocess = config.preprocess
-  }
-  return entry
-}
-
-function normalizePagePath(value: unknown): string | undefined {
-  const raw = typeof value === 'string'
-    ? value
-    : value && typeof value === 'object' && 'path' in value && typeof (value as { path?: unknown }).path === 'string'
-      ? (value as { path: string }).path
-      : undefined
-  if (!raw) {
-    return undefined
-  }
-  const normalized = ensurePosix(raw).replace(LEADING_DOTS_SLASHES_RE, '')
-  return normalized.length > 0 ? normalized : undefined
-}
-
-function resolvePageStyleFiles(entry: { root?: string, pages?: unknown }): string[] {
-  const root = entry.root ? normalizeRoot(entry.root) : ''
-  if (!root || !Array.isArray(entry.pages)) {
-    return []
-  }
-  return entry.pages
-    .map(normalizePagePath)
-    .filter((page): page is string => Boolean(page))
-    .map(page => ensurePosix(path.posix.join(root, page)))
-}
-
-function resolvePageStyleSourceFiles(
-  entry: { root?: string, pages?: unknown },
-  baseDir: string,
-): ResolvedSubpackageTargetSourceFile[] {
-  const root = entry.root ? normalizeRoot(entry.root) : ''
-  if (!root || !Array.isArray(entry.pages)) {
-    return []
-  }
-
-  return entry.pages
-    .map(normalizePagePath)
-    .filter((page): page is string => Boolean(page))
-    .flatMap((page) => {
-      const sourceAbsolutePath = path.resolve(baseDir, root, `${page}.css`)
-      if (!fs.existsSync(sourceAbsolutePath) || !fs.statSync(sourceAbsolutePath).isFile()) {
-        return []
-      }
-      return [{
-        fileName: ensurePosix(path.posix.join(root, `${page}.css`)),
-        sourceAbsolutePath,
-      }]
-    })
-}
-
-function removeStyleExt(fileName: string): string {
-  const ext = path.posix.extname(fileName)
-  return ext ? fileName.slice(0, -ext.length) : fileName
-}
-
-function walkFiles(directory: string, predicate: (fileName: string) => boolean): string[] {
-  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
-    return []
-  }
-
-  const files: string[] = []
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-    const absolutePath = path.join(directory, entry.name)
-    if (entry.isDirectory()) {
-      files.push(...walkFiles(absolutePath, predicate))
-    }
-    else if (entry.isFile() && predicate(entry.name)) {
-      files.push(absolutePath)
-    }
-  }
-  return files
-}
-
-function resolveComponentStyleSourceFiles(
-  root: string,
-  baseDir: string,
-): ResolvedSubpackageTargetSourceFile[] {
-  const componentsDir = path.resolve(baseDir, root, 'components')
-  return walkFiles(componentsDir, fileName => fileName.endsWith('.css')).map((sourceAbsolutePath) => {
-    const fileName = ensurePosix(path.relative(baseDir, sourceAbsolutePath))
-    return {
-      fileName,
-      sourceAbsolutePath,
-    }
-  })
-}
-
-function resolveSourceModules(
-  root: string,
-  baseDir: string,
-): ResolvedSubpackageTargetSourceModule[] {
-  const directories = [
-    path.resolve(baseDir, root, 'pages'),
-    path.resolve(baseDir, root, 'components'),
-  ]
-  return directories.flatMap(directory =>
-    walkFiles(directory, fileName => /\.[^.]+\.(?:vue|tsx|jsx|ts|js)$/.test(fileName)).map((sourceAbsolutePath) => {
-      const fileName = ensurePosix(path.relative(baseDir, sourceAbsolutePath))
-      const styleFileName = removeStyleExt(fileName)
-      return {
-        fileName,
-        styleFileName,
-        sourceAbsolutePath,
-      }
-    }),
-  )
 }
 
 function resolveSubPackages(config: UniAppSubPackageConfig): ResolvedSubPackage[] {
@@ -353,90 +177,24 @@ function resolveSubPackages(config: UniAppSubPackageConfig): ResolvedSubPackage[
   const entries = normalizeSubpackageStyleRules(config.rules)
   const styleRules: UniAppSubPackageStyleEntry[] = entries.length > 0
     ? entries
-    : [createDefaultStyleEntry(config)]
+    : [createDefaultStyleEntry<UniAppSubPackageStyleEntry>(
+        config,
+        normalizeCandidateList(config.sourceFileName ?? config.indexFileName),
+      )]
 
-  const resolved: ResolvedSubPackage[] = []
-
-  for (const entry of subPackages) {
-    if (!entry?.root) {
-      continue
-    }
-
-    const normalizedRoot = normalizeRoot(entry.root)
-    if (!normalizedRoot) {
-      continue
-    }
-
-    for (const styleEntry of styleRules) {
-      const componentStyleSourceFiles = resolveComponentStyleSourceFiles(normalizedRoot, baseDir)
-
-      if (shouldUseAppStyleReference(styleEntry)) {
-        const referenceFileName = ensurePosix(styleEntry.referenceFileName ?? 'app.css')
-        const resolvedEntry: ResolvedSubPackage = {
-          root: ensurePosix(normalizedRoot),
-          sourceRelativePath: referenceFileName,
-          sourceAbsolutePath: path.resolve(baseDir, referenceFileName),
-          referenceFileName,
-          outputName: styleEntry.outputName ?? resolveReferenceOutputName(referenceFileName),
-          preprocess: false,
-          framework: 'uni-app',
-        }
-        resolvedEntry.targetFiles = [
-          ...resolvePageStyleFiles(entry),
-          ...componentStyleSourceFiles.map(file => removeStyleExt(file.fileName)),
-        ]
-        resolvedEntry.targetSourceFiles = [
-          ...resolvePageStyleSourceFiles(entry, baseDir),
-          ...componentStyleSourceFiles,
-        ]
-        resolvedEntry.sourceModules = resolveSourceModules(normalizedRoot, baseDir)
-        applyStyleEntryOptions(resolvedEntry, styleEntry)
-        resolved.push(resolvedEntry)
-        continue
-      }
-
-      const candidates = normalizeCandidateList(styleEntry.sourceFileName)
-      let matchedFileName: string | undefined
-      let matchedAbsolutePath: string | undefined
-
-      for (const candidate of candidates) {
-        const indexAbsolutePath = path.resolve(baseDir, normalizedRoot, candidate)
-        if (fs.existsSync(indexAbsolutePath) && fs.statSync(indexAbsolutePath).isFile()) {
-          matchedFileName = candidate
-          matchedAbsolutePath = indexAbsolutePath
-          break
-        }
-      }
-
-      if (!matchedFileName || !matchedAbsolutePath) {
-        continue
-      }
-
-      const sourceRelativePath = ensurePosix(path.join(normalizedRoot, matchedFileName))
-
-      const resolvedEntry: ResolvedSubPackage = {
-        root: ensurePosix(normalizedRoot),
-        sourceRelativePath,
-        sourceAbsolutePath: matchedAbsolutePath,
-        outputName: resolveOutputName(matchedFileName, styleEntry.outputName),
-        preprocess: (styleEntry.preprocess ?? config.preprocess) !== false,
-        framework: 'uni-app',
-      }
-      resolvedEntry.targetFiles = [
-        ...resolvePageStyleFiles(entry),
-        ...componentStyleSourceFiles.map(file => removeStyleExt(file.fileName)),
-      ]
-      resolvedEntry.targetSourceFiles = [
-        ...resolvePageStyleSourceFiles(entry, baseDir),
-        ...componentStyleSourceFiles,
-      ]
-      resolvedEntry.sourceModules = resolveSourceModules(normalizedRoot, baseDir)
-      applyStyleEntryOptions(resolvedEntry, styleEntry)
-      resolved.push(resolvedEntry)
-    }
-  }
-
-  return resolved
+  return resolveSubpackageStyleScopes({
+    framework: 'uni-app',
+    sourceRoot: baseDir,
+    subPackages,
+    styleEntries: styleRules,
+    defaultStyleCandidates: FALLBACK_INDEX_FILE_NAMES,
+    preprocess: config.preprocess,
+    collectTargets: collectFrameworkTargets,
+    normalizeStyleCandidates: normalizeCandidateList,
+    resolveOutputName,
+    resolveSourceRelativePath: (root, candidate) => ensurePosix(path.join(root, candidate)),
+    isStyleFile: filePath => fs.existsSync(filePath) && fs.statSync(filePath).isFile(),
+  })
 }
 
 export function createUniAppSubPackageImportResolver(

--- a/packages/weapp-style-injector/src/vite/taro.ts
+++ b/packages/weapp-style-injector/src/vite/taro.ts
@@ -7,9 +7,15 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { createStyleInjector } from '../core'
+import {
+  assignDefined,
+  collectPresetConfigs,
+  createAsyncScopeGenerator,
+  createStyleRuleTargets,
+} from '../preset-resolution'
 import { isFileMatchedBySubpackageScope, resolveSubpackageStyleImport, shouldInjectSubpackageStyleImport } from '../subpackage'
 import { createTaroSubPackageImportResolver, resolveTaroSubPackages } from '../taro'
-import { ensurePosix, mergePerFileResolvers, toArray } from '../utils'
+import { ensurePosix, mergePerFileResolvers } from '../utils'
 import weappStyleInjector from '../vite'
 
 export type { SubpackageStyleRule, SubpackageStyleRules } from '../subpackage'
@@ -158,45 +164,25 @@ export function StyleInjector(options: ViteTaroStyleInjectorOptions = {}) {
     ...rest
   } = options
 
-  const configs = new Map<string, TaroSubPackageConfig>()
-
-  for (const entry of toArray(subPackages)) {
-    configs.set(path.resolve(entry.appConfigPath), entry)
-  }
-
-  const candidatePaths = appConfigPath
-    ? toArray(appConfigPath).map(entry => path.resolve(entry))
-    : resolveDefaultAppConfigPaths()
-
-  for (const candidate of candidatePaths) {
-    if (!configs.has(candidate) && fs.existsSync(candidate)) {
-      const config: TaroSubPackageConfig = { appConfigPath: candidate }
-      if (sourceFileName !== undefined) {
-        config.sourceFileName = sourceFileName
+  const entries = collectPresetConfigs<TaroSubPackageConfig>({
+    explicitConfigs: subPackages,
+    requestedPaths: appConfigPath,
+    defaultPaths: resolveDefaultAppConfigPaths(),
+    getConfigPath: config => config.appConfigPath,
+    createDiscoveredConfig: (candidate) => {
+      const config: TaroSubPackageConfig = {
+        appConfigPath: candidate,
       }
-      if (outputName !== undefined) {
-        config.outputName = outputName
-      }
-      if (files !== undefined) {
-        config.files = files
-      }
-      if (include !== undefined) {
-        config.include = include
-      }
-      if (exclude !== undefined) {
-        config.exclude = exclude
-      }
+      assignDefined(config, { sourceFileName, outputName, files, include, exclude })
       if (rules !== undefined) {
         config.rules = rules
       }
       else if (sourceFileName === undefined) {
-        config.rules = [{ from: { ref: 'app.css' }, to: { files, include, exclude } }]
+        config.rules = [{ from: { ref: 'app.css' }, to: createStyleRuleTargets(files, include, exclude) }]
       }
-      configs.set(candidate, config)
-    }
-  }
-
-  const entries = [...configs.values()]
+      return config
+    },
+  })
   const taroResolver = createTaroSubPackageImportResolver(entries)
   const resolvedSubPackages = entries.flatMap(resolveTaroSubPackages)
 
@@ -212,19 +198,7 @@ export function StyleInjector(options: ViteTaroStyleInjectorOptions = {}) {
   }
   if (resolvedSubPackages.length > 0) {
     injectorOptions.subpackageStyleScopes = resolvedSubPackages
-    injectorOptions.generateSubpackageStyle = async (context) => {
-      const scope = resolvedSubPackages.find(entry => entry.root === context.root && entry.sourceAbsolutePath === context.sourcePath)
-      if (!scope) {
-        return undefined
-      }
-      if (scope.generate) {
-        return scope.generate(context)
-      }
-      if (!fs.existsSync(scope.sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.promises.readFile(scope.sourceAbsolutePath, 'utf8')
-    }
+    injectorOptions.generateSubpackageStyle = createAsyncScopeGenerator(resolvedSubPackages)
   }
 
   const sourceStyleInjector = createTaroSourceStyleInjectorPlugin(resolvedSubPackages)

--- a/packages/weapp-style-injector/src/vite/uni-app.ts
+++ b/packages/weapp-style-injector/src/vite/uni-app.ts
@@ -9,8 +9,8 @@ import { createRequire } from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
+import { assignDefined, collectPresetConfigs, createStyleRuleTargets } from '../preset-resolution'
 import { resolveUniAppStyleScopes, splitUniAppStyleScopes } from '../uni-app'
-import { toArray } from '../utils'
 import weappStyleInjector from '../vite'
 
 export type { SubpackageStyleRule, SubpackageStyleRules } from '../subpackage'
@@ -322,51 +322,33 @@ export function StyleInjector(options: ViteUniAppStyleInjectorOptions = {}) {
     ...rest
   } = options
 
-  const configs = new Map<string, UniAppSubPackageConfig>()
   const { subPackages: scopedSubPackages, manual: manualStyleScopes } = splitUniAppStyleScopes(styleScopes)
-
-  for (const entry of [...toArray(subPackages), ...scopedSubPackages]) {
-    configs.set(path.resolve(entry.pagesJsonPath), entry)
-  }
-
-  const candidatePaths = pagesJsonPath
-    ? toArray(pagesJsonPath).map(entry => path.resolve(entry))
-    : resolveDefaultPagesJsonPaths()
-
-  for (const candidate of candidatePaths) {
-    if (!configs.has(candidate) && fs.existsSync(candidate)) {
+  const explicitConfigs = Array.isArray(subPackages)
+    ? subPackages
+    : subPackages
+      ? [subPackages]
+      : []
+  const configs = collectPresetConfigs<UniAppSubPackageConfig>({
+    explicitConfigs: [...explicitConfigs, ...scopedSubPackages],
+    requestedPaths: pagesJsonPath,
+    defaultPaths: resolveDefaultPagesJsonPaths(),
+    getConfigPath: config => config.pagesJsonPath,
+    createDiscoveredConfig: (candidate) => {
       const config: UniAppSubPackageConfig = {
         pagesJsonPath: candidate,
       }
-      if (indexFileName !== undefined) {
-        config.indexFileName = indexFileName
-      }
-      if (sourceFileName !== undefined) {
-        config.sourceFileName = sourceFileName
-      }
-      if (outputName !== undefined) {
-        config.outputName = outputName
-      }
-      if (files !== undefined) {
-        config.files = files
-      }
-      if (include !== undefined) {
-        config.include = include
-      }
-      if (exclude !== undefined) {
-        config.exclude = exclude
-      }
+      assignDefined(config, { indexFileName, sourceFileName, outputName, files, include, exclude })
       if (rules !== undefined) {
         config.rules = rules
       }
       else if (sourceFileName === undefined && indexFileName === undefined) {
-        config.rules = [{ from: { ref: 'app.css' }, to: { files, include, exclude } }]
+        config.rules = [{ from: { ref: 'app.css' }, to: createStyleRuleTargets(files, include, exclude) }]
       }
-      configs.set(candidate, config)
-    }
-  }
+      return config
+    },
+  })
 
-  const entries = configs.size > 0 ? [...configs.values()] : undefined
+  const entries = configs.length > 0 ? configs : undefined
   const manualEntries = manualStyleScopes.length > 0 ? manualStyleScopes : undefined
   const resolvedSubPackages = resolveUniAppStyleScopes(entries, manualEntries)
 

--- a/packages/weapp-style-injector/src/webpack/mpx.ts
+++ b/packages/weapp-style-injector/src/webpack/mpx.ts
@@ -2,10 +2,14 @@ import type { MpxSubPackageConfig } from '../mpx'
 import type { SubpackageStyleRules } from '../subpackage'
 import type { WebpackObjectPluginInstance, WebpackWeappStyleInjectorOptions } from '../webpack'
 
-import fs from 'node:fs'
-import path from 'node:path'
 import { resolveDefaultMpxAppPaths, resolveMpxSubPackages } from '../mpx'
-import { toArray } from '../utils'
+import {
+  assignDefined,
+  collectPresetConfigs,
+  createStyleRuleTargets,
+  createSyncScopeGenerator,
+  loadSubpackageTargetStyle,
+} from '../preset-resolution'
 import { weappStyleInjectorWebpack } from '../webpack'
 
 export type { MpxSubPackageConfig } from '../mpx'
@@ -37,73 +41,35 @@ export function StyleInjector(options: WebpackMpxStyleInjectorOptions = {}): Web
     ...rest
   } = options
 
-  const configs = new Map<string, MpxSubPackageConfig>()
-
-  for (const entry of toArray(subPackages)) {
-    configs.set(path.resolve(entry.appPath), entry)
-  }
-
-  const candidatePaths = appPath
-    ? toArray(appPath).map(entry => path.resolve(entry))
-    : resolveDefaultMpxAppPaths()
-
-  for (const candidate of candidatePaths) {
-    if (!configs.has(candidate) && fs.existsSync(candidate)) {
-      const config: MpxSubPackageConfig = { appPath: candidate }
-      if (sourceRoot !== undefined) {
-        config.sourceRoot = sourceRoot
+  const configs = collectPresetConfigs<MpxSubPackageConfig>({
+    explicitConfigs: subPackages,
+    requestedPaths: appPath,
+    defaultPaths: resolveDefaultMpxAppPaths(),
+    getConfigPath: config => config.appPath,
+    createDiscoveredConfig: (candidate) => {
+      const config: MpxSubPackageConfig = {
+        appPath: candidate,
       }
-      if (sourceFileName !== undefined) {
-        config.sourceFileName = sourceFileName
-      }
-      if (outputName !== undefined) {
-        config.outputName = outputName
-      }
-      if (files !== undefined) {
-        config.files = files
-      }
-      if (include !== undefined) {
-        config.include = include
-      }
-      if (exclude !== undefined) {
-        config.exclude = exclude
-      }
+      assignDefined(config, { sourceRoot, sourceFileName, outputName, files, include, exclude })
       if (rules !== undefined) {
         config.rules = rules
       }
       else if (sourceFileName === undefined) {
-        config.rules = [{ from: { ref: 'app.css' }, to: { files, include, exclude } }]
+        config.rules = [{ from: { ref: 'app.css' }, to: createStyleRuleTargets(files, include, exclude) }]
       }
-      configs.set(candidate, config)
-    }
-  }
+      return config
+    },
+  })
 
-  const resolvedSubPackages = [...configs.values()].flatMap(resolveMpxSubPackages)
+  const resolvedSubPackages = configs.flatMap(resolveMpxSubPackages)
   const injectorOptions: WebpackWeappStyleInjectorOptions = {
     ...rest,
   }
 
   if (resolvedSubPackages.length > 0) {
     injectorOptions.subpackageStyleScopes = resolvedSubPackages
-    injectorOptions.generateSubpackageStyle = (context) => {
-      const scope = resolvedSubPackages.find(entry => entry.root === context.root && entry.sourceAbsolutePath === context.sourcePath)
-      if (!scope) {
-        return undefined
-      }
-      if (scope.generate) {
-        return scope.generate(context)
-      }
-      if (!fs.existsSync(scope.sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.readFileSync(scope.sourceAbsolutePath, 'utf8')
-    }
-    injectorOptions.loadSubpackageTargetStyle = (_fileName, sourceAbsolutePath) => {
-      if (!fs.existsSync(sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.readFileSync(sourceAbsolutePath, 'utf8')
-    }
+    injectorOptions.generateSubpackageStyle = createSyncScopeGenerator(resolvedSubPackages)
+    injectorOptions.loadSubpackageTargetStyle = loadSubpackageTargetStyle
   }
 
   return weappStyleInjectorWebpack(injectorOptions)

--- a/packages/weapp-style-injector/src/webpack/taro.ts
+++ b/packages/weapp-style-injector/src/webpack/taro.ts
@@ -2,11 +2,17 @@ import type { SubpackageStyleRules } from '../subpackage'
 import type { TaroSubPackageConfig } from '../taro'
 import type { WebpackObjectPluginInstance, WebpackWeappStyleInjectorOptions } from '../webpack'
 
-import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
+import {
+  assignDefined,
+  collectPresetConfigs,
+  createStyleRuleTargets,
+  createSyncScopeGenerator,
+  loadSubpackageTargetStyle,
+} from '../preset-resolution'
 import { createTaroSubPackageImportResolver, resolveTaroSubPackages } from '../taro'
-import { mergePerFileResolvers, toArray } from '../utils'
+import { mergePerFileResolvers } from '../utils'
 import { weappStyleInjectorWebpack } from '../webpack'
 
 export type { SubpackageStyleRule, SubpackageStyleRules } from '../subpackage'
@@ -50,45 +56,25 @@ export function StyleInjector(options: WebpackTaroStyleInjectorOptions = {}): We
     ...rest
   } = options
 
-  const configs = new Map<string, TaroSubPackageConfig>()
-
-  for (const entry of toArray(subPackages)) {
-    configs.set(path.resolve(entry.appConfigPath), entry)
-  }
-
-  const candidatePaths = appConfigPath
-    ? toArray(appConfigPath).map(entry => path.resolve(entry))
-    : resolveDefaultAppConfigPaths()
-
-  for (const candidate of candidatePaths) {
-    if (!configs.has(candidate) && fs.existsSync(candidate)) {
-      const config: TaroSubPackageConfig = { appConfigPath: candidate }
-      if (sourceFileName !== undefined) {
-        config.sourceFileName = sourceFileName
+  const entries = collectPresetConfigs<TaroSubPackageConfig>({
+    explicitConfigs: subPackages,
+    requestedPaths: appConfigPath,
+    defaultPaths: resolveDefaultAppConfigPaths(),
+    getConfigPath: config => config.appConfigPath,
+    createDiscoveredConfig: (candidate) => {
+      const config: TaroSubPackageConfig = {
+        appConfigPath: candidate,
       }
-      if (outputName !== undefined) {
-        config.outputName = outputName
-      }
-      if (files !== undefined) {
-        config.files = files
-      }
-      if (include !== undefined) {
-        config.include = include
-      }
-      if (exclude !== undefined) {
-        config.exclude = exclude
-      }
+      assignDefined(config, { sourceFileName, outputName, files, include, exclude })
       if (rules !== undefined) {
         config.rules = rules
       }
       else if (sourceFileName === undefined) {
-        config.rules = [{ from: { ref: 'app.css' }, to: { files, include, exclude } }]
+        config.rules = [{ from: { ref: 'app.css' }, to: createStyleRuleTargets(files, include, exclude) }]
       }
-      configs.set(candidate, config)
-    }
-  }
-
-  const entries = [...configs.values()]
+      return config
+    },
+  })
   const taroResolver = createTaroSubPackageImportResolver(entries)
   const resolvedSubPackages = entries.flatMap(resolveTaroSubPackages)
 
@@ -104,25 +90,8 @@ export function StyleInjector(options: WebpackTaroStyleInjectorOptions = {}): We
   }
   if (resolvedSubPackages.length > 0) {
     injectorOptions.subpackageStyleScopes = resolvedSubPackages
-    injectorOptions.generateSubpackageStyle = (context) => {
-      const scope = resolvedSubPackages.find(entry => entry.root === context.root && entry.sourceAbsolutePath === context.sourcePath)
-      if (!scope) {
-        return undefined
-      }
-      if (scope.generate) {
-        return scope.generate(context)
-      }
-      if (!fs.existsSync(scope.sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.readFileSync(scope.sourceAbsolutePath, 'utf8')
-    }
-    injectorOptions.loadSubpackageTargetStyle = (_fileName, sourceAbsolutePath) => {
-      if (!fs.existsSync(sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.readFileSync(sourceAbsolutePath, 'utf8')
-    }
+    injectorOptions.generateSubpackageStyle = createSyncScopeGenerator(resolvedSubPackages)
+    injectorOptions.loadSubpackageTargetStyle = loadSubpackageTargetStyle
   }
 
   return weappStyleInjectorWebpack(injectorOptions)

--- a/packages/weapp-style-injector/src/webpack/uni-app.ts
+++ b/packages/weapp-style-injector/src/webpack/uni-app.ts
@@ -2,11 +2,16 @@ import type { SubpackageStyleRules } from '../subpackage'
 import type { UniAppStyleScopeInput, UniAppSubPackageConfig } from '../uni-app'
 import type { WebpackObjectPluginInstance, WebpackWeappStyleInjectorOptions } from '../webpack'
 
-import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
+import {
+  assignDefined,
+  collectPresetConfigs,
+  createStyleRuleTargets,
+  createSyncScopeGenerator,
+  loadSubpackageTargetStyle,
+} from '../preset-resolution'
 import { resolveUniAppStyleScopes, splitUniAppStyleScopes } from '../uni-app'
-import { toArray } from '../utils'
 import { weappStyleInjectorWebpack } from '../webpack'
 
 export type { SubpackageStyleRule, SubpackageStyleRules } from '../subpackage'
@@ -48,51 +53,28 @@ export function StyleInjector(options: WebpackUniAppStyleInjectorOptions = {}): 
     ...rest
   } = options
 
-  const configs = new Map<string, UniAppSubPackageConfig>()
   const { subPackages: scopedSubPackages, manual: manualStyleScopes } = splitUniAppStyleScopes(styleScopes)
-
-  for (const entry of [...toArray(subPackages), ...scopedSubPackages]) {
-    configs.set(path.resolve(entry.pagesJsonPath), entry)
-  }
-
-  const candidatePaths = pagesJsonPath
-    ? toArray(pagesJsonPath).map(entry => path.resolve(entry))
-    : resolveDefaultPagesJsonPaths()
-
-  for (const candidate of candidatePaths) {
-    if (!configs.has(candidate) && fs.existsSync(candidate)) {
+  const configs = collectPresetConfigs<UniAppSubPackageConfig>({
+    explicitConfigs: [...(Array.isArray(subPackages) ? subPackages : subPackages ? [subPackages] : []), ...scopedSubPackages],
+    requestedPaths: pagesJsonPath,
+    defaultPaths: resolveDefaultPagesJsonPaths(),
+    getConfigPath: config => config.pagesJsonPath,
+    createDiscoveredConfig: (candidate) => {
       const config: UniAppSubPackageConfig = {
         pagesJsonPath: candidate,
       }
-      if (indexFileName !== undefined) {
-        config.indexFileName = indexFileName
-      }
-      if (sourceFileName !== undefined) {
-        config.sourceFileName = sourceFileName
-      }
-      if (outputName !== undefined) {
-        config.outputName = outputName
-      }
-      if (files !== undefined) {
-        config.files = files
-      }
-      if (include !== undefined) {
-        config.include = include
-      }
-      if (exclude !== undefined) {
-        config.exclude = exclude
-      }
+      assignDefined(config, { indexFileName, sourceFileName, outputName, files, include, exclude })
       if (rules !== undefined) {
         config.rules = rules
       }
       else if (sourceFileName === undefined && indexFileName === undefined) {
-        config.rules = [{ from: { ref: 'app.css' }, to: { files, include, exclude } }]
+        config.rules = [{ from: { ref: 'app.css' }, to: createStyleRuleTargets(files, include, exclude) }]
       }
-      configs.set(candidate, config)
-    }
-  }
+      return config
+    },
+  })
 
-  const entries = configs.size > 0 ? [...configs.values()] : undefined
+  const entries = configs.length > 0 ? configs : undefined
   const manualEntries = manualStyleScopes.length > 0 ? manualStyleScopes : undefined
   const resolvedSubPackages = resolveUniAppStyleScopes(entries, manualEntries)
 
@@ -107,25 +89,8 @@ export function StyleInjector(options: WebpackUniAppStyleInjectorOptions = {}): 
   }
   if (resolvedSubPackages.length > 0) {
     injectorOptions.subpackageStyleScopes = resolvedSubPackages
-    injectorOptions.generateSubpackageStyle = (context) => {
-      const scope = resolvedSubPackages.find(entry => entry.root === context.root && entry.sourceAbsolutePath === context.sourcePath)
-      if (!scope) {
-        return undefined
-      }
-      if (scope.generate) {
-        return scope.generate(context)
-      }
-      if (!fs.existsSync(scope.sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.readFileSync(scope.sourceAbsolutePath, 'utf8')
-    }
-    injectorOptions.loadSubpackageTargetStyle = (_fileName, sourceAbsolutePath) => {
-      if (!fs.existsSync(sourceAbsolutePath)) {
-        return undefined
-      }
-      return fs.readFileSync(sourceAbsolutePath, 'utf8')
-    }
+    injectorOptions.generateSubpackageStyle = createSyncScopeGenerator(resolvedSubPackages)
+    injectorOptions.loadSubpackageTargetStyle = loadSubpackageTargetStyle
   }
 
   return weappStyleInjectorWebpack(injectorOptions)

--- a/packages/weapp-style-injector/test/shared-resolution.test.ts
+++ b/packages/weapp-style-injector/test/shared-resolution.test.ts
@@ -1,0 +1,133 @@
+import type { ResolvedSubpackageStyleScope } from '@/subpackage'
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { resolveMpxSubPackages } from '@/mpx'
+import {
+  collectPresetConfigs,
+  createAsyncScopeGenerator,
+  createSyncScopeGenerator,
+} from '@/preset-resolution'
+import { resolveTaroSubPackages } from '@/taro'
+import { resolveUniAppStyleScopes } from '@/uni-app'
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'weapp-style-injector-shared-'))
+}
+
+function createScope(sourceAbsolutePath: string): ResolvedSubpackageStyleScope {
+  return {
+    root: 'pkg/nested',
+    sourceRelativePath: 'pkg/nested/index.css',
+    sourceAbsolutePath,
+    outputName: 'index',
+    preprocess: false,
+    framework: 'test',
+  }
+}
+
+describe('shared sub-package resolution', () => {
+  it.each([
+    {
+      framework: 'uni-app',
+      resolve(tempDir: string) {
+        const pagesJsonPath = path.join(tempDir, 'pages.json')
+        fs.writeFileSync(pagesJsonPath, JSON.stringify({
+          subPackages: [{ root: '.\\pkg\\nested', pages: [{ path: '.\\pages\\home' }] }],
+        }))
+        return resolveUniAppStyleScopes({ pagesJsonPath, sourceFileName: 'index.css' }, undefined)
+      },
+    },
+    {
+      framework: 'taro',
+      resolve(tempDir: string) {
+        const appConfigPath = path.join(tempDir, 'app.config.json')
+        fs.writeFileSync(appConfigPath, JSON.stringify({
+          subPackages: [{ root: '.\\pkg\\nested', pages: [{ path: '.\\pages\\home' }] }],
+        }))
+        return resolveTaroSubPackages({ appConfigPath, sourceFileName: 'index.css' })
+      },
+    },
+    {
+      framework: 'mpx',
+      resolve(tempDir: string) {
+        const appPath = path.join(tempDir, 'app.json')
+        fs.writeFileSync(appPath, JSON.stringify({
+          subPackages: [{ root: '.\\pkg\\nested', pages: [{ path: '.\\pages\\home' }] }],
+        }))
+        return resolveMpxSubPackages({ appPath, sourceFileName: 'index.css' })
+      },
+    },
+  ])('normalizes relative and backslash paths for $framework', ({ framework, resolve }) => {
+    const tempDir = createTempDir()
+    const scopeRoot = path.join(tempDir, 'pkg/nested')
+    fs.mkdirSync(path.join(scopeRoot, 'pages'), { recursive: true })
+    fs.writeFileSync(path.join(scopeRoot, 'index.css'), '.scope {}')
+    fs.writeFileSync(path.join(scopeRoot, 'pages/home.css'), '.home {}')
+
+    const [scope] = resolve(tempDir)
+    expect(scope).toMatchObject({
+      root: 'pkg/nested',
+      sourceRelativePath: 'pkg/nested/index.css',
+      framework,
+      targetFiles: ['pkg/nested/pages/home'],
+      targetSourceFiles: [{
+        fileName: 'pkg/nested/pages/home.css',
+        sourceAbsolutePath: path.join(scopeRoot, 'pages/home.css'),
+      }],
+    })
+  })
+})
+
+describe('shared preset resolution', () => {
+  it('keeps explicit configs ahead of discovered defaults and deduplicates paths', () => {
+    const tempDir = createTempDir()
+    const explicitPath = path.join(tempDir, 'explicit.json')
+    const discoveredPath = path.join(tempDir, 'discovered.json')
+    fs.writeFileSync(explicitPath, '{}')
+    fs.writeFileSync(discoveredPath, '{}')
+
+    const explicit = { filePath: explicitPath, marker: 'explicit' }
+    const configs = collectPresetConfigs({
+      explicitConfigs: explicit,
+      requestedPaths: [explicitPath, discoveredPath],
+      defaultPaths: [],
+      getConfigPath: config => config.filePath,
+      createDiscoveredConfig: filePath => ({ filePath, marker: 'discovered' }),
+    })
+
+    expect(configs).toEqual([
+      explicit,
+      { filePath: discoveredPath, marker: 'discovered' },
+    ])
+  })
+
+  it('keeps sync and async scope generation behavior aligned', async () => {
+    const tempDir = createTempDir()
+    const sourcePath = path.join(tempDir, 'index.css')
+    fs.writeFileSync(sourcePath, '.scope {}')
+    const context = {
+      root: 'pkg/nested',
+      sourcePath,
+      outputFileName: 'pkg/nested/index.wxss',
+      styleExt: '.wxss',
+      framework: 'test',
+      bundler: 'test',
+      sourceFiles: [],
+      pageStyleFiles: [],
+    }
+
+    expect(createSyncScopeGenerator([createScope(sourcePath)])(context)).toBe('.scope {}')
+    await expect(createAsyncScopeGenerator([createScope(sourcePath)])(context)).resolves.toBe('.scope {}')
+
+    const generatedScope = createScope(sourcePath)
+    generatedScope.generate = () => '.generated {}'
+    expect(createSyncScopeGenerator([generatedScope])(context)).toBe('.generated {}')
+    await expect(createAsyncScopeGenerator([generatedScope])(context)).resolves.toBe('.generated {}')
+
+    fs.unlinkSync(sourcePath)
+    expect(createSyncScopeGenerator([createScope(sourcePath)])(context)).toBeUndefined()
+    await expect(createAsyncScopeGenerator([createScope(sourcePath)])(context)).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## 重构范围

- 新增内部 `subpackage-resolution`，统一 uni-app、Taro、MPX 的页面路径标准化、目标样式与源码模块发现、app style reference 判断、公共选项复制和 scope 构造。
- 新增内部 `preset-resolution`，统一显式配置与默认配置发现、路径去重、规则目标构造，以及 Vite/Webpack 的异步/同步 scope 读取。
- 保留 uni-app Vite preprocess/pluginContainer、Taro source transform 和 Webpack compilation 生命周期差异。
- `package.json` exports、根入口、公开类型和函数签名均未改变。

## 去重结果

使用相同 jscpd 参数统计生产源码：

- 重构前：774 个重复行，20.17%
- 重构后：256 个重复行，7.41%
- 共减少 518 个重复行，达到低于 12% 的目标

## 本地验证

- `pnpm --filter weapp-style-injector test`：93 tests passed
- `pnpm --filter weapp-style-injector build`：通过
- `pnpm --dir packages/weapp-tailwindcss exec vitest run test/style-injector.unit.test.ts test/bundlers/style-injector-integration.unit.test.ts test/bundlers/webpack-style-injector-integration.unit.test.ts`：10 tests passed
- `pnpm exec eslint packages/weapp-style-injector/src --max-warnings=0`：通过
- `git diff --check`：通过
- 八个既有 package exports 的 ESM、CJS 与类型声明 smoke test：通过

计划中的 test 目录 ESLint 命令无法作为有效 gate：根 ESLint 配置会忽略 `packages/weapp-style-injector/test`；新增测试已由 Vitest 覆盖。严格 `tsc --noEmit` 仅剩未改动的 `src/subpackage.ts` 与 `test/index.test.ts` 中既有诊断，本包正式构建使用 `noCheck` 且已通过。

本次为无用户可见行为和 API 变化的内部重构，因此不添加 changeset，也不联动 `create-weapp-vite`。