### PR TITLE
fix(vite): 统一 gitignore source candidate 边界

### DIFF
--- a/.changeset/quiet-vite-source-identities.md
+++ b/.changeset/quiet-vite-source-identities.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 Vite transform 与 HMR 未复用 Tailwind Scanner 实际文件范围的问题，避免被 `.gitignore` 排除的模块重新进入 source candidates。

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/scan-root.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/scan-root.ts
@@ -1,7 +1,7 @@
 import type { TailwindSourceEntry } from '@/tailwindcss/source-scan'
 import path from 'node:path'
 import { resolveProjectSourceFiles } from '@tailwindcss-mangle/engine'
-import { isFileExcludedByTailwindSourceEntries, isFileMatchedByTailwindSourceEntries, toPosixPath } from '@/tailwindcss/source-scan'
+import { isFileExcludedByTailwindSourceEntries, isFileMatchedByTailwindSourceEntries, resolveSourceScanPath, toPosixPath } from '@/tailwindcss/source-scan'
 
 const TAILWIND_V4_IGNORED_CONTENT_DIRS = [
   '.git',
@@ -148,9 +148,15 @@ function createDefaultIgnoredSources(
 }
 
 /** 创建与文件系统 root scan 一致的增量源码资格判断器。 */
-export function createSourceCandidateEligibilityMatcher(roots: SourceCandidateEligibilityRoot[]) {
+export function createSourceCandidateEligibilityMatcher(
+  roots: SourceCandidateEligibilityRoot[],
+  eligibleFiles?: Iterable<string>,
+) {
+  const eligibleFileSet = eligibleFiles === undefined
+    ? undefined
+    : new Set([...eligibleFiles].map(resolveSourceScanPath))
   const matchers = roots.map((options) => {
-    const root = path.resolve(options.root)
+    const root = resolveSourceScanPath(options.root)
     const outDirIgnore = resolveOutDirIgnorePattern(root, options.outDir)
     const entries = options.entries
     const explicit = options.explicit === true
@@ -166,10 +172,11 @@ export function createSourceCandidateEligibilityMatcher(roots: SourceCandidateEl
       }
       return isFileMatchedByTailwindSourceEntries(resolvedFile, entries)
         && !isFileExcludedByTailwindSourceEntries(resolvedFile, ignoredSources)
+        && (eligibleFileSet?.has(resolvedFile) ?? true)
     }
   })
   return (file: string) => {
-    const resolvedFile = path.resolve(file)
+    const resolvedFile = resolveSourceScanPath(file)
     return matchers.some(matches => matches(resolvedFile))
   }
 }

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/store.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/store.ts
@@ -132,7 +132,7 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     }
   }
 
-  async function scanRoot({ entries, explicit, root, outDir }: ScanSourceCandidateRootOptions) {
+  async function resolveScanFiles({ entries, explicit, root, outDir }: ScanSourceCandidateRootOptions) {
     const files = await resolveSourceCandidateScanFiles({
       entries,
       explicit,
@@ -140,7 +140,13 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
       outDir,
       root,
     })
-    await Promise.all(files.map(file => syncFile(resolveSourceScanPath(file))))
+    return files.map(resolveSourceScanPath)
+  }
+
+  async function scanRoot(options: ScanSourceCandidateRootOptions) {
+    const resolvedFiles = await resolveScanFiles(options)
+    options.onFilesResolved?.(resolvedFiles)
+    await Promise.all(resolvedFiles.map(syncFile))
   }
 
   function replaceFinal(id: string, nextCandidates: Set<string>) {
@@ -417,6 +423,7 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     syncFile,
     syncCurrentSource,
     syncCurrentFile,
+    resolveScanFiles,
     scanRoot,
     syncInline,
     remove,

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/types-and-cache.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/types-and-cache.ts
@@ -14,6 +14,7 @@ export interface SourceCandidateStore {
   syncFile: (id: string) => Promise<void>
   syncCurrentSource: (id: string, source: string) => Promise<SourceCandidateChange>
   syncCurrentFile: (id: string) => Promise<SourceCandidateChange>
+  resolveScanFiles: (options: ScanSourceCandidateRootOptions) => Promise<string[]>
   scanRoot: (options: ScanSourceCandidateRootOptions) => Promise<void>
   syncInline: (inlineCandidates: TailwindInlineSourceCandidates | undefined) => void
   remove: (id: string) => SourceCandidateChange
@@ -58,6 +59,7 @@ export interface ScanSourceCandidateRootOptions {
   outDir?: string | undefined
   entries?: TailwindSourceEntry[] | undefined
   explicit?: boolean | undefined
+  onFilesResolved?: ((files: string[]) => void) | undefined
 }
 
 export interface SourceCandidateCollectorOptions {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-scan-session.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-scan-session.ts
@@ -7,6 +7,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { LRUCache } from 'lru-cache'
+import { resolveSourceScanPath } from '@/tailwindcss/source-scan'
 import { isTailwindV4CssEntry } from '@/tailwindcss/v4/css-entries'
 import { createSourceCandidateEligibilityMatcher } from '../../shared/source-candidates/scan-root'
 import { isSourceStyleRequest } from '../../shared/style-requests'
@@ -22,9 +23,13 @@ type CssMemory = ReturnType<typeof createViteCssMemory>
 type RuntimeState = ReturnType<typeof createViteRuntimeClassSet>['runtimeState']
 type HmrCandidateState = ReturnType<typeof createViteHmrCandidateState>
 type SourceCandidateScanSnapshot = ReturnType<SourceCandidateCollector['snapshot']>
+interface SourceCandidateScanCacheEntry {
+  eligibleFiles: string[]
+  snapshot: SourceCandidateScanSnapshot
+}
 type SourceScanResult = NonNullable<Awaited<ReturnType<typeof resolveViteSourceScanEntries>>>
 
-const sourceCandidateScanSnapshotCache = new LRUCache<string, SourceCandidateScanSnapshot>({
+const sourceCandidateScanSnapshotCache = new LRUCache<string, SourceCandidateScanCacheEntry>({
   max: SOURCE_CANDIDATE_SCAN_CACHE_MAX,
 })
 
@@ -53,11 +58,17 @@ export async function syncFrameworkSourceCandidatesForHotUpdate(
 }
 
 export function createFrameworkSourceScanSession(options: FrameworkSourceScanSessionOptions) {
-  const sourceCandidateScanCache = new LRUCache<string, SourceCandidateScanSnapshot>({
+  const sourceCandidateScanCache = new LRUCache<string, SourceCandidateScanCacheEntry>({
     max: SOURCE_CANDIDATE_SCAN_CACHE_MAX,
   })
   let sourceScanEntries: SourceScanResult['entries']
   let sourceScanMatcher: ReturnType<typeof createSourceCandidateEligibilityMatcher>
+  let sourceScanBoundaryMatcher: ReturnType<typeof createSourceCandidateEligibilityMatcher>
+  let sourceScanRoots: ReturnType<typeof collectRoots> = []
+  let sourceScanOutDir: string | undefined
+  let sourceScanEligibleFiles = new Set<string>()
+  let sourceScanEligibleFilesRefresh: Promise<void> | undefined
+  const sourceScanIneligibleFiles = new Set<string>()
   let sourceScanDependencies = new Set<string>()
   let sourceScanExplicit = false
   let sourceCandidateScanSignature: string | undefined
@@ -70,6 +81,7 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
   const isDependency = (file: string) => sourceScanDependencies.has(normalizeDependency(file))
   const invalidate = () => {
     sourceCandidateScanInvalidated = true
+    sourceScanIneligibleFiles.clear()
   }
   const hasState = () => sourceCandidateScanSignature !== undefined
 
@@ -107,9 +119,36 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     if (!sourceCandidateScanSignature) {
       return
     }
-    const snapshot = options.sourceCandidateCollector.snapshot()
-    sourceCandidateScanCache.set(sourceCandidateScanSignature, snapshot)
-    sourceCandidateScanSnapshotCache.set(sourceCandidateScanSignature, snapshot)
+    const entry = {
+      eligibleFiles: [...sourceScanEligibleFiles],
+      snapshot: options.sourceCandidateCollector.snapshot(),
+    }
+    sourceCandidateScanCache.set(sourceCandidateScanSignature, entry)
+    sourceCandidateScanSnapshotCache.set(sourceCandidateScanSignature, entry)
+  }
+
+  const updateSourceScanMatchers = (eligibleFiles: Iterable<string>) => {
+    sourceScanEligibleFiles = new Set(eligibleFiles)
+    const matcherRoots = sourceScanRoots.map(scanRoot => ({
+      ...scanRoot,
+      outDir: sourceScanOutDir,
+    }))
+    sourceScanBoundaryMatcher = createSourceCandidateEligibilityMatcher(matcherRoots)
+    sourceScanMatcher = createSourceCandidateEligibilityMatcher(matcherRoots, sourceScanEligibleFiles)
+  }
+
+  const refreshSourceScanEligibleFiles = async () => {
+    sourceScanEligibleFilesRefresh ??= Promise.all(sourceScanRoots.map(scanRoot => options.sourceCandidateCollector.resolveScanFiles({
+      entries: scanRoot.entries,
+      explicit: scanRoot.explicit,
+      root: scanRoot.root,
+      outDir: sourceScanOutDir,
+    })))
+      .then(files => updateSourceScanMatchers(files.flat()))
+      .finally(() => {
+        sourceScanEligibleFilesRefresh = undefined
+      })
+    await sourceScanEligibleFilesRefresh
   }
 
   const shouldDiscoverAutoCssSources = (autoCssSourcesDiscovered: boolean) => {
@@ -135,10 +174,8 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     sourceScanExplicit = sourceScan?.explicit ?? false
     sourceScanDependencies = new Set((sourceScan?.dependencies ?? []).map(normalizeDependency))
     const roots = collectRoots(root, sourceScanEntries)
-    sourceScanMatcher = createSourceCandidateEligibilityMatcher(roots.map(scanRoot => ({
-      ...scanRoot,
-      outDir,
-    })))
+    sourceScanRoots = roots
+    sourceScanOutDir = outDir
     const nextScanSignature = createSourceCandidateScanSignature({
       inlineCandidates: sourceScan?.inlineCandidates,
       outDir,
@@ -147,7 +184,7 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     })
     if (hasState() && sourceCandidateScanSignature === nextScanSignature) {
       options.sourceCandidateCollector.syncInline(sourceScan?.inlineCandidates)
-      sourceCandidateScanCache.set(nextScanSignature, options.sourceCandidateCollector.snapshot())
+      cacheCurrent()
       options.debug('reuse vite source candidate scan for watch rebuild')
       sourceCandidateScanInvalidated = false
       return
@@ -156,7 +193,9 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
       ? sourceCandidateScanCache.get(nextScanSignature) ?? sourceCandidateScanSnapshotCache.get(nextScanSignature)
       : undefined
     if (cachedScan) {
-      options.sourceCandidateCollector.restore(cachedScan)
+      options.sourceCandidateCollector.restore(cachedScan.snapshot)
+      sourceScanIneligibleFiles.clear()
+      updateSourceScanMatchers(cachedScan.eligibleFiles)
       sourceCandidateScanSignature = nextScanSignature
       options.debug('reuse cached vite source candidate scan for watch rebuild')
       sourceCandidateScanInvalidated = false
@@ -169,18 +208,20 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
       options.sourceCandidateCollector.clearScan()
     }
     options.sourceCandidateCollector.syncInline(sourceScan?.inlineCandidates)
+    const eligibleFiles = new Set<string>()
+    sourceScanIneligibleFiles.clear()
     await Promise.all(roots.map(scanRoot => options.sourceCandidateCollector.scanRoot({
       entries: scanRoot.entries,
       explicit: scanRoot.explicit,
       root: scanRoot.root,
       outDir,
+      onFilesResolved: files => files.forEach(file => eligibleFiles.add(file)),
     })))
+    updateSourceScanMatchers(eligibleFiles)
     sourceCandidateScanSignature = nextScanSignature
     sourceCandidateScanInvalidated = false
     if (options.isWatchLikeBuild()) {
-      const snapshot = options.sourceCandidateCollector.snapshot()
-      sourceCandidateScanCache.set(nextScanSignature, snapshot)
-      sourceCandidateScanSnapshotCache.set(nextScanSignature, snapshot)
+      cacheCurrent()
     }
   }
 
@@ -217,14 +258,24 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     return previous
   }
 
-  const syncChangedFile = (id: string, sourceOverride?: string) => {
+  const syncChangedFile = async (id: string, sourceOverride?: string) => {
     if (!options.shouldOwnTailwindGeneration || !options.isCandidateRequest(id)) {
-      return Promise.resolve(undefined)
+      return undefined
     }
     const file = cleanUrl(id)
     const runtimeAffectingByDependency = isDependency(file)
     if (runtimeAffectingByDependency) {
       invalidate()
+    }
+    const resolvedFile = resolveSourceScanPath(file)
+    if (sourceScanMatcher
+      && !sourceScanMatcher(file)
+      && sourceScanBoundaryMatcher?.(file)
+      && !sourceScanIneligibleFiles.has(resolvedFile)) {
+      await refreshSourceScanEligibleFiles()
+      if (!sourceScanMatcher(file)) {
+        sourceScanIneligibleFiles.add(resolvedFile)
+      }
     }
     if (sourceScanMatcher && !sourceScanMatcher(file)) {
       const change = options.sourceCandidateCollector.remove(file)
@@ -243,7 +294,8 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     }
     const existingTask = pendingSourceCandidateSyncByFile.get(file)
     if (existingTask) {
-      return existingTask.then(() => syncChangedFile(id, sourceOverride))
+      await existingTask
+      return syncChangedFile(id, sourceOverride)
     }
     const previousSource = options.sourceCandidateCollector.source(file)
     const task = (sourceOverride === undefined

--- a/packages/weapp-tailwindcss/test/bundlers/source-candidate-eligibility.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/source-candidate-eligibility.unit.test.ts
@@ -1,8 +1,36 @@
 import path from 'node:path'
-import { describe, expect, it } from 'vitest'
-import { createSourceCandidateEligibilityMatcher } from '@/bundlers/shared/source-candidates/scan-root'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createSourceCandidateEligibilityMatcher, resolveSourceCandidateScanFiles } from '@/bundlers/shared/source-candidates/scan-root'
+
+const createdDirs: string[] = []
 
 describe('source candidate eligibility', () => {
+  afterEach(async () => {
+    await Promise.all(createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+  })
+
+  it('uses scanner file identities to exclude gitignored transformed modules', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-source-eligibility-'))
+    const sourceFile = path.join(root, 'src/App.vue')
+    const ignoredFile = path.join(root, 'ignored-by-gitignore.js')
+    createdDirs.push(root)
+    await mkdir(path.dirname(sourceFile), { recursive: true })
+    await writeFile(path.join(root, '.gitignore'), 'ignored-by-gitignore.js\n')
+    await writeFile(sourceFile, '<template><view class="text-green-500" /></template>')
+    await writeFile(ignoredFile, 'export const className = "text-red-500"')
+
+    const files = await resolveSourceCandidateScanFiles({
+      filter: () => true,
+      root,
+    })
+    const matches = createSourceCandidateEligibilityMatcher([{ root }], files)
+
+    expect(matches(sourceFile)).toBe(true)
+    expect(matches(ignoredFile)).toBe(false)
+  })
+
   it('applies Tailwind default ignores to implicit root scans', () => {
     const root = path.resolve('workspace/packages/app')
     const matches = createSourceCandidateEligibilityMatcher([{ root, outDir: 'dist' }])

--- a/packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -120,12 +120,14 @@ describe('vite framework source scan session', () => {
 
   it('keeps implicit transformed modules inside the source scan roots', async () => {
     const { appRoot, workspaceRoot } = await createTempWorkspace()
+    const appFile = path.join(appRoot, 'src/App.vue')
+    await mkdir(path.dirname(appFile), { recursive: true })
+    await writeFile(appFile, 'text-green-400')
     const extractor = vi.fn(async (source: string) => [source])
     const { session, sourceCandidateCollector } = createSession({ appRoot, extractor })
     await session.sync()
     extractor.mockClear()
 
-    const appFile = path.join(appRoot, 'src/App.vue')
     const dependencyFile = path.join(workspaceRoot, 'node_modules/monaco-editor/index.ts')
     await session.syncChangedFile(dependencyFile, 'text-blue-500')
     await session.syncChangedFile(appFile, 'text-green-500')
@@ -133,6 +135,34 @@ describe('vite framework source scan session', () => {
     expect(extractor).toHaveBeenCalledOnce()
     expect(extractor).toHaveBeenCalledWith('text-green-500', 'vue')
     expect(sourceCandidateCollector.values()).toEqual(new Set(['text-green-500']))
+  })
+
+  it('keeps gitignored modules out while accepting newly created source files', async () => {
+    const { appRoot } = await createTempWorkspace()
+    const ignoredFile = path.join(appRoot, 'ignored-by-gitignore.js')
+    const existingFile = path.join(appRoot, 'src/App.vue')
+    const newFile = path.join(appRoot, 'src/NewPage.vue')
+    await mkdir(path.dirname(existingFile), { recursive: true })
+    await writeFile(path.join(appRoot, '.gitignore'), 'ignored-by-gitignore.js\n')
+    await writeFile(ignoredFile, 'text-red-500')
+    await writeFile(existingFile, 'text-green-500')
+
+    const extractor = vi.fn(async (source: string) => [source])
+    const { session, sourceCandidateCollector } = createSession({ appRoot, extractor })
+    const resolveScanFiles = vi.spyOn(sourceCandidateCollector, 'resolveScanFiles')
+    await session.sync()
+    resolveScanFiles.mockClear()
+    extractor.mockClear()
+
+    await session.syncChangedFile(ignoredFile, 'text-red-500')
+    await session.syncChangedFile(ignoredFile, 'text-red-500')
+    await writeFile(newFile, 'text-sky-500')
+    await session.syncChangedFile(newFile, 'text-sky-500')
+
+    expect(resolveScanFiles).toHaveBeenCalledTimes(2)
+    expect(extractor).toHaveBeenCalledOnce()
+    expect(extractor).toHaveBeenCalledWith('text-sky-500', 'vue')
+    expect(sourceCandidateCollector.values()).toEqual(new Set(['text-green-500', 'text-sky-500']))
   })
 
   it('keeps explicitly configured dependency sources eligible outside the vite root', async () => {


### PR DESCRIPTION
## 问题

5.2.13 已阻止默认模式下 `node_modules` 重新进入 Vite source candidates，但初始 Oxide Scanner 与 transform/HMR 的资格判断仍有语义差异：Scanner 会遵循 `.gitignore`，增量 matcher 不会，因此被 `.gitignore` 排除但进入 Vite 模块图的文件仍可能污染 candidates。

## 修复

- 将 Oxide Scanner 实际解析出的文件 identity 作为隐式 source scan 的资格来源
- 初始扫描、Vite transform、watch/HMR 与扫描快照缓存复用同一组文件 identity
- 新增合法源码文件时只刷新 Scanner 文件发现，并继续支持 watch/HMR
- 显式 `@source` / `tailwindcss.v4.sources` 仍按 source entries 匹配，允许主动引入 Vite root 外的依赖
- 对未命中的文件增加扫描代际内负向缓存，并合并并发刷新，避免 ignored transform 重复触发文件发现
- 增加 patch changeset

## 验证

- `pnpm vitest run --project weapp-tailwindcss ...`：8 个相关测试文件，317 项通过
- `pnpm --filter weapp-tailwindcss build`
- `pnpm exec eslint --no-warn-ignored ...`
- `pnpm changeset status`
- `git diff --check`

Refs #1059