### PR TITLE
fix(uni-app-x): support native local important styles

### DIFF
--- a/.changeset/fix-uni-app-x-native-important-apply.md
+++ b/.changeset/fix-uni-app-x-native-important-apply.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x 组件局部样式中的 Tailwind v4 后缀重要修饰符导致 Android、iOS App 的 SCSS 编译失败，并确保局部样式内的相对 `@reference` 按原始 `.uvue` 模块位置解析。

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -75,6 +75,8 @@ export interface AppCase {
   requiredFiles: string[]
   transformedFiles?: string[]
   transformedOutputFiles?: string[]
+  /** 热更新移除断言应限定到实际发生变更的产物，避免被其他入口的同值声明干扰。 */
+  hmrTransformedOutputFiles?: string[]
   transformedContains: Array<string | RegExp>
   compiledStyleContains?: Array<string | RegExp>
   transformedNotContains?: Array<string | RegExp>
@@ -600,6 +602,7 @@ export const uniAppXAppCases: AppCase[] = [
       'components/BindClass.uvue.ts',
       'pages/index/index.uvue.ts',
     ],
+    hmrTransformedOutputFiles: ['components/BindClass.uvue.ts'],
     transformedContains: ['hbuilderx-app-dynamic-v4-android'],
     compiledStyleContains: [
       'issue 822 component child',

--- a/e2e/hbuilderx-local/runner.ts
+++ b/e2e/hbuilderx-local/runner.ts
@@ -228,6 +228,17 @@ async function readExistingAppTransformedOutput(projectRoot: string, outputRoot:
   return (await Promise.all(transformedFiles.map(readUtf8))).join('\n')
 }
 
+async function readExistingAppHmrTransformedOutput(projectRoot: string, outputRoot: string, item: AppCase) {
+  if (!item.hmrTransformedOutputFiles?.length) {
+    return readExistingAppTransformedOutput(projectRoot, outputRoot, item)
+  }
+  const transformedFiles = item.hmrTransformedOutputFiles.map(file => path.resolve(outputRoot, file))
+  if (!(await Promise.all(transformedFiles.map(fileExists))).every(Boolean)) {
+    return undefined
+  }
+  return (await Promise.all(transformedFiles.map(readUtf8))).join('\n')
+}
+
 async function readExistingAppStyleOutput(outputRoot: string, item: AppCase) {
   const styleFiles = resolveAppStyleOutputFiles(outputRoot, item)
   if (styleFiles.length === 0) {
@@ -275,7 +286,10 @@ async function waitForAppTransformedContent(
           continue
         }
       }
-      if (!hasNoContent(transformed, forbidden)) {
+      const forbiddenScope = forbidden?.length
+        ? await readExistingAppHmrTransformedOutput(projectRoot, outputRoot, item)
+        : transformed
+      if (forbiddenScope == null || !hasNoContent(forbiddenScope, forbidden)) {
         continue
       }
       return outputRoot

--- a/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
@@ -48,6 +48,13 @@ function createAlias(fileId: string, utility: string, index: number) {
   return `wtu-${createStableHash(`${fileId}:${utility}`)}-${index.toString(36)}`
 }
 
+function serializeApplyUtility(utility: string) {
+  if (!utility.endsWith('!') || utility.endsWith('\\!')) {
+    return utility
+  }
+  return `${utility.slice(0, -1)}#{'!'}`
+}
+
 function isRuntimeCandidate(candidate: string, runtimeSet?: Set<string>) {
   if (!runtimeSet || runtimeSet.size === 0) {
     return false
@@ -299,7 +306,7 @@ export class UniAppXComponentLocalStyleCollector {
         ? `.${alias}, :deep(.${alias})`
         : `.${alias}`
       lines.push(`${selector} {`)
-      lines.push(`  @apply ${utility};`)
+      lines.push(`  @apply ${serializeApplyUtility(utility)};`)
       lines.push('}')
     }
     return `${lines.join('\n')}\n`

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
@@ -35,7 +35,7 @@ import { retainUniAppXAuthorApplyCss } from './vite/author-apply'
 import { createUniAppXHarmonyApplyExpander } from './vite/harmony-apply'
 import { createUniAppXNativeHmrReloader } from './vite/native-hmr'
 import { createUniAppXNativeBuildTargetResolver } from './vite/native-target'
-import { isCssModuleExport, resolvePreprocessorTransform, resolveUniAppXCssTarget } from './vite/style-request'
+import { isCssModuleExport, normalizeRelativeTailwindReferences, resolvePreprocessorTransform, resolveUniAppXCssTarget } from './vite/style-request'
 import { createUniAppXWebLocalStyleBridge } from './vite/web-local-style'
 
 type TransformUVue = typeof import('./transform')['transformUVue']
@@ -168,22 +168,23 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       if (isCssModuleExport(code)) {
         return
       }
-      const hasTailwindRoot = hasTailwindRootDirectives(code, { importFallback: true })
-      const hasTailwindApply = hasTailwindApplyDirective(code)
+      const sourceCode = normalizeRelativeTailwindReferences(code, id)
+      const hasTailwindRoot = hasTailwindRootDirectives(sourceCode, { importFallback: true })
+      const hasTailwindApply = hasTailwindApplyDirective(sourceCode)
       const shouldGenerateCss = hasTailwindRoot || hasTailwindApply
       const isNativeSfcAuthorStyle = isNativeStyle && resolveUniAppXCssTarget(id) === 'uvue'
       if (!shouldGenerateCss && (!isNativeStyle || isNativeSfcAuthorStyle)) {
         return
       }
-      harmonyApply.rememberSource(code, id)
+      harmonyApply.rememberSource(sourceCode, id)
       const generatedCss = (
         shouldGenerateCss
       )
         ? await generateCss?.(
             id,
             isNativeSfcAuthorStyle && hasTailwindApply && !hasTailwindRoot
-              ? harmonyApply.prepareStyles(code, id)
-              : code,
+              ? harmonyApply.prepareStyles(sourceCode, id)
+              : sourceCode,
             {
               ...hookContext,
               disableSourceScan: isNativeSfcAuthorStyle && hasTailwindApply && !hasTailwindRoot,
@@ -194,9 +195,9 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
         : undefined
       const styleCode = typeof generatedCss === 'string' && generatedCss.trim().length > 0
         ? hasTailwindApply && !hasTailwindRoot
-          ? retainUniAppXAuthorApplyCss(generatedCss, code)
+          ? retainUniAppXAuthorApplyCss(generatedCss, sourceCode)
           : generatedCss
-        : code
+        : sourceCode
       const styleHandlerOptions = getStyleHandlerOptions(
         id,
         isNativeStyle && hasTailwindRoot ? 'tailwind-root' : isNativeStyle ? 'author-apply' : undefined,

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite/style-request.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite/style-request.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { normalizeTailwindcssV4InfinityCalcCss } from '@weapp-tailwindcss/postcss'
 import { cleanUrl } from '@/bundlers/vite/utils'
 
@@ -6,6 +7,8 @@ const INLINE_LANG_RE = /lang\.([a-z]+)/i
 const PREPROCESSOR_EXT_RE = /\.(?:scss|sass|less|styl|stylus)(?:\?|$)/i
 const UVUE_NVUE_RE = /\.(?:uvue|nvue)$/
 const CSS_MODULE_EXPORT_RE = /^\s*export\s+default\s+(?:\{|\w|\[\])/
+const RELATIVE_REFERENCE_RE = /@reference\s+(["'])(\.\.?[\\/][^"']+)\1\s*;?/g
+const WINDOWS_ABSOLUTE_PATH_RE = /^[a-z]:[\\/]/i
 
 export function isPreprocessorRequest(id: string, lang?: string): boolean {
   const normalizedLang = lang?.toLowerCase()
@@ -26,6 +29,19 @@ export function resolveUniAppXCssTarget(id: string) {
 
 export function isCssModuleExport(code: string) {
   return CSS_MODULE_EXPORT_RE.test(code)
+}
+
+export function normalizeRelativeTailwindReferences(code: string, id: string) {
+  if (!code.includes('@reference')) {
+    return code
+  }
+  const sourceFile = cleanUrl(id)
+  const pathApi = WINDOWS_ABSOLUTE_PATH_RE.test(sourceFile) ? path.win32 : path
+  const sourceDir = pathApi.dirname(sourceFile)
+  return code.replace(RELATIVE_REFERENCE_RE, (_full, quote: string, request: string) => {
+    const resolved = pathApi.resolve(sourceDir, request).replace(/\\/g, '/')
+    return `@reference ${quote}${resolved}${quote};`
+  })
 }
 
 interface ResolvePreprocessorTransformOptions {

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -17,7 +17,12 @@ function extractInjectedStyle(code: string) {
 
 function extractAliasByUtility(styleBlock: string) {
   const entries = [...styleBlock.matchAll(/\.([A-Za-z0-9-]+)(?:, :deep\(\.[A-Za-z0-9-]+\))? \{\n  @apply ([^;]+);/g)]
-  return new Map(entries.map(match => [match[2], match[1]]))
+  return new Map(entries.map((match) => {
+    const utility = match[2].endsWith("#{'!'}")
+      ? `${match[2].slice(0, -"#{'!'}".length)}!`
+      : match[2]
+    return [utility, match[1]]
+  }))
 }
 
 describe('uni-app-x', () => {
@@ -213,8 +218,10 @@ const condition = true
     const aliasByUtility = extractAliasByUtility(styleBlock)
     for (const utility of runtimeSet) {
       expect(aliasByUtility.get(utility), utility).toBeTruthy()
-      expect(styleBlock).toContain(`@apply ${utility};`)
     }
+    expect(styleBlock).toContain("@apply w-[100rpx]#{'!'};")
+    expect(styleBlock).not.toContain('@apply w-[100rpx]!;')
+    expect(styleBlock).toContain('@apply h-[100rpx];')
     expect(result?.code).toContain(`leftClass="${aliasByUtility.get('bg-primary')} ${aliasByUtility.get('w-[100rpx]!')}"`)
     expect(result?.code).toContain(aliasByUtility.get('px-[30rpx]')!)
     expect(result?.code).toContain(`class="${aliasByUtility.get('w-[100rpx]!')} ${aliasByUtility.get('h-[100rpx]')} ${aliasByUtility.get('rounded-[10rpx]')}"`)

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite-style-request.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite-style-request.test.ts
@@ -1,0 +1,26 @@
+import { normalizeRelativeTailwindReferences } from '@/uni-app-x/vite/style-request'
+
+describe('uni-app-x vite style request', () => {
+  it('resolves relative Tailwind references from the source SFC', () => {
+    expect(normalizeRelativeTailwindReferences(
+      '@reference "../../main.css";\n.card { @apply flex; }',
+      '/project/pages/index/index.uvue?vue&type=style&index=0&lang.scss',
+    )).toContain('@reference "/project/main.css";')
+  })
+
+  it('normalizes Windows source paths as module ids', () => {
+    expect(normalizeRelativeTailwindReferences(
+      '@reference "..\\..\\main.css";',
+      'C:\\project\\pages\\index\\index.uvue?vue&type=style',
+    )).toBe('@reference "C:/project/main.css";')
+  })
+
+  it('preserves package, import-map, and absolute references', () => {
+    const source = [
+      '@reference "tailwindcss";',
+      '@reference "#theme";',
+      '@reference "/project/main.css";',
+    ].join('\n')
+    expect(normalizeRelativeTailwindReferences(source, '/project/pages/index.uvue')).toBe(source)
+  })
+})


### PR DESCRIPTION
## Summary

- serialize Tailwind v4 suffix-important utilities through SCSS without losing the `!` modifier
- resolve relative `@reference` directives from the originating `.uvue` module
- scope native HMR removal assertions to the transformed component under test

## Validation

- Android Emulator (Pixel 5, API 30): initial runtime plus six HMR mutations passed with screenshot/pixel assertions
- iOS Simulator (iPhone 17 Pro, iOS 26.5): launch/runtime and HMR passed; simulator screenshot visually verified
- `pnpm --filter weapp-tailwindcss test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter weapp-tailwindcss build`