### PR TITLE
fix(ci): confirm flaky performance budget failures

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
     name: Benchmark shard (${{ matrix.case_name }})
     needs: benchmark-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ github.event_name == 'pull_request' && 20 || 45 }}
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 45 }}
     strategy:
       fail-fast: false
       max-parallel: 6

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -808,6 +808,8 @@ jobs:
           E2E_WATCH_MAX_MEMORY_HEAP_USED_MB: ${{ matrix.watch_max_memory_heap_used_mb || '4096' }}
           E2E_WATCH_COMMAND_TIMEOUT_MS: ${{ matrix.watch_command_timeout_ms }}
           E2E_WATCH_MAX_ATTEMPTS: ${{ matrix.watch_max_attempts || '2' }}
+          # GitHub-hosted runner 的单次性能尖峰需要在全新 watch session 中复现，语义错误与超时仍立即失败。
+          E2E_WATCH_CONFIRM_PERFORMANCE_BUDGET: '1'
           E2E_WATCH_ROUND_PROFILE: ${{ matrix.round_profile }}
           E2E_WATCH_WEB_ONLY: ${{ matrix.watch_web_only || '0' }}
           E2E_WATCH_MINI_PROGRAM_ONLY: ${{ matrix.watch_mini_program_only || '0' }}

--- a/benchmark/version-compare/scripts/ci-report.mjs
+++ b/benchmark/version-compare/scripts/ci-report.mjs
@@ -133,6 +133,74 @@ function normalizePackageSpec(value) {
   return `weapp-tailwindcss@${value}`
 }
 
+const hmrMemoryMetrics = new Set(['hmrPeakRssMb', 'hmrSteadyRssMb'])
+
+function violationId(violation) {
+  return `${violation.key}::${violation.metric}`
+}
+
+export function requiresHmrMemoryConfirmation(guard) {
+  return guard.violations.length > 0
+    && guard.violations.every(violation => hmrMemoryMetrics.has(violation.metric))
+}
+
+export function confirmHmrMemoryViolations(primaryGuard, confirmationGuard) {
+  const confirmationById = new Map(
+    confirmationGuard.violations
+      .filter(violation => hmrMemoryMetrics.has(violation.metric))
+      .map(violation => [violationId(violation), violation]),
+  )
+  const observations = [...(primaryGuard.observations ?? [])]
+  const violations = primaryGuard.violations.flatMap((violation) => {
+    if (!hmrMemoryMetrics.has(violation.metric)) {
+      return [violation]
+    }
+    const confirmation = confirmationById.get(violationId(violation))
+    if (!confirmation) {
+      observations.push({
+        ...violation,
+        message: `首次检测到 HMR RSS 回归，反向顺序独立复测未复现（${fmtMs(violation.baseline)} -> ${fmtMs(violation.current)} MB）`,
+      })
+      return []
+    }
+    return [{
+      ...violation,
+      message: `HMR RSS 回归经反向顺序独立复测确认：首次 ${fmtMs(violation.baseline)} -> ${fmtMs(violation.current)} MB；复测 ${fmtMs(confirmation.baseline)} -> ${fmtMs(confirmation.current)} MB`,
+      confirmation: {
+        baseline: confirmation.baseline,
+        current: confirmation.current,
+        deltaPercent: confirmation.deltaPercent,
+        absoluteDelta: confirmation.absoluteDelta,
+      },
+    }]
+  })
+
+  return {
+    ...primaryGuard,
+    passed: violations.length === 0,
+    violations,
+    observations,
+    memoryConfirmation: {
+      order: 'current->baseline',
+      confirmedViolations: violations.filter(violation => hmrMemoryMetrics.has(violation.metric)).length,
+    },
+  }
+}
+
+export function markHmrMemoryConfirmationUnavailable(primaryGuard, reason) {
+  return {
+    ...primaryGuard,
+    violations: primaryGuard.violations.map(violation => ({
+      ...violation,
+      message: `HMR RSS 首次检测已超限，但反向顺序独立复测不可用：${reason}`,
+    })),
+    memoryConfirmation: {
+      order: 'current->baseline',
+      error: reason,
+    },
+  }
+}
+
 export function buildSummary(raw, baselineLabel, currentLabel) {
   const rows = raw.rows ?? []
   const byKey = new Map(rows.map(row => [`${row.version}::${row.key}`, row]))
@@ -586,7 +654,12 @@ export function toMarkdown(summary, baselineSpec) {
         `- 中位数回归置信上限：p <= ${guard.thresholds.maximumMedianRegressionPValue}`,
         '- 中位数回归需严格多数样本同步越界，并通过单侧分布置信检验',
         '- 端到端 HMR 回归需插件处理阶段同步越界确认',
-        '- HMR 内存回归需 peak 与 steady 两项同步越界确认',
+        '- HMR 内存回归需 peak 与 steady 两项同步越界，并通过反向顺序独立复测确认',
+        ...(guard.memoryConfirmation
+          ? [guard.memoryConfirmation.error
+              ? `- HMR 内存独立复测：${guard.memoryConfirmation.order}，不可用：${guard.memoryConfirmation.error}`
+              : `- HMR 内存独立复测：${guard.memoryConfirmation.order}，确认 ${guard.memoryConfirmation.confirmedViolations} 项`]
+          : []),
         `- 违规项：${guard.violations.length}`,
         ...guard.violations.map(item => `- ${item.key} / ${item.metric}: ${item.message ?? `${fmtMs(item.baseline)} -> ${fmtMs(item.current)} (${fmtPct(item.deltaPercent)})`}`),
         `- 观察项：${guard.observations?.length ?? 0}`,

--- a/benchmark/version-compare/scripts/run-ci.mjs
+++ b/benchmark/version-compare/scripts/run-ci.mjs
@@ -5,7 +5,15 @@ import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { classifyPerformanceChanges, performanceRelevantPaths, summarizeFiles } from './change-relevance.mjs'
-import { asInformationalPerformanceGuard, buildSummary, evaluatePerformanceGuard, toMarkdown } from './ci-report.mjs'
+import {
+  asInformationalPerformanceGuard,
+  buildSummary,
+  confirmHmrMemoryViolations,
+  evaluatePerformanceGuard,
+  markHmrMemoryConfirmationUnavailable,
+  requiresHmrMemoryConfirmation,
+  toMarkdown,
+} from './ci-report.mjs'
 import { benchmarkProjectDirs } from './projects.mjs'
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -470,25 +478,28 @@ async function main() {
     { version: currentLabel, root: currentRoot },
   ], null, 2), 'utf8')
 
