### PR TITLE
fix(vite): 统一清理生成器 module id 查询

### DIFF
--- a/.changeset/tidy-sidecar-paths.md
+++ b/.changeset/tidy-sidecar-paths.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 Tailwind v4 通用生成器仍可能把带 query 或 hash 的 bundler module id 当作物理文件路径读取的问题，确保 weapp-vite sidecar 等虚拟样式请求在进入文件系统解析前统一还原为源码路径。

--- a/packages/weapp-tailwindcss/src/bundlers/shared/v4-generation-core.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/v4-generation-core.ts
@@ -7,7 +7,7 @@ import { adaptGeneratedCssWithFrameworkPipeline, adaptGeneratedCssWithFrameworkR
 import { generateCssByGenerator } from './generator-css'
 import { preferScopedGeneratedCssRules } from './generator-css/scoped-rules'
 import { resolvePostcssRequestOption } from './generator-css/source-resolver/postcss-source'
-import { isVueScopedStyleRequest } from './style-requests'
+import { isVueScopedStyleRequest, stripRequestQuery } from './style-requests'
 
 export interface TailwindV4GenerationCoreInput extends GenerateCssByGeneratorOptions {
   compilationChanges?: CompilationDependencyChange[] | undefined
@@ -35,19 +35,23 @@ function resolveGenerationOptions(
   options: TailwindV4GenerationCoreInput,
   mode: ReturnType<typeof resolveCompilerMode>,
 ) {
+  const physicalFile = stripRequestQuery(options.file)
+  const normalizedOptions = physicalFile === options.file
+    ? options
+    : { ...options, file: physicalFile }
   if (mode === 'legacy') {
-    return options
+    return normalizedOptions
   }
-  const scopeId = options.scope?.id ?? options.outputFile ?? options.file
+  const scopeId = normalizedOptions.scope?.id ?? normalizedOptions.outputFile ?? normalizedOptions.file
   const compilationChanges = mergeCompilationDependencyChanges(
-    options.compilationChanges,
-    consumeCompilationScopeChanges(options.runtimeState, scopeId),
+    normalizedOptions.compilationChanges,
+    consumeCompilationScopeChanges(normalizedOptions.runtimeState, scopeId),
   )
   if (compilationChanges.length === 0) {
-    return options
+    return normalizedOptions
   }
   return {
-    ...options,
+    ...normalizedOptions,
     compilationChanges,
     previousClassSet: undefined,
     previousCss: undefined,

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -13784,7 +13784,12 @@ ${utilities}
     const replayedCss = emitted.find(file => file.fileName === 'pages/index/index.wxss')?.source
     expect(generateCssByGeneratorMock).toHaveBeenCalledWith(expect.objectContaining({
       rawSource: cleanSource,
-      file: cleanStyleRequest,
+      file: sourceFile,
+      cssHandlerOptions: expect.objectContaining({
+        sourceOptions: expect.objectContaining({
+          requestFile: cleanStyleRequest,
+        }),
+      }),
     }))
     expect(replayedCss).toContain('.clean-style')
     expect(replayedCss).not.toContain('.tw-watch-style-case')

--- a/packages/weapp-tailwindcss/test/compiler/compiler-mode.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/compiler-mode.test.ts
@@ -85,6 +85,39 @@ describe('compiler mode', () => {
     expect(result?.artifact).toBeUndefined()
   })
 
+  it.each([
+    [
+      '/workspace/src/app.wxss?weapp-vite-sidecar-owner=app&weapp-vite-sidecar=style&lang.css',
+      '/workspace/src/app.wxss',
+    ],
+    [
+      'C:\\workspace\\src\\app.wxss?weapp-vite-sidecar=style#virtual',
+      'C:\\workspace\\src\\app.wxss',
+    ],
+  ])('normalizes the physical generation file for bundler request %s', async (file, physicalFile) => {
+    process.env[COMPILER_MODE_ENV] = 'legacy'
+    const generateCssByGenerator = vi.fn(async (options: { file: string }) => {
+      expect(options.file).toBe(physicalFile)
+      return {
+        ...createGeneratedResult('.p-4 { padding: 1rem; }'),
+        metadata: {
+          file: physicalFile,
+          outputFile: 'app.css',
+        },
+      }
+    })
+    vi.doMock('@/bundlers/shared/generator-css', () => ({ generateCssByGenerator }))
+    const { generateTailwindV4Css } = await import('@/bundlers/shared/v4-generation-core')
+
+    const result = await generateTailwindV4Css({
+      ...createGenerationOptions(),
+      file,
+    })
+
+    expect(generateCssByGenerator).toHaveBeenCalledTimes(1)
+    expect(result?.metadata.file).toBe(physicalFile)
+  })
+
   it('uses the root framework adapter in graph mode', async () => {
     process.env[COMPILER_MODE_ENV] = 'graph'
     const generateCssByGenerator = vi.fn(async (options: { deferCssAdaptation?: boolean }) => {


### PR DESCRIPTION
## 背景

#1047 已在 Vite adapter 层清理 weapp-vite sidecar 请求，但 Tailwind v4 通用生成器仍可能直接使用带 query/hash 的 module id 读取文件，导致 `ENOENT`。

## 修改

- 在共享 generation core 统一将 bundler module id 还原为物理文件路径
- legacy 与 graph 模式共用同一规范化边界
- 增加 POSIX sidecar ID 与 Windows 反斜杠路径回归测试
- 补充 patch changeset

## 验证

- `pnpm --filter weapp-tailwindcss lint`
- compiler 相关定向测试：21 项通过
- `pnpm build:ci`
- 本地 link 到 weapp-vite 后运行 changed-project HMR：6/6 场景通过
- 本地 link 到 weapp-vite 后运行 Tailwind 模板 HMR：5/5 场景通过