### PR TITLE
fix(postcss): clean calc after inline expansion

### DIFF
--- a/.changeset/calm-inline-calculations.md
+++ b/.changeset/calm-inline-calculations.md
@@ -1,0 +1,6 @@
+---
+'@weapp-tailwindcss/postcss': patch
+'weapp-tailwindcss': patch
+---
+
+修复逻辑方向属性展开后残留 `calc()` 声明导致小程序间距计算异常的问题，并避免清理过程改变作者声明的级联与 `!important` 语义。

--- a/packages/postcss/src/plugins/getCustomPropertyCleaner.ts
+++ b/packages/postcss/src/plugins/getCustomPropertyCleaner.ts
@@ -25,12 +25,31 @@ export function getCustomPropertyCleaner(options: IStyleHandlerOptions): Accepte
     OnceExit(root) {
       root.walkDecls((decl) => {
         const prevNode = decl.prev()
-        if (!prevNode || prevNode.type !== 'decl' || prevNode.prop !== decl.prop) {
+
+        // 精确重复：仅比对紧邻前兄弟，保留原语义（避免 a:1;a:2;a:1 级联被误删）
+        if (
+          prevNode
+          && prevNode.type === 'decl'
+          && prevNode.prop === decl.prop
+          && prevNode.value === decl.value
+        ) {
+          decl.remove()
           return
         }
 
-        if (prevNode.value === decl.value) {
-          decl.remove()
+        // 逻辑简写（如 margin-inline）会被展开成交错的物理声明
+        // （margin-left; margin-right; margin-left(calc); margin-right(calc)），
+        // 故字面回退值未必是紧邻前兄弟，需向前扫描同规则内所有兄弟声明。
+        let hasEarlierSameProp = false
+        let node = prevNode
+        while (node) {
+          if (node.type === 'decl' && node.prop === decl.prop) {
+            hasEarlierSameProp = true
+            break
+          }
+          node = node.prev()
+        }
+        if (!hasEarlierSameProp) {
           return
         }
 

--- a/packages/postcss/src/plugins/getCustomPropertyCleaner.ts
+++ b/packages/postcss/src/plugins/getCustomPropertyCleaner.ts
@@ -31,6 +31,7 @@ export function getCustomPropertyCleaner(options: IStyleHandlerOptions): Accepte
           prevNode
           && prevNode.type === 'decl'
           && prevNode.prop === decl.prop
+          && prevNode.important === decl.important
           && prevNode.value === decl.value
         ) {
           decl.remove()

--- a/packages/postcss/src/plugins/getCustomPropertyCleaner.ts
+++ b/packages/postcss/src/plugins/getCustomPropertyCleaner.ts
@@ -1,5 +1,5 @@
 // 移除冗余的 CSS 自定义属性声明，避免重复覆盖
-import type { AcceptedPlugin } from 'postcss'
+import type { AcceptedPlugin, Declaration } from 'postcss'
 import type { IStyleHandlerOptions } from '../types'
 import { regExpTest } from '@weapp-tailwindcss/shared'
 import valueParser from 'postcss-value-parser'
@@ -20,6 +20,48 @@ export function getCustomPropertyCleaner(options: IStyleHandlerOptions): Accepte
 
   const shouldInspectValue = (value: string) => value.includes('var(') && value.includes('--')
 
+  const containsIncludedCustomProperty = (value: string) => {
+    if (!shouldInspectValue(value)) {
+      return false
+    }
+
+    const parsed = valueParser(value)
+    let containsIncludedCustomProperty = false
+
+    parsed.walk((node) => {
+      if (node.type !== 'function' || node.value !== 'var' || containsIncludedCustomProperty) {
+        return
+      }
+      const match = node.nodes.find((x) => {
+        return x.type === 'word' && regExpTest(includeCustomProperties, x.value)
+      })
+      if (match) {
+        containsIncludedCustomProperty = true
+      }
+    })
+
+    return containsIncludedCustomProperty
+  }
+
+  const hasSameSourceRange = (left: Declaration, right: Declaration) => {
+    const leftSource = left.source
+    const rightSource = right.source
+    if (
+      !leftSource?.start
+      || !leftSource.end
+      || !rightSource?.start
+      || !rightSource.end
+      || leftSource.input !== rightSource.input
+    ) {
+      return false
+    }
+
+    return leftSource.start.line === rightSource.start.line
+      && leftSource.start.column === rightSource.start.column
+      && leftSource.end.line === rightSource.end.line
+      && leftSource.end.column === rightSource.end.column
+  }
+
   return {
     postcssPlugin: 'postcss-remove-include-custom-properties',
     OnceExit(root) {
@@ -38,44 +80,31 @@ export function getCustomPropertyCleaner(options: IStyleHandlerOptions): Accepte
           return
         }
 
-        // 逻辑简写（如 margin-inline）会被展开成交错的物理声明
-        // （margin-left; margin-right; margin-left(calc); margin-right(calc)），
-        // 故字面回退值未必是紧邻前兄弟，需向前扫描同规则内所有兄弟声明。
-        let hasEarlierSameProp = false
+        if (!containsIncludedCustomProperty(decl.value)) {
+          return
+        }
+
+        // 逻辑简写展开后，同一来源的物理属性会交错排列；只允许跨过这些同源声明，
+        // 避免把作者独立编写的非相邻级联声明误判为 fallback。
+        let fallbackDecl: Declaration | undefined
         let node = prevNode
         while (node) {
           if (node.type === 'decl' && node.prop === decl.prop) {
-            hasEarlierSameProp = true
+            fallbackDecl = node
             break
           }
           node = node.prev()
         }
-        if (!hasEarlierSameProp) {
+        if (
+          !fallbackDecl
+          || fallbackDecl.important !== decl.important
+          || (fallbackDecl !== prevNode && !hasSameSourceRange(fallbackDecl, decl))
+          || containsIncludedCustomProperty(fallbackDecl.value)
+        ) {
           return
         }
 
-        if (!shouldInspectValue(decl.value)) {
-          return
-        }
-
-        const parsed = valueParser(decl.value)
-        let containsIncludedCustomProperty = false
-
-        parsed.walk((node) => {
-          if (node.type !== 'function' || node.value !== 'var' || containsIncludedCustomProperty) {
-            return
-          }
-          const match = node.nodes.find((x) => {
-            return x.type === 'word' && regExpTest(includeCustomProperties, x.value)
-          })
-          if (match) {
-            containsIncludedCustomProperty = true
-          }
-        })
-
-        if (containsIncludedCustomProperty) {
-          decl.remove()
-        }
+        decl.remove()
       })
     },
   }

--- a/packages/postcss/test/calc.test.ts
+++ b/packages/postcss/test/calc.test.ts
@@ -301,4 +301,37 @@ describe('calc', () => {
     const { css } = await styleHandler(code)
     expect(css).toMatchSnapshot()
   })
+
+  it('移除逻辑简写(margin-inline/padding-inline)展开后交错的 calc 残留', async () => {
+    const code = `page,
+:root {
+  --spacing: 8rpx;
+}
+.mx-20 {
+  margin-inline: calc(var(--spacing) * 20);
+}
+.px-12 {
+  padding-inline: calc(var(--spacing) * 12);
+}`
+
+    const styleHandler = createStyleHandler({
+      isMainChunk: true,
+      cssCalc: [
+        '--spacing',
+      ],
+      px2rpx: true,
+    })
+    const { css } = await styleHandler(code)
+
+    // 字面回退值保留
+    expect(css).toContain('margin-left: 160rpx;')
+    expect(css).toContain('margin-right: 160rpx;')
+    expect(css).toContain('padding-left: 96rpx;')
+    expect(css).toContain('padding-right: 96rpx;')
+    // 展开后交错的 calc 残留被清除
+    expect(css).not.toMatch(/margin-left:\s*calc\(var\(--spacing\)/)
+    expect(css).not.toMatch(/margin-right:\s*calc\(var\(--spacing\)/)
+    expect(css).not.toMatch(/padding-left:\s*calc\(var\(--spacing\)/)
+    expect(css).not.toMatch(/padding-right:\s*calc\(var\(--spacing\)/)
+  })
 })

--- a/packages/postcss/test/getCustomPropertyCleaner.test.ts
+++ b/packages/postcss/test/getCustomPropertyCleaner.test.ts
@@ -1,0 +1,49 @@
+import postcss from 'postcss'
+import { getCustomPropertyCleaner } from '@/plugins/getCustomPropertyCleaner'
+
+const cleaner = getCustomPropertyCleaner({
+  cssCalc: {
+    includeCustomProperties: ['--spacing'],
+  },
+} as any)
+
+async function clean(css: string) {
+  return postcss([cleaner!]).process(css, { from: undefined })
+}
+
+describe('getCustomPropertyCleaner', () => {
+  it('保留不同来源的非相邻级联声明', async () => {
+    const { css } = await clean(`.demo {
+  width: 10px;
+  color: red;
+  width: calc(var(--spacing) * 2);
+}`)
+
+    expect(css).toContain('width: calc(var(--spacing) * 2)')
+  })
+
+  it.each([
+    `width: 10px;
+  color: red;
+  width: calc(var(--spacing) * 2) !important;`,
+    `width: 10px !important;
+  color: red;
+  width: calc(var(--spacing) * 2);`,
+  ])('保留 important 不一致的级联声明', async (declarations) => {
+    const { css } = await clean(`.demo {
+  ${declarations}
+}`)
+
+    expect(css).toContain('width: calc(var(--spacing) * 2)')
+  })
+
+  it('仍移除紧邻 fallback 后引用目标变量的声明', async () => {
+    const { css } = await clean(`.demo {
+  width: 16px;
+  width: calc(var(--spacing) * 2);
+}`)
+
+    expect(css).toContain('width: 16px')
+    expect(css).not.toContain('calc(var(--spacing)')
+  })
+})


### PR DESCRIPTION
修复 `mx-20` 编译成小程序后在宽度为 430px 的设备上渲染为 20px 的问题。