-  const matrixArgs = [
-    path.join(repoRoot, 'benchmark/version-compare/scripts/run-matrix.mjs'),
-    '--versions-file',
-    versionsPath,
-    '--build-runs',
-    String(buildRuns),
-    '--hmr-runs',
-    String(hmrRuns),
-    '--timeout',
-    String(timeoutMs),
-    '--poll-interval',
-    String(pollIntervalMs),
-    '--out',
-    rawPath,
-  ]
-  if (only) {
-    matrixArgs.push('--only', only)
+  const runMatrix = async ({ versionsFile, outputFile, matrixBuildRuns }) => {
+    const matrixArgs = [
+      path.join(repoRoot, 'benchmark/version-compare/scripts/run-matrix.mjs'),
+      '--versions-file',
+      versionsFile,
+      '--build-runs',
+      String(matrixBuildRuns),
+      '--hmr-runs',
+      String(hmrRuns),
+      '--timeout',
+      String(timeoutMs),
+      '--poll-interval',
+      String(pollIntervalMs),
+      '--out',
+      outputFile,
+    ]
+    if (only) {
+      matrixArgs.push('--only', only)
+    }
+    await run(repoRoot, process.execPath, matrixArgs)
   }
-  await run(repoRoot, process.execPath, matrixArgs)
+  await runMatrix({ versionsFile: versionsPath, outputFile: rawPath, matrixBuildRuns: buildRuns })
 
   const raw = JSON.parse(await fs.readFile(rawPath, 'utf8'))
   const performanceChanges = baselineRef
@@ -532,9 +543,46 @@ async function main() {
   }
   const summary = buildSummary(raw, baselineLabel, currentLabel)
   if (baselineRef) {
-    const performanceGuard = evaluatePerformanceGuard(summary, {
+    let performanceGuard = evaluatePerformanceGuard(summary, {
       regressionPercent: parseNumber('--regression-percent', 5),
     })
+    if (
+      performanceRelevantChanges
+      && requiresHmrMemoryConfirmation(performanceGuard)
+      && !process.argv.includes('--skip-memory-confirmation')
+    ) {
+      const confirmationVersionsPath = path.join(resultDir, 'memory-confirmation-versions.json')
+      const confirmationRawPath = path.join(resultDir, 'memory-confirmation-raw.json')
+      const confirmationSummaryPath = path.join(resultDir, 'memory-confirmation-summary.json')
+      await fs.writeFile(confirmationVersionsPath, JSON.stringify([
+        { version: currentLabel, root: currentRoot },
+        { version: baselineLabel, root: baselineRoot },
+      ], null, 2), 'utf8')
+      process.stdout.write('[benchmark] confirming HMR memory regression with reversed current->baseline order\n')
+      await runMatrix({
+        versionsFile: confirmationVersionsPath,
+        outputFile: confirmationRawPath,
+        matrixBuildRuns: 0,
+      })
+      const confirmationRaw = JSON.parse(await fs.readFile(confirmationRawPath, 'utf8'))
+      const confirmationSummary = buildSummary(confirmationRaw, baselineLabel, currentLabel)
+      const confirmationGuard = evaluatePerformanceGuard(confirmationSummary, {
+        regressionPercent: parseNumber('--regression-percent', 5),
+      })
+      await fs.writeFile(confirmationSummaryPath, `${JSON.stringify(confirmationSummary, null, 2)}\n`, 'utf8')
+      const confirmationError = confirmationSummary.errors.length > 0
+        ? `matrix has ${confirmationSummary.errors.length} failed row(s)`
+        : confirmationGuard.violations.some(violation => violation.metric === 'hmrMemorySamples')
+          ? 'matrix has incomplete RSS samples'
+          : undefined
+      if (confirmationError) {
+        performanceGuard = markHmrMemoryConfirmationUnavailable(performanceGuard, confirmationError)
+      }
+      else {
+        performanceGuard = confirmHmrMemoryViolations(performanceGuard, confirmationGuard)
+      }
+      process.stdout.write(`[benchmark] HMR memory confirmation -> ${confirmationSummaryPath}\n`)
+    }
     const relevantFiles = summarizeFiles(performanceChanges.relevantFiles)
     const ignoredFiles = summarizeFiles(performanceChanges.ignoredReleaseMetadataFiles)
     const informationalReason = ignoredFiles

--- a/e2e/watch/hot-update/performance-confirmation.ts
+++ b/e2e/watch/hot-update/performance-confirmation.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const PERFORMANCE_BUDGET_RE = /^(?:Error:\s*)?\[([^\]]+)\] (.+?) (hot update|weapp-tailwindcss processing|memory RSS peak|memory RSS delta|heap used) exceeded budget:/m
+const FAILURE_LOG_SUFFIX = '-watch-hmr-runner-failure.log'
+
+export interface PerformanceBudgetFailure {
+  key: string
+  label: string
+}
+
+export type PerformanceBudgetConfirmationDecision
+  = | { action: 'none' }
+    | { action: 'retry', failure: PerformanceBudgetFailure }
+    | { action: 'confirmed', failure: PerformanceBudgetFailure }
+    | { action: 'inconclusive', expected: PerformanceBudgetFailure, actual?: PerformanceBudgetFailure }
+
+export function parsePerformanceBudgetFailure(message: string): PerformanceBudgetFailure | undefined {
+  const matched = message.match(PERFORMANCE_BUDGET_RE)
+  if (!matched) {
+    return undefined
+  }
+
+  const [, project, sample, budget] = matched
+  const label = `${project}: ${sample} ${budget}`
+  return {
+    key: `${project}\0${sample}\0${budget}`,
+    label,
+  }
+}
+
+export function resolvePerformanceBudgetConfirmation(
+  enabled: boolean,
+  expected: PerformanceBudgetFailure | undefined,
+  actual: PerformanceBudgetFailure | undefined,
+): PerformanceBudgetConfirmationDecision {
+  if (!expected) {
+    return enabled && actual
+      ? { action: 'retry', failure: actual }
+      : { action: 'none' }
+  }
+
+  if (actual?.key === expected.key) {
+    return { action: 'confirmed', failure: actual }
+  }
+
+  return { action: 'inconclusive', expected, actual }
+}
+
+export async function listWatchHmrFailureLogs(cwd: string) {
+  const failuresDir = path.resolve(cwd, 'benchmark/e2e-watch-hmr/failures')
+  const entries = await fs.readdir(failuresDir, { withFileTypes: true }).catch(() => [])
+  return new Set(entries
+    .filter(entry => entry.isFile() && entry.name.endsWith(FAILURE_LOG_SUFFIX))
+    .map(entry => entry.name))
+}
+
+export async function readNewPerformanceBudgetFailure(cwd: string, previousLogs: Set<string>) {
+  const failuresDir = path.resolve(cwd, 'benchmark/e2e-watch-hmr/failures')
+  const currentLogs = await listWatchHmrFailureLogs(cwd)
+  const newLogs = [...currentLogs].filter(file => !previousLogs.has(file)).sort().reverse()
+
+  for (const file of newLogs) {
+    const content = await fs.readFile(path.join(failuresDir, file), 'utf8').catch(() => '')
+    const failure = parsePerformanceBudgetFailure(content)
+    if (failure) {
+      return failure
+    }
+  }
+
+  return undefined
+}

--- a/e2e/watch/hot-update/shared.ts
+++ b/e2e/watch/hot-update/shared.ts
@@ -1,4 +1,5 @@
 import type { ConcreteOrPlatformWatchCaseName, WatchCaseArtifacts } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
+import type { PerformanceBudgetFailure } from './performance-confirmation'
 import fs from 'node:fs/promises'
 import process from 'node:process'
 import { execa } from 'execa'
@@ -7,6 +8,11 @@ import { expect } from 'vitest'
 import { buildCases, demoWatchShardCases, getBaseWatchCaseName, isDemoWatchShardName, isLocalOnlyWatchCase } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases'
 import { DEFAULT_PLUGIN_PROCESS_BUDGET_MS } from '../../../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/types'
 import { assertDevHmrArtifactSnapshotGate } from '../../watchArtifactSnapshotGate'
+import {
+  listWatchHmrFailureLogs,
+  readNewPerformanceBudgetFailure,
+  resolvePerformanceBudgetConfirmation,
+} from './performance-confirmation'
 
 export type WatchProjectGroup = 'demo'
 export type DemoWatchShardName
@@ -611,8 +617,10 @@ export function shouldRunGroupedTarget(caseName: WatchCaseName, target: WatchPro
 
 async function runWatchHmrCommand(cwd: string, args: string[], commandTimeoutMs: number) {
   const maxAttempts = Math.max(1, toNumberEnv('E2E_WATCH_MAX_ATTEMPTS', 2))
+  const confirmPerformanceBudget = toBoolEnv('E2E_WATCH_CONFIRM_PERFORMANCE_BUDGET', false)
   const heartbeatIntervalMs = Math.max(30_000, toNumberEnv('E2E_WATCH_HEARTBEAT_INTERVAL_MS', 60_000))
   const env = { ...process.env }
+  let performanceBudgetConfirmation: PerformanceBudgetFailure | undefined
 
   for (const key of Object.keys(env)) {
     if (key === 'VITEST' || key.startsWith('VITEST_')) {
@@ -626,11 +634,17 @@ async function runWatchHmrCommand(cwd: string, args: string[], commandTimeoutMs:
     delete env.BABEL_ENV
   }
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  for (let attempt = 1; attempt <= maxAttempts + 1; attempt += 1) {
+    const failureLogsBeforeAttempt = confirmPerformanceBudget
+      ? await listWatchHmrFailureLogs(cwd)
+      : new Set<string>()
     const attemptStartedAt = Date.now()
     const heartbeat = setInterval(() => {
       const elapsedSeconds = Math.round((Date.now() - attemptStartedAt) / 1000)
-      process.stdout.write(`[e2e-watch] watch-hmr attempt ${attempt}/${maxAttempts} still running (${elapsedSeconds}s elapsed)\n`)
+      const attemptLabel = performanceBudgetConfirmation
+        ? 'performance budget confirmation'
+        : `attempt ${attempt}/${maxAttempts}`
+      process.stdout.write(`[e2e-watch] watch-hmr ${attemptLabel} still running (${elapsedSeconds}s elapsed)\n`)
     }, heartbeatIntervalMs)
 
     try {
@@ -643,6 +657,11 @@ async function runWatchHmrCommand(cwd: string, args: string[], commandTimeoutMs:
         killSignal: 'SIGKILL',
         forceKillAfterDelay: 1000,
       })
+      if (performanceBudgetConfirmation) {
+        process.stdout.write(
+          `[e2e-watch] performance budget observation was not reproduced: ${performanceBudgetConfirmation.label}\n`,
+        )
+      }
       return
     }
     catch (error) {
@@ -650,6 +669,34 @@ async function runWatchHmrCommand(cwd: string, args: string[], commandTimeoutMs:
       // 命令级超时通常意味着预算不足，直接重试只会重复消耗整段 CI 时间。
       if (timedOut) {
         throw error
+      }
+
+      const currentPerformanceFailure = confirmPerformanceBudget
+        ? await readNewPerformanceBudgetFailure(cwd, failureLogsBeforeAttempt)
+        : undefined
+      const confirmation = resolvePerformanceBudgetConfirmation(
+        confirmPerformanceBudget,
+        performanceBudgetConfirmation,
+        currentPerformanceFailure,
+      )
+
+      if (confirmation.action === 'retry') {
+        performanceBudgetConfirmation = confirmation.failure
+        process.stdout.write(
+          `[e2e-watch] performance budget exceeded once; confirming with a fresh watch session: ${confirmation.failure.label}\n`,
+        )
+        continue
+      }
+      if (confirmation.action === 'confirmed') {
+        process.stdout.write(`[e2e-watch] performance budget regression confirmed: ${confirmation.failure.label}\n`)
+        throw error
+      }
+      if (confirmation.action === 'inconclusive') {
+        const actual = confirmation.actual?.label ?? 'non-performance failure'
+        throw new Error(
+          `performance budget confirmation was inconclusive: expected ${confirmation.expected.label}, received ${actual}`,
+          { cause: error },
+        )
       }
       if (attempt >= maxAttempts) {
         throw error

--- a/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
@@ -716,6 +716,114 @@ describe('benchmark ci report', () => {
     expect(evaluatePerformanceGuard(summary).passed).toBe(true)
   })
 
+  it('requires an independent reversed-order run to confirm HMR RSS regressions', async () => {
+    const {
+      confirmHmrMemoryViolations,
+      markHmrMemoryConfirmationUnavailable,
+      requiresHmrMemoryConfirmation,
+      toMarkdown,
+    } = await import('../../../../benchmark/version-compare/scripts/ci-report.mjs')
+    const primaryGuard = {
+      passed: false,
+      thresholds: { regressionPercent: 5 },
+      violations: [
+        { key: 'taro-webpack', metric: 'hmrPeakRssMb', baseline: 1900, current: 2150, deltaPercent: 13.16, absoluteDelta: 250 },
+        { key: 'taro-webpack', metric: 'hmrSteadyRssMb', baseline: 1850, current: 2080, deltaPercent: 12.43, absoluteDelta: 230 },
+      ],
+    }
+
+    expect(requiresHmrMemoryConfirmation(primaryGuard)).toBe(true)
+    expect(requiresHmrMemoryConfirmation({
+      ...primaryGuard,
+      violations: [...primaryGuard.violations, { key: 'taro-webpack', metric: 'hmrP95' }],
+    })).toBe(false)
+
+    const unconfirmed = confirmHmrMemoryViolations(primaryGuard, {
+      passed: true,
+      thresholds: { regressionPercent: 5 },
+      violations: [],
+    })
+    expect(unconfirmed).toMatchObject({
+      passed: true,
+      violations: [],
+      memoryConfirmation: {
+        order: 'current->baseline',
+        confirmedViolations: 0,
+      },
+    })
+    expect(unconfirmed.observations).toHaveLength(2)
+    expect(unconfirmed.observations[0].message).toContain('反向顺序独立复测未复现')
+
+    const confirmed = confirmHmrMemoryViolations(primaryGuard, {
+      passed: false,
+      thresholds: { regressionPercent: 5 },
+      violations: [
+        { key: 'taro-webpack', metric: 'hmrPeakRssMb', baseline: 1920, current: 2160, deltaPercent: 12.5, absoluteDelta: 240 },
+        { key: 'taro-webpack', metric: 'hmrSteadyRssMb', baseline: 1860, current: 2090, deltaPercent: 12.37, absoluteDelta: 230 },
+      ],
+    })
+    expect(confirmed.passed).toBe(false)
+    expect(confirmed.violations).toEqual([
+      expect.objectContaining({
+        metric: 'hmrPeakRssMb',
+        message: expect.stringContaining('复测 1920.00 -> 2160.00 MB'),
+        confirmation: expect.objectContaining({ baseline: 1920, current: 2160 }),
+      }),
+      expect.objectContaining({
+        metric: 'hmrSteadyRssMb',
+        confirmation: expect.objectContaining({ baseline: 1860, current: 2090 }),
+      }),
+    ])
+
+    const unavailable = markHmrMemoryConfirmationUnavailable(primaryGuard, 'matrix has incomplete RSS samples')
+    expect(unavailable).toMatchObject({
+      passed: false,
+      memoryConfirmation: {
+        order: 'current->baseline',
+        error: 'matrix has incomplete RSS samples',
+      },
+    })
+    expect(unavailable.violations[0].message).toContain('独立复测不可用')
+
+    const markdown = toMarkdown({
+      generatedAt: '2026-08-03T00:00:00.000Z',
+      options: { buildRuns: 3, hmrRuns: 6, timeoutMs: 180000 },
+      baseline: 'base:main',
+      current: 'current:feature',
+      compares: [],
+      errors: [],
+      baselineErrors: [],
+      currentErrors: [],
+      currentOnlyErrors: [],
+      sharedErrors: [],
+      averages: {
+        buildDeltaPct: undefined,
+        hmrDeltaPct: undefined,
+        buildCompareCount: 0,
+        watchHmrCompareCount: 0,
+        buildPluginDeltaPct: undefined,
+        hmrPluginDeltaPct: undefined,
+        buildPluginCompareCount: 0,
+        watchHmrPluginCompareCount: 0,
+      },
+      performanceGuard: unconfirmed,
+    }, 'main')
+    expect(markdown).toContain('HMR 内存独立复测：current->baseline，确认 0 项')
+  })
+
+  it('runs HMR memory confirmation without builds and reverses version order', async () => {
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const source = fs.readFileSync(path.resolve(__dirname, '../../../../benchmark/version-compare/scripts/run-ci.mjs'), 'utf8')
+
+    expect(source).toContain("{ version: currentLabel, root: currentRoot }")
+    expect(source).toContain("{ version: baselineLabel, root: baselineRoot }")
+    expect(source).toContain('matrixBuildRuns: 0')
+    expect(source).toContain('memory-confirmation-raw.json')
+    expect(source).toContain("violation.metric === 'hmrMemorySamples'")
+    expect(source).toContain('markHmrMemoryConfirmationUnavailable')
+  })
+
   it('ignores sub-10ms timing drift while retaining the percentage guard for larger regressions', async () => {
     const { buildSummary, evaluatePerformanceGuard } = await import('../../../../benchmark/version-compare/scripts/ci-report.mjs')
     const baselineLabel = 'base:main'

--- a/packages/weapp-tailwindcss/test/ci/watch-performance-confirmation.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/watch-performance-confirmation.test.ts
@@ -1,0 +1,47 @@
+import {
+  parsePerformanceBudgetFailure,
+  resolvePerformanceBudgetConfirmation,
+} from '../../../../e2e/watch/hot-update/performance-confirmation'
+
+describe('watch performance budget confirmation', () => {
+  const pluginFailure = parsePerformanceBudgetFailure(
+    'Error: [demo/taro-vite-react-tailwindcss-v4] template:added-class:hot-update weapp-tailwindcss processing exceeded budget: 11488ms > 10000ms',
+  )
+
+  it('parses supported performance budget failures', () => {
+    expect(pluginFailure).toEqual({
+      key: 'demo/taro-vite-react-tailwindcss-v4\0template:added-class:hot-update\0weapp-tailwindcss processing',
+      label: 'demo/taro-vite-react-tailwindcss-v4: template:added-class:hot-update weapp-tailwindcss processing',
+    })
+    expect(parsePerformanceBudgetFailure(
+      '[demo] case memory RSS peak exceeded budget: 6000MB > 5632MB',
+    )).toBeDefined()
+    expect(parsePerformanceBudgetFailure(
+      '[demo] vite:transform heap used exceeded budget: 4300MB > 4096MB',
+    )).toBeDefined()
+    expect(parsePerformanceBudgetFailure('Error: output assertion failed')).toBeUndefined()
+  })
+
+  it('retries only the first performance budget failure', () => {
+    expect(resolvePerformanceBudgetConfirmation(true, undefined, pluginFailure)).toMatchObject({
+      action: 'retry',
+    })
+    expect(resolvePerformanceBudgetConfirmation(false, undefined, pluginFailure)).toEqual({ action: 'none' })
+  })
+
+  it('blocks confirmed and inconclusive follow-up failures', () => {
+    expect(resolvePerformanceBudgetConfirmation(true, pluginFailure, pluginFailure)).toMatchObject({
+      action: 'confirmed',
+    })
+
+    const differentFailure = parsePerformanceBudgetFailure(
+      '[demo/taro-vite-react-tailwindcss-v4] script:added-class:hot-update hot update exceeded budget: 61000ms > 60000ms',
+    )
+    expect(resolvePerformanceBudgetConfirmation(true, pluginFailure, differentFailure)).toMatchObject({
+      action: 'inconclusive',
+    })
+    expect(resolvePerformanceBudgetConfirmation(true, pluginFailure, undefined)).toMatchObject({
+      action: 'inconclusive',
+    })
+  })
+})

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -1305,7 +1305,9 @@ describe('e2e watch workflow', () => {
     expect(prRunStep.env.E2E_WATCH_MAX_PLUGIN_PROCESS_MS).toBe("${{ matrix.watch_max_plugin_process_ms || '6000' }}")
     expect(nightlyRunStep.env.E2E_WATCH_MAX_PLUGIN_PROCESS_MS).toBe("${{ matrix.watch_max_plugin_process_ms || '6000' }}")
     expect(prRunStep.env.E2E_WATCH_MAX_ATTEMPTS).toBe("${{ matrix.watch_max_attempts || '2' }}")
+    expect(prRunStep.env.E2E_WATCH_CONFIRM_PERFORMANCE_BUDGET).toBe('1')
     expect(nightlyRunStep.env.E2E_WATCH_MAX_ATTEMPTS).toBe("${{ matrix.watch_max_attempts || '2' }}")
+    expect(nightlyRunStep.env.E2E_WATCH_CONFIRM_PERFORMANCE_BUDGET).toBeUndefined()
   })
 
   it('keeps any explicit e2e watch plugin processing matrix budget within 60000ms', () => {

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -235,7 +235,7 @@ describe('ci workflows', () => {
       }
     }
 
-    expect(benchmarkWorkflow.jobs['benchmark-shard']['timeout-minutes']).toContain("github.event_name == 'pull_request' && 20")
+    expect(benchmarkWorkflow.jobs['benchmark-shard']['timeout-minutes']).toContain("github.event_name == 'pull_request' && 30")
     expect(releaseGateWorkflow.jobs['release-gate']['timeout-minutes']).toBe(30)
 
     const watchRows: Array<Record<string, unknown>> = watchWorkflow.jobs['pr-quick-gate'].strategy.matrix.include
@@ -475,7 +475,7 @@ describe('ci workflows', () => {
     expect(job.needs).toBe('benchmark-matrix')
     expect(job.strategy['fail-fast']).toBe(false)
     expect(job.strategy['max-parallel']).toBe(6)
-    expect(job['timeout-minutes']).toContain("github.event_name == 'pull_request' && 20")
+    expect(job['timeout-minutes']).toContain("github.event_name == 'pull_request' && 30")
     expect(job['timeout-minutes']).toContain('|| 45')
     expect(matrixInclude).toContain('needs.benchmark-matrix.outputs.include')
     expect(job.env.BENCH_ONLY).toBe('${{ matrix.bench_only }}')
@@ -544,7 +544,7 @@ describe('ci workflows', () => {
       'next',
     ])
     expect(workflow.on.workflow_dispatch.inputs.baseline.default).toBe('auto')
-    expect(job['timeout-minutes']).toContain("github.event_name == 'pull_request' && 20")
+    expect(job['timeout-minutes']).toContain("github.event_name == 'pull_request' && 30")
     expect(job['timeout-minutes']).toContain('|| 45')
     expect(job.env.WEAPP_TW_BENCH_BASELINE).toContain('auto')
     expect(job.env.BENCH_BUILD_RUNS).toContain("github.event_name == 'pull_request' && '3'")


### PR DESCRIPTION
## 问题

当前性能 gate 把 GitHub-hosted runner 的单次绝对测量直接作为阻断依据：

- benchmark 的 HMR peak/steady RSS 每个版本只有一次进程级汇总，固定 baseline → current 顺序会放大 runner 时间漂移。
- e2e-watch 对 hot-update、plugin processing 和 memory budget 采用单次失败；Taro 分片为控制时长显式关闭了通用重试，因此 macOS 上一次 11.488s > 10s 的尖峰会让功能断言全部通过的 job 失败。

这两类失败都表现为同一提交重跑后恢复，持续消耗维护时间。

## 修复

### Benchmark RSS

- 仅当首次失败项全部属于 HMR peak/steady RSS 时触发独立复测，其他真实性能失败仍立即阻断。
- 复用已准备的 baseline/current 根目录并跳过 cold build，只重跑 HMR。
- 复测反转为 current → baseline，抵消固定执行顺序和 runner 时间漂移。
- 相同项目、相同 RSS 指标两轮都超限才阻断；未复现的首次超限降为 observation。
- 复测异常或 RSS 样本不完整时保守阻断，并写入 summary 与 annotation。

### E2E Watch budgets

- PR quick gate 中，只有可识别的 hot-update、plugin processing、RSS 和 heap 预算失败会启动一次全新 watch session 进行确认。
- 同一项目、同一 sample、同一预算类型再次超限才确认回归并阻断。
- 确认阶段若变成超时、产物语义错误、另一项预算失败或缺少结构化日志，按 inconclusive 保守阻断。
- nightly 保持单次严格测量；原有通用重试次数与所有性能阈值均不变。

PR benchmark shard timeout 从 20 分钟调整为 30 分钟，仅为按需复测预留空间；正常通过路径不增加执行步骤。

## 本地验证

- `pnpm --dir packages/weapp-tailwindcss exec vitest run test/watch-hmr-regression.unit.test.ts test/ci`：9 files / 187 tests passed
- `pnpm --filter weapp-tailwindcss build`：通过
- `node --check benchmark/version-compare/scripts/ci-report.mjs`：通过
- `node --check benchmark/version-compare/scripts/run-ci.mjs`：通过
- `pnpm exec eslint ... --no-warn-ignored --max-warnings=0`：通过
- `git diff --check`：通过

上一提交的远端 benchmark 验证已通过 5 个 shard 与最终 performance guard。

## 发布判断

本次仅调整仓库内部 CI 与测试工具，不改变发布包 API 或用户行为，因此不添加 changeset，也不联动 `create-weapp-vite`。release skill 推荐的两个 changeset 检查脚本在当前 main 不存在。