### PR TITLE
fix(website): satisfy Lynx SEO metadata gate

### DIFF
--- a/website/docs/quick-start/frameworks/lynx.md
+++ b/website/docs/quick-start/frameworks/lynx.md
@@ -5,6 +5,9 @@ keywords:
   - Lynx
   - ReactLynx
   - Rspeedy
+  - Rspack
+  - Lynx CSS
+  - 跨端开发
   - Tailwind CSS 4
   - weapp-tailwindcss
 ---

--- a/website/static/llms-index.json
+++ b/website/static/llms-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-12T08:20:02.270Z",
+  "generatedAt": "2026-08-13T04:52:38.610Z",
   "siteUrl": "https://tw.icebreaker.top",
   "totals": {
     "all": 167,
@@ -3554,6 +3554,9 @@
         "Lynx",
         "ReactLynx",
         "Rspeedy",
+        "Rspack",
+        "Lynx CSS",
+        "跨端开发",
         "Tailwind CSS 4",
         "weapp-tailwindcss",
         "快速开始",
@@ -3563,10 +3566,7 @@
         "frameworks",
         "tailwindcss",
         "小程序",
-        "微信小程序",
-        "uni-app",
-        "taro",
-        "mpx"
+        "微信小程序"
       ],
       "headings": [
         "安装",

--- a/website/static/seo-quality-report.json
+++ b/website/static/seo-quality-report.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-12T08:20:02.382Z",
+  "generatedAt": "2026-08-13T04:52:38.731Z",
   "totals": {
     "files": 167,
-    "issues": 1
+    "issues": 0
   },
   "coverage": {
     "docs": {
@@ -22,15 +22,6 @@
       "keywords": 1
     }
   },
-  "issueTypes": {
-    "few_keywords": 1
-  },
-  "issues": [
-    {
-      "type": "few_keywords",
-      "file": "quick-start/frameworks/lynx.md",
-      "message": "keywords 数量偏少（5）",
-      "scope": "docs"
-    }
-  ]
+  "issueTypes": {},
+  "issues": []
 }


### PR DESCRIPTION
## Summary

- 补齐 Lynx 快速开始页的 SEO keywords 至严格门禁要求
- 重新生成 GEO 索引与 SEO 质量报告，将存量问题归零

## Root cause

`website/docs/quick-start/frameworks/lynx.md` 只有 5 个关键词，而严格 SEO 门禁要求至少 8 个。website PR #1069 合并后触发了主分支独立门禁，因此暴露了该存量问题。

## Validation

- `pnpm --filter @weapp-tailwindcss/website seo:quality:strict`
- `pnpm --filter @weapp-tailwindcss/website typecheck`
- `pnpm --filter @weapp-tailwindcss/website build`

Related to #1069