### PR TITLE
docs: fix broken star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ npx skills add sonofmagic/skills --skill weapp-tailwindcss
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sonofmagic/weapp-tailwindcss&type=Date)](https://star-history.com/#sonofmagic/weapp-tailwindcss&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sonofmagic/weapp-tailwindcss&type=Date)](https://star-history.dera.page/#sonofmagic/weapp-tailwindcss&Date)

--- a/README_en.md
+++ b/README_en.md
@@ -125,4 +125,4 @@ Before contributing, read the repository `AGENTS.md` and the closest `AGENTS.md`
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=sonofmagic/weapp-tailwindcss&type=Date)](https://star-history.com/#sonofmagic/weapp-tailwindcss&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sonofmagic/weapp-tailwindcss&type=Date)](https://star-history.dera.page/#sonofmagic/weapp-tailwindcss&Date)


### PR DESCRIPTION
The current star history charts are broken because the underlying GitHub stargazer API is unreliable. This change points the charts to a working alternative so visitors can again see the project's star history.