### PR TITLE
feat(website): add package manager tab logos

### DIFF
--- a/website/src/css/custom/_docs.scss
+++ b/website/src/css/custom/_docs.scss
@@ -75,6 +75,27 @@ html.docs-wrapper .theme-doc-markdown .theme-admonition {
   max-width: none;
 }
 
+html.docs-wrapper .package-manager-tab__label {
+  display: inline-flex;
+  min-width: max-content;
+  align-items: center;
+  gap: 0.45rem;
+  white-space: nowrap;
+}
+
+html.docs-wrapper .package-manager-tab__label > i {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: 0 0 1.125rem;
+}
+
+@media (width <= 480px) {
+  html.docs-wrapper .package-manager-tabs > .tabs__item {
+    padding-right: 0.55rem;
+    padding-left: 0.55rem;
+  }
+}
+
 html.docs-wrapper .theme-doc-markdown > h1:first-child,
 html.docs-wrapper .theme-doc-markdown header h1 {
   max-width: 82ch;

--- a/website/src/theme/Tabs/index.tsx
+++ b/website/src/theme/Tabs/index.tsx
@@ -1,0 +1,56 @@
+import type { Props } from '@theme/Tabs'
+import type { ReactElement, ReactNode } from 'react'
+
+import OriginalTabs from '@theme-original/Tabs'
+import clsx from 'clsx'
+import React, { Children, cloneElement, isValidElement } from 'react'
+
+const packageManagerIcons = {
+  npm: 'icon-[logos--npm-icon]',
+  yarn: 'icon-[logos--yarn]',
+  pnpm: 'icon-[logos--pnpm]',
+  bun: 'icon-[logos--bun]',
+} as const
+
+interface TabItemProps {
+  label?: ReactNode
+  value: string
+}
+
+function PackageManagerLabel({ label, value }: Required<TabItemProps>) {
+  const iconClassName = packageManagerIcons[value as keyof typeof packageManagerIcons]
+
+  if (!iconClassName) {
+    return label
+  }
+
+  return (
+    <span className="package-manager-tab__label">
+      <i aria-hidden="true" className={iconClassName}></i>
+      <span>{label}</span>
+    </span>
+  )
+}
+
+export default function Tabs(props: Props): ReactNode {
+  if (props.groupId !== 'npm2yarn') {
+    return <OriginalTabs {...props} />
+  }
+
+  const children = Children.map(props.children, (child) => {
+    if (!isValidElement<TabItemProps>(child)) {
+      return child
+    }
+
+    const label = child.props.label ?? child.props.value
+    return cloneElement(child as ReactElement<TabItemProps>, {
+      label: <PackageManagerLabel label={label} value={child.props.value} />,
+    })
+  })
+
+  return (
+    <OriginalTabs {...props} className={clsx(props.className, 'package-manager-tabs')}>
+      {children}
+    </OriginalTabs>
+  )
+}

--- a/website/tests/framework-sidebar.spec.ts
+++ b/website/tests/framework-sidebar.spec.ts
@@ -25,6 +25,48 @@ async function expandCategory(page: Parameters<typeof test>[0]['page'], name: st
 }
 
 for (const route of ['/docs/quick-start/install', '/en/docs/quick-start/install']) {
+  test(`${route} renders package manager logos and keeps tabs interactive`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto(new URL(route, baseURL).toString(), { waitUntil: 'networkidle' })
+
+    const tabs = page.locator('.theme-tabs-container').first()
+    const expectedTabs = [
+      { name: 'npm', icon: 'logos--npm-icon' },
+      { name: 'Yarn', icon: 'logos--yarn' },
+      { name: 'pnpm', icon: 'logos--pnpm' },
+      { name: 'Bun', icon: 'logos--bun' },
+    ] as const
+
+    for (const { icon, name } of expectedTabs) {
+      const tab = tabs.getByRole('tab', { name, exact: true })
+      const logo = tab.locator(`[class~="icon-[${icon}]"]`)
+      await expect(tab).toBeVisible()
+      await expect(logo).toHaveCount(1)
+
+      const style = await logo.evaluate((element) => {
+        const computedStyle = getComputedStyle(element)
+        const box = element.getBoundingClientRect()
+        return {
+          backgroundImage: computedStyle.backgroundImage,
+          height: box.height,
+          maskImage: computedStyle.maskImage,
+          width: box.width,
+        }
+      })
+
+      expect(style.backgroundImage !== 'none' || style.maskImage !== 'none').toBe(true)
+      expect(style.width).toBeCloseTo(18, 0)
+      expect(style.height).toBeCloseTo(18, 0)
+    }
+
+    const tabList = tabs.getByRole('tablist')
+    expect(await tabList.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true)
+
+    await tabs.getByRole('tab', { name: 'pnpm', exact: true }).click()
+    await expect(tabs.getByRole('tab', { name: 'pnpm', exact: true })).toHaveAttribute('aria-selected', 'true')
+    await expect(tabs.getByRole('tabpanel')).toContainText('pnpm add')
+  })
+
   test(`${route} renders framework logos for every setup item`, async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 1000 })
     await page.goto(new URL(route, baseURL).toString(), { waitUntil: 'networkidle' })


### PR DESCRIPTION
## 变更内容

- 为 npm2yarn 生成的 npm、Yarn、pnpm、Bun 标签增加对应品牌 Logo
- 保留 Docusaurus 原生 Tabs 的键盘导航、同步选择与 SSR 行为
- 收紧移动端标签间距，390px 视口无横向溢出
- 覆盖中英文安装页的图标渲染与标签切换回归

## 验证

- `pnpm --filter @weapp-tailwindcss/website typecheck`
- `pnpm --filter @weapp-tailwindcss/website build`
- 定向 ESLint
- Chromium 中英文 Playwright 回归：2 项通过
- 深浅色与 390px 移动端截图检查