### PR TITLE
fix(vite): 统一 Web source candidate 扫描边界

### DIFF
--- a/.changeset/calm-web-scan-roots.md
+++ b/.changeset/calm-web-scan-roots.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 Vite Web generator 在 monorepo 中通过 transform 和 HMR 扫描第三方依赖的问题，并保留显式 source 引入外部依赖的能力。

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/scan-root.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/scan-root.ts
@@ -55,6 +55,8 @@ interface ResolveSourceCandidateScanFilesOptions {
   root: string
 }
 
+type SourceCandidateEligibilityRoot = Omit<ResolveSourceCandidateScanFilesOptions, 'filter'>
+
 function resolveOutDirIgnorePattern(root: string, outDir: string | undefined) {
   if (!outDir) {
     return
@@ -146,32 +148,29 @@ function createDefaultIgnoredSources(
 }
 
 /** 创建与文件系统 root scan 一致的增量源码资格判断器。 */
-export function createSourceCandidateEligibilityMatcher(options: {
-  root: string
-  outDir?: string | undefined
-  entries?: TailwindSourceEntry[] | undefined
-  explicit?: boolean | undefined
-}) {
-  const root = path.resolve(options.root)
-  const outDirIgnore = resolveOutDirIgnorePattern(root, options.outDir)
-  const entries = options.entries
-  const explicit = options.explicit === true
-  const ignoredSources = createDefaultIgnoredSources(root, outDirIgnore, entries, explicit)
-  return (file: string) => {
-    const resolvedFile = path.resolve(file)
-    const relative = path.relative(root, resolvedFile)
-    if (explicit && entries !== undefined) {
+export function createSourceCandidateEligibilityMatcher(roots: SourceCandidateEligibilityRoot[]) {
+  const matchers = roots.map((options) => {
+    const root = path.resolve(options.root)
+    const outDirIgnore = resolveOutDirIgnorePattern(root, options.outDir)
+    const entries = options.entries
+    const explicit = options.explicit === true
+    const hasPositiveEntry = entries?.some(entry => !entry.negated) === true
+    const ignoredSources = createDefaultIgnoredSources(root, outDirIgnore, entries, explicit)
+    return (resolvedFile: string) => {
+      if (explicit) {
+        return hasPositiveEntry && isFileMatchedByTailwindSourceEntries(resolvedFile, entries)
+      }
+      const relative = path.relative(root, resolvedFile)
       if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
         return false
       }
-      return entries?.length && entries.some(entry => !entry.negated)
-        ? isFileMatchedByTailwindSourceEntries(resolvedFile, entries)
-        : false
+      return isFileMatchedByTailwindSourceEntries(resolvedFile, entries)
+        && !isFileExcludedByTailwindSourceEntries(resolvedFile, ignoredSources)
     }
-    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
-      return true
-    }
-    return !isFileExcludedByTailwindSourceEntries(resolvedFile, ignoredSources)
+  })
+  return (file: string) => {
+    const resolvedFile = path.resolve(file)
+    return matchers.some(matches => matches(resolvedFile))
   }
 }
 

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-scan-session.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-scan-session.ts
@@ -133,14 +133,12 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     const sourceScan = await resolveViteSourceScanEntries(options.opts, options.runtimeState.tailwindRuntime, { outDir, root })
     sourceScanEntries = sourceScan?.entries
     sourceScanExplicit = sourceScan?.explicit ?? false
-    sourceScanMatcher = createSourceCandidateEligibilityMatcher({
-      entries: sourceScanEntries,
-      explicit: sourceScanExplicit,
-      outDir,
-      root,
-    })
     sourceScanDependencies = new Set((sourceScan?.dependencies ?? []).map(normalizeDependency))
     const roots = collectRoots(root, sourceScanEntries)
+    sourceScanMatcher = createSourceCandidateEligibilityMatcher(roots.map(scanRoot => ({
+      ...scanRoot,
+      outDir,
+    })))
     const nextScanSignature = createSourceCandidateScanSignature({
       inlineCandidates: sourceScan?.inlineCandidates,
       outDir,

--- a/packages/weapp-tailwindcss/test/bundlers/source-candidate-eligibility.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/source-candidate-eligibility.unit.test.ts
@@ -1,41 +1,76 @@
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { createSourceCandidateEligibilityMatcher } from '@/bundlers/shared/source-candidates/scan-root'
 
 describe('source candidate eligibility', () => {
   it('applies Tailwind default ignores to implicit root scans', () => {
-    const matches = createSourceCandidateEligibilityMatcher({ root: '/project', outDir: 'dist' })
+    const root = path.resolve('workspace/packages/app')
+    const matches = createSourceCandidateEligibilityMatcher([{ root, outDir: 'dist' }])
 
-    expect(matches('/project/src/App.vue')).toBe(true)
-    expect(matches('/project/node_modules/monaco/editor.ts')).toBe(false)
-    expect(matches('/project/dist/assets/index.js')).toBe(false)
+    expect(matches(path.join(root, 'src/App.vue'))).toBe(true)
+    expect(matches(path.join(root, 'node_modules/monaco/editor.ts'))).toBe(false)
+    expect(matches(path.join(root, 'dist/assets/index.js'))).toBe(false)
+    expect(matches(path.resolve(root, '../../node_modules/monaco/editor.ts'))).toBe(false)
   })
 
-  it('allows explicitly included dependency sources', () => {
-    const matches = createSourceCandidateEligibilityMatcher({
-      root: '/project',
+  it('allows explicitly included dependency sources outside the vite root', () => {
+    const root = path.resolve('workspace/packages/app')
+    const dependencyRoot = path.resolve(root, '../../node_modules/example')
+    const matches = createSourceCandidateEligibilityMatcher([{
+      root,
       explicit: true,
       entries: [{
-        base: '/project',
-        pattern: 'node_modules/example/**/*.ts',
+        base: dependencyRoot,
+        pattern: '**/*.ts',
         negated: false,
       }],
-    })
+    }])
 
-    expect(matches('/project/node_modules/example/index.ts')).toBe(true)
-    expect(matches('/project/node_modules/other/index.ts')).toBe(false)
+    expect(matches(path.join(dependencyRoot, 'src/index.ts'))).toBe(true)
+    expect(matches(path.resolve(root, '../../node_modules/other/index.ts'))).toBe(false)
   })
 
   it('does not treat an uninitialized explicit negative scan as match-all', () => {
-    const matches = createSourceCandidateEligibilityMatcher({
-      root: '/project',
+    const root = path.resolve('workspace/packages/app')
+    const matches = createSourceCandidateEligibilityMatcher([{
+      root,
       explicit: true,
       entries: [{
-        base: '/project',
+        base: root,
         pattern: 'node_modules/**',
         negated: true,
       }],
-    })
+    }])
 
-    expect(matches('/project/src/App.vue')).toBe(false)
+    expect(matches(path.join(root, 'src/App.vue'))).toBe(false)
+  })
+
+  it('applies implicit negative sources to transformed modules', () => {
+    const root = path.resolve('workspace/packages/app')
+    const generatedRoot = path.join(root, 'src/generated')
+    const matches = createSourceCandidateEligibilityMatcher([{
+      root,
+      entries: [{
+        base: generatedRoot,
+        pattern: '**/*',
+        negated: true,
+      }],
+    }])
+
+    expect(matches(path.join(root, 'src/App.vue'))).toBe(true)
+    expect(matches(path.join(generatedRoot, 'client.ts'))).toBe(false)
+  })
+
+  it('accepts files from every implicit source root', () => {
+    const appRoot = path.resolve('workspace/packages/app')
+    const sharedRoot = path.resolve('workspace/shared-ui')
+    const matches = createSourceCandidateEligibilityMatcher([
+      { root: appRoot },
+      { root: sharedRoot },
+    ])
+
+    expect(matches(path.join(appRoot, 'src/App.vue'))).toBe(true)
+    expect(matches(path.join(sharedRoot, 'Button.vue'))).toBe(true)
+    expect(matches(path.resolve('workspace/unrelated/index.ts'))).toBe(false)
   })
 })

--- a/packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts
@@ -1,8 +1,69 @@
-import { describe, expect, it, vi } from 'vitest'
-import { createSourceCandidateCollector } from '@/bundlers/vite/source-candidates'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createFrameworkSourceScanSession } from '@/bundlers/vite/shared/framework-source-scan-session'
+import { createSourceCandidateCollector } from '@/bundlers/vite/source-candidates'
+
+const createdDirs: string[] = []
+
+async function createTempWorkspace() {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-source-session-'))
+  const appRoot = path.join(workspaceRoot, 'packages/app')
+  await mkdir(appRoot, { recursive: true })
+  createdDirs.push(workspaceRoot)
+  return { appRoot, workspaceRoot }
+}
+
+function createSession(options: {
+  appRoot: string
+  extractor: (source: string) => Promise<string[]>
+  sources?: Array<{ base: string, pattern: string, negated: boolean }>
+}) {
+  const sourceCandidateCollector = createSourceCandidateCollector({ extractor: options.extractor })
+  const hmrCandidateState = {
+    apply: vi.fn(change => change),
+    createChange: vi.fn((_file, change) => change),
+  }
+  return {
+    session: createFrameworkSourceScanSession({
+      cssMemory: {
+        refreshRememberedCssSourceByCurrentFile: vi.fn(async () => {}),
+        refreshRememberedCssSourceBySourceFile: vi.fn(async () => {}),
+      } as any,
+      debug: vi.fn(),
+      getResolvedConfig: () => ({ root: options.appRoot }),
+      hmrCandidateState: hmrCandidateState as any,
+      isCandidateRequest: () => true,
+      isWatchLikeBuild: () => true,
+      opts: {},
+      runtimeState: {
+        tailwindRuntime: {
+          majorVersion: 4,
+          options: {
+            projectRoot: options.appRoot,
+            tailwindcss: {
+              cwd: options.appRoot,
+              v4: {
+                base: options.appRoot,
+                sources: options.sources,
+              },
+            },
+          },
+        },
+      } as any,
+      shouldOwnTailwindGeneration: true,
+      sourceCandidateCollector,
+    }),
+    sourceCandidateCollector,
+  }
+}
 
 describe('vite framework source scan session', () => {
+  afterEach(async () => {
+    await Promise.all(createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+  })
+
   it('serializes explicit source snapshots for the same HMR file', async () => {
     let releaseFirstExtraction!: () => void
     const firstExtractionBlocked = new Promise<void>((resolve) => {
@@ -55,5 +116,44 @@ describe('vite framework source scan session', () => {
     expect(extractedSources).toEqual(['old-candidate', 'new-candidate'])
     expect(sourceCandidateCollector.values()).toEqual(new Set(['new-candidate']))
     expect(hmrCandidateState.apply).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps implicit transformed modules inside the source scan roots', async () => {
+    const { appRoot, workspaceRoot } = await createTempWorkspace()
+    const extractor = vi.fn(async (source: string) => [source])
+    const { session, sourceCandidateCollector } = createSession({ appRoot, extractor })
+    await session.sync()
+    extractor.mockClear()
+
+    const appFile = path.join(appRoot, 'src/App.vue')
+    const dependencyFile = path.join(workspaceRoot, 'node_modules/monaco-editor/index.ts')
+    await session.syncChangedFile(dependencyFile, 'text-blue-500')
+    await session.syncChangedFile(appFile, 'text-green-500')
+
+    expect(extractor).toHaveBeenCalledOnce()
+    expect(extractor).toHaveBeenCalledWith('text-green-500', 'vue')
+    expect(sourceCandidateCollector.values()).toEqual(new Set(['text-green-500']))
+  })
+
+  it('keeps explicitly configured dependency sources eligible outside the vite root', async () => {
+    const { appRoot, workspaceRoot } = await createTempWorkspace()
+    const dependencyRoot = path.join(workspaceRoot, 'node_modules/example')
+    const extractor = vi.fn(async (source: string) => [source])
+    const { session, sourceCandidateCollector } = createSession({
+      appRoot,
+      extractor,
+      sources: [{ base: dependencyRoot, pattern: '**/*.ts', negated: false }],
+    })
+    await session.sync()
+    extractor.mockClear()
+
+    const dependencyFile = path.join(dependencyRoot, 'index.ts')
+    const unrelatedFile = path.join(workspaceRoot, 'node_modules/other/index.ts')
+    await session.syncChangedFile(dependencyFile, 'text-blue-500')
+    await session.syncChangedFile(unrelatedFile, 'text-red-500')
+
+    expect(extractor).toHaveBeenCalledOnce()
+    expect(extractor).toHaveBeenCalledWith('text-blue-500', 'ts')
+    expect(sourceCandidateCollector.values()).toEqual(new Set(['text-blue-500']))
   })
 })


### PR DESCRIPTION
## 背景

Generic Vite Web generator 在裸 `@import "tailwindcss"` 的隐式 source 模式下，会把 Vite 模块图中的第三方依赖重新合并进候选集合，导致 CSS 污染和明显的构建耗时增加。

Refs #1059

## 修改

- 使用实际 source scan roots 构建统一的 eligibility matcher，供初始扫描、transform、watch 与 HMR 共用
- 隐式模式仅接受扫描 root 内文件，并应用 Tailwind 默认忽略、输出目录和负向 source 规则
- 显式 source 按各 entry 自身的 base 匹配，保留显式扫描 Vite root 外依赖的能力
- 支持 Vite root、`tailwindcssBasedir` 和 CSS entry roots 组成的多 root 隐式扫描
- 补充 monorepo 根部 `node_modules`、多 root、负向 source、显式外部依赖和 session/HMR 回归测试

## 验证

- `pnpm vitest run --project weapp-tailwindcss packages/weapp-tailwindcss/test/bundlers/source-candidate-eligibility.unit.test.ts packages/weapp-tailwindcss/test/bundlers/vite-source-scan.unit.test.ts packages/weapp-tailwindcss/test/bundlers/vite-source-candidates.unit.test.ts packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts`：52 passed
- `pnpm vitest run --project weapp-tailwindcss packages/weapp-tailwindcss/test/bundlers/vite-plugin-hooks.unit.test.ts packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts`：227 passed
- 改动文件 ESLint 与 `git diff --check` 通过
- `pnpm --filter weapp-tailwindcss build` 通过

使用 issue 中的 dashboard 复现项目验证：

- `.collapse`、`.text-blue-500`、`.touch-pinch-zoom`、`.table-caption`、`.rounded-ss` 不再进入主 CSS
- Iconify 仍生成 42 个图标 selector
- 单次 Web production build 从约 11 秒降至约 3.7 秒
- `source-candidates` transform 总耗时从约 6.3 秒降至约 0.36 秒；第三方模块只执行快速 eligibility 判断，不再提取 candidates
- `monaco.css` 与官方插件输出完全一致，主 CSS selector 集合一致

## Changeset

包含 `weapp-tailwindcss` patch changeset。主线已有的 #1061 changeset 正在被版本 PR #1056 消费，因此本 PR 保留独立 changeset，避免发布顺序导致本修复漏发。