### PR TITLE
chore(packages): refresh cross-platform descriptions

### DIFF
--- a/.changeset/bright-platforms-share.md
+++ b/.changeset/bright-platforms-share.md
@@ -1,0 +1,30 @@
+---
+'@weapp-tailwindcss/cli': patch
+'@weapp-tailwindcss/cva': patch
+'@weapp-tailwindcss/debug-uni-app-x': patch
+'@weapp-tailwindcss/experimental': patch
+'@weapp-tailwindcss/hbuilderx-runner': patch
+'@weapp-tailwindcss/init': patch
+'@weapp-tailwindcss/lynx': patch
+'@weapp-tailwindcss/logger': patch
+'@weapp-tailwindcss/merge': patch
+'@weapp-tailwindcss/postcss': patch
+'@weapp-tailwindcss/postcss-calc': patch
+'@weapp-tailwindcss/react-native': patch
+'@weapp-tailwindcss/reset': patch
+'@weapp-tailwindcss/runtime': patch
+'@weapp-tailwindcss/shared': patch
+'@weapp-tailwindcss/typography': patch
+'@weapp-tailwindcss/ui': patch
+'@weapp-tailwindcss/variants': patch
+'tailwindcss-config': patch
+'tailwindcss-core-plugins-extractor': patch
+'tailwindcss-injector': patch
+'theme-transition': patch
+'weapp-style-injector': patch
+'weapp-tailwindcss': patch
+'weapp-tw': patch
+'wetw': patch
+---
+
+统一更新各发布包的 npm 描述，明确 `weapp-tailwindcss` 面向 Web、小程序、React Native、Lynx 与跨端框架的全端 Tailwind CSS 定位，并保留各子包的具体职责边界。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">weapp-tailwindcss</h1>
 
 <p align="center">
-  <strong>把 Tailwind CSS 带到小程序与多端开发中。</strong>
+  <strong>Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！</strong>
 </p>
 
 <p align="center">
@@ -25,7 +25,7 @@
 
 ## 项目定位
 
-`weapp-tailwindcss` 是面向小程序生态的 Tailwind CSS 适配方案。它负责把 Tailwind CSS 生成的选择器、工具类和部分 CSS 能力转换成小程序与多端框架更容易消费的形式。
+`weapp-tailwindcss` 是面向全端场景的 Tailwind CSS 工具链。核心包负责 Web 与小程序的样式生成、类名转译和构建器适配，生态包进一步覆盖 React Native、Lynx、运行时类名工具与跨端 UI。
 
 它适合这些场景：
 
@@ -33,6 +33,7 @@
 - 在 `uni-app` / `uni-app x`、Taro、Mpx、原生小程序、weapp-vite 等框架里复用同一套原子化样式写法。
 - 在 Tailwind CSS v4 项目中处理小程序 class 转义、选择器兼容、rpx 任意值、CSS 降级和 H5/Web 输出差异。
 - 在多端项目中同时覆盖小程序、H5/Web 与 App WebView 等目标。
+- 通过 `@weapp-tailwindcss/react-native` 与 `@weapp-tailwindcss/lynx` 将同一套原子化开发体验扩展到 React Native 和 Lynx。
 
 ## 当前支持
 

--- a/README.md
+++ b/README.md
@@ -15,80 +15,151 @@
 </p>
 
 <p align="center">
+  <a href="https://tw.icebreaker.top">官网</a> ·
+  <a href="https://tw.icebreaker.top/docs/intro">文档</a> ·
+  <a href="https://tw.icebreaker.top/docs/quick-start/install">快速开始</a> ·
+  <a href="https://tw.icebreaker.top/docs/tools/weapp-tw-cli">CLI</a> ·
+  <a href="https://github.com/sonofmagic/weapp-tailwindcss/tree/main/demo">示例</a>
+</p>
+
+<p align="center">
   <a href="https://github.com/sonofmagic/weapp-tailwindcss/stargazers"><img src="https://badgen.net/github/stars/sonofmagic/weapp-tailwindcss" alt="GitHub stars"></a>
   <a href="https://www.npmjs.com/package/weapp-tailwindcss"><img src="https://badgen.net/npm/dm/weapp-tailwindcss" alt="npm downloads"></a>
   <a href="https://www.npmjs.com/package/weapp-tailwindcss"><img src="https://badgen.net/npm/license/weapp-tailwindcss" alt="license"></a>
   <a href="https://github.com/sonofmagic/weapp-tailwindcss/actions/workflows/ci.yml"><img src="https://github.com/sonofmagic/weapp-tailwindcss/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://codecov.io/gh/sonofmagic/weapp-tailwindcss"><img src="https://codecov.io/gh/sonofmagic/weapp-tailwindcss/branch/main/graph/badge.svg?token=zn05qXYznt" alt="codecov"></a>
-  <a href="https://deepwiki.com/sonofmagic/weapp-tailwindcss"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+  <a href="https://deepwiki.com/sonofmagic/weapp-tailwindcss"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"></a>
 </p>
 
 ## 项目定位
 
-`weapp-tailwindcss` 是面向全端场景的 Tailwind CSS 工具链。核心包负责 Web 与小程序的样式生成、类名转译和构建器适配，生态包进一步覆盖 React Native、Lynx、运行时类名工具与跨端 UI。
+`weapp-tailwindcss` 是一套面向全端的 Tailwind CSS 工具链：用同一套原子化样式开发体验，覆盖 Web/H5、小程序、App WebView、React Native 和 Lynx。
 
-它适合这些场景：
+核心包负责 Tailwind CSS v4 的 CSS 生成、类名转译、平台兼容和构建器生命周期集成；平台包与运行时包负责把这套能力延伸到不同的渲染器和应用框架。
 
-- 在微信小程序、支付宝小程序、抖音小程序等小程序环境中使用 Tailwind CSS。
-- 在 `uni-app` / `uni-app x`、Taro、Mpx、原生小程序、weapp-vite 等框架里复用同一套原子化样式写法。
-- 在 Tailwind CSS v4 项目中处理小程序 class 转义、选择器兼容、rpx 任意值、CSS 降级和 H5/Web 输出差异。
-- 在多端项目中同时覆盖小程序、H5/Web 与 App WebView 等目标。
-- 通过 `@weapp-tailwindcss/react-native` 与 `@weapp-tailwindcss/lynx` 将同一套原子化开发体验扩展到 React Native 和 Lynx。
+它解决的是“同一套 Tailwind 输入，按目标端生成正确产物”的问题，而不是为每个平台维护一套互不相干的 class 规则。
 
-## 当前支持
+## 支持范围
 
-| 能力         | 说明                                                                          |
-| ------------ | ----------------------------------------------------------------------------- |
-| Tailwind CSS | 支持 Tailwind CSS v4                                                          |
-| 构建工具     | 支持 Vite、Webpack 5、Rspack、Rollup、Rolldown、Gulp 与 Node API              |
-| 框架         | 支持 uni-app / uni-app x、Taro、Mpx、原生小程序、weapp-vite 等接入方式        |
-| 多端输出     | 覆盖小程序、H5/Web 与 App WebView 等平台差异                                  |
-| 运行时生态   | 提供 merge、variants、cva、runtime、typography、theme-transition、ui 等配套包 |
-| Node.js      | `weapp-tailwindcss@5.2.0` 起需要 Node.js `>=22.12.0`                           |
+| 目标端 | 推荐入口 | 适用场景 |
+| --- | --- | --- |
+| Web / H5 | `weapp-tailwindcss/vite`、`/webpack`、`/rspack`、`/gulp` 或 Node API | 浏览器 CSS、H5 和普通 Web 构建 |
+| 小程序 | 对应构建器入口，或 `@weapp-tailwindcss/cli --target weapp` | 微信、支付宝、抖音、QQ 等小程序 CSS |
+| App WebView | `weapp-tailwindcss` 的框架集成 | uni-app、Taro 等框架的 App WebView 构建 |
+| uni-app x | `weapp-tailwindcss/vite` | Android、iOS 与 HarmonyOS 原生应用构建 |
+| React Native / Expo | `@weapp-tailwindcss/react-native` | Metro、Babel 和 React Native style manifest |
+| ReactLynx / Rspeedy | `@weapp-tailwindcss/lynx` | Lynx 普通 CSS 与 Rspeedy 构建 |
 
-从 `weapp-tailwindcss@5.2.0` 开始，Node.js 最低版本提升到 `22.12.0`，该版本默认支持从 CommonJS 加载 ESM。使用 HBuilderX 的 `uni-app` / `uni-app x` 项目还需要升级到 HBuilderX `5.11` 或更高版本，避免 IDE 内置 Node 无法加载 ESM 依赖。
+当前主线维护 Tailwind CSS v4。平台集成会复用核心 generator，但各目标端仍需以真实运行时支持的 CSS 属性和选择器为准。
 
-## 官方文档
+## 快速开始
 
-- [官网首页](https://tw.icebreaker.top)
-- [快速开始](https://tw.icebreaker.top/docs/quick-start/install)
-- [Tailwind CSS v4 接入](https://tw.icebreaker.top/docs/quick-start/v4)
-- [框架接入指南](https://tw.icebreaker.top/docs/quick-start/frameworks/uni-app-vite)
-- [uni-app x 专题](https://tw.icebreaker.top/docs/uni-app-x)
-- [多端配置口径](https://tw.icebreaker.top/docs/multi-platform)
-- [配置项参考](https://tw.icebreaker.top/docs/api/interfaces/UserDefinedOptions)
-- [常见问题](https://tw.icebreaker.top/docs/issues)
+### 1. 安装 Tailwind CSS 与核心包
+
+```bash
+pnpm add -D tailwindcss weapp-tailwindcss
+```
+
+### 2. 创建 CSS-first 入口
+
+```css
+@import "tailwindcss";
+
+@source "./**/*.{html,js,ts,jsx,tsx,vue}";
+@source not "../node_modules";
+@source not "../dist";
+```
+
+入口文件必须被项目实际引入；`cssEntries` 只用于让生成器稳定识别 Tailwind 入口，不会替代 bundler 的模块图。
+
+### 3. 注册构建器插件
+
+以 Vite 为例，先注册框架插件，再注册 `WeappTailwindcss`：
+
+```ts
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { WeappTailwindcss } from 'weapp-tailwindcss/vite'
+
+const projectRoot = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [
+    // 先放你的框架插件，例如 uni()。
+    WeappTailwindcss({
+      cssEntries: [resolve(projectRoot, 'src/app.css')],
+      cssOptions: {
+        rem2rpx: true,
+      },
+    }),
+  ],
+})
+```
+
+Webpack、Rspack、Gulp、Taro、uni-app、Mpx 和原生小程序的完整配置见[框架接入指南](https://tw.icebreaker.top/docs/quick-start/frameworks/uni-app-vite)。
+
+## CLI
+
+需要独立 CSS 构建、watch 或 canonicalize 时，安装 `@weapp-tailwindcss/cli`：
+
+```bash
+pnpm add -D @weapp-tailwindcss/cli weapp-tailwindcss tailwindcss
+
+# 默认生成 Web CSS
+pnpm exec weapp-tw -i src/app.css -o dist/output.css
+
+# 显式生成小程序兼容 CSS
+pnpm exec weapp-tw -i src/app.css -o dist/app.wxss --target weapp
+```
+
+CLI 默认目标是 `web`，支持 stdin/stdout、watch、原生 watcher、`--poll`、minify、optimize、source map 和 `canonicalize`。`--target weapp` 是 CSS-only 转换：不会扫描或改写 WXML、JS、TS、JSX、TSX，也不会替代完整项目的构建器集成。
+
+完整参数表见 [weapp-tw CLI 文档](https://tw.icebreaker.top/docs/tools/weapp-tw-cli)。
+
+## 选择正确的包
+
+| 需求 | 包 |
+| --- | --- |
+| Tailwind CSS 生成、类名转译和构建器接入 | `weapp-tailwindcss` |
+| 独立 CSS CLI、watch 和 canonicalize | `@weapp-tailwindcss/cli` |
+| PostCSS AST、选择器兼容和 CSS 平台转换 | `@weapp-tailwindcss/postcss` |
+| React Native / Expo 编译 | `@weapp-tailwindcss/react-native` |
+| ReactLynx / Rspeedy 集成 | `@weapp-tailwindcss/lynx` |
+| `twMerge`、`tv`、`cva` 等运行时 class 工具 | `@weapp-tailwindcss/runtime`、`@weapp-tailwindcss/merge`、`@weapp-tailwindcss/variants`、`@weapp-tailwindcss/cva` |
+| Typography、主题过渡和跨端 UI | `@weapp-tailwindcss/typography`、`theme-transition`、`@weapp-tailwindcss/ui` |
+
+## 重要边界
+
+- Tailwind CSS v4 的生成由 `weapp-tailwindcss` 接管。小程序构建中不要同时注册 `tailwindcss`、`@tailwindcss/postcss` 或 `@tailwindcss/vite` 作为第二套生成器。
+- JS/WXML 类名只转换 Tailwind generator 已确认生成的精确候选集合，不对普通业务字符串做启发式替换。
+- 构建器集成通过 Vite、Webpack、Rspack、Gulp 等生命周期 API 维护源码、样式、依赖和 watch 关系，不靠后置扫描项目目录补状态。
+- React Native、Lynx 和小程序的 CSS/样式能力并不等同于浏览器；不支持的属性、选择器和运行时能力应以目标端测试结果为准。
+
+## 环境要求
+
+- Node.js `>=22.12.0`
+- Tailwind CSS `>=4.0.0`
+- 使用 HBuilderX 的 `uni-app` / `uni-app x` 项目需要 HBuilderX `>=5.11`
+
+## 文档与示例
+
+- [官网](https://tw.icebreaker.top)
+- [安装与快速开始](https://tw.icebreaker.top/docs/quick-start/install)
+- [Tailwind CSS v4 指南](https://tw.icebreaker.top/docs/quick-start/v4)
+- [框架接入](https://tw.icebreaker.top/docs/quick-start/frameworks/uni-app-vite)
+- [React Native / Expo](https://tw.icebreaker.top/docs/quick-start/react-native-expo)
+- [ReactLynx / Rspeedy](https://tw.icebreaker.top/docs/quick-start/frameworks/lynx)
+- [多端配置](https://tw.icebreaker.top/docs/multi-platform)
+- [API 参考](https://tw.icebreaker.top/docs/api/interfaces/UserDefinedOptions)
+- [官方 CLI](https://tw.icebreaker.top/docs/tools/weapp-tw-cli)
+- [框架示例](https://github.com/sonofmagic/weapp-tailwindcss/tree/main/demo)
+- [React Native 与 Lynx 示例](https://github.com/sonofmagic/weapp-tailwindcss/tree/main/examples)
 - [备用文档地址](https://ice-tw.netlify.app/)
-
-## 核心包
-
-| 包                                | 用途                               |
-| --------------------------------- | ---------------------------------- |
-| `weapp-tailwindcss`               | 核心转译与构建器适配入口           |
-| `@weapp-tailwindcss/postcss`      | CSS AST 处理、选择器兼容与平台降级 |
-| `@weapp-tailwindcss/postcss-calc` | `calc()` 表达式安全归约            |
-| `@weapp-tailwindcss/reset`        | 小程序多框架 reset 样式资源        |
-| `tailwindcss-config`              | Tailwind CSS 配置加载              |
-| `tailwindcss-injector`            | Tailwind 指令注入与 WXML 依赖追踪  |
-| `weapp-style-injector`            | 小程序构建产物样式入口注入         |
-
-## 运行时与组件生态
-
-| 包                               | 用途                                                       |
-| -------------------------------- | ---------------------------------------------------------- |
-| `@weapp-tailwindcss/runtime`     | escape/unescape、缓存、rpx 转换等运行时基础能力            |
-| `@weapp-tailwindcss/merge`       | Tailwind Merge v3 的小程序运行时封装                       |
-| `@weapp-tailwindcss/variants`    | tailwind-variants 的小程序运行时封装                       |
-| `@weapp-tailwindcss/cva`         | class-variance-authority 的小程序运行时封装                |
-| `@weapp-tailwindcss/typography`  | Tailwind Typography 的小程序适配版本                       |
-| `theme-transition`               | 主题切换运行时与 Tailwind 插件                             |
-| `@weapp-tailwindcss/ui`          | 面向小程序的原子化 UI 运行时层                             |
-
-所有包的默认 `README.md` 都使用中文，并提供对应的 `README.en.md` 英文版本。
 
 ## AI Skill
 
-官方 Skill 已按任务拆分为接入、迁移、排障、运行时、自定义构建和 React Native 六个工作流，并保留 `weapp-tailwindcss` 兼容协调入口。推荐一次安装整套：
+官方 Skill 已按接入、迁移、排障、运行时、自定义构建和 React Native 拆分。推荐安装完整套件：
 
 ```bash
 npx skills add sonofmagic/skills \
@@ -102,7 +173,7 @@ npx skills add sonofmagic/skills \
   -y
 ```
 
-旧的单 Skill 安装命令仍然可用，并会负责识别任务与引导到专用 Skill：
+旧的单 Skill 命令仍然可用：
 
 ```bash
 npx skills add sonofmagic/skills --skill weapp-tailwindcss
@@ -110,15 +181,9 @@ npx skills add sonofmagic/skills --skill weapp-tailwindcss
 
 更多说明见 [Skill 文档](https://tw.icebreaker.top/docs/ai/basics/skill)。
 
-## 贡献
+## 参与贡献
 
-欢迎通过 issue 或 pull request 参与改进：
-
-- 报告可复现的问题。
-- 补充框架接入示例或文档。
-- 改进转译、兼容、运行时或测试覆盖。
-
-提交前请先阅读仓库内的 `AGENTS.md` 与目标目录下的就近规则。
+欢迎提交可复现 issue、框架接入示例、文档改进、转译修复和测试用例。提交前请阅读仓库根目录的 `AGENTS.md` 与目标目录下最近的 `AGENTS.md`，并使用 `pnpm` 完成本地验证。
 
 ## License
 

--- a/README_en.md
+++ b/README_en.md
@@ -15,80 +15,151 @@
 </p>
 
 <p align="center">
+  <a href="https://tw.icebreaker.top">Website</a> ·
+  <a href="https://tw.icebreaker.top/docs/intro">Docs</a> ·
+  <a href="https://tw.icebreaker.top/docs/quick-start/install">Quick Start</a> ·
+  <a href="https://tw.icebreaker.top/docs/tools/weapp-tw-cli">CLI</a> ·
+  <a href="https://github.com/sonofmagic/weapp-tailwindcss/tree/main/demo">Examples</a>
+</p>
+
+<p align="center">
   <a href="https://github.com/sonofmagic/weapp-tailwindcss/stargazers"><img src="https://badgen.net/github/stars/sonofmagic/weapp-tailwindcss" alt="GitHub stars"></a>
   <a href="https://www.npmjs.com/package/weapp-tailwindcss"><img src="https://badgen.net/npm/dm/weapp-tailwindcss" alt="npm downloads"></a>
   <a href="https://www.npmjs.com/package/weapp-tailwindcss"><img src="https://badgen.net/npm/license/weapp-tailwindcss" alt="license"></a>
   <a href="https://github.com/sonofmagic/weapp-tailwindcss/actions/workflows/ci.yml"><img src="https://github.com/sonofmagic/weapp-tailwindcss/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://codecov.io/gh/sonofmagic/weapp-tailwindcss"><img src="https://codecov.io/gh/sonofmagic/weapp-tailwindcss/branch/main/graph/badge.svg?token=zn05qXYznt" alt="codecov"></a>
-  <a href="https://deepwiki.com/sonofmagic/weapp-tailwindcss"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+  <a href="https://deepwiki.com/sonofmagic/weapp-tailwindcss"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"></a>
 </p>
 
 ## What It Is
 
-`weapp-tailwindcss` is a cross-platform Tailwind CSS toolchain. The core package owns Web and mini-program style generation, class transforms, and builder integrations, while ecosystem packages extend the same utility-first experience to React Native, Lynx, runtime class utilities, and cross-platform UI.
+`weapp-tailwindcss` is a cross-platform Tailwind CSS toolchain. It brings one utility-first development experience to Web/H5, mini programs, App WebViews, React Native, and Lynx.
 
-It is designed for:
+The core package owns Tailwind CSS v4 generation, class transforms, platform compatibility, and builder lifecycle integrations. Platform and runtime packages extend the same workflow to different renderers and application frameworks.
 
-- Using Tailwind CSS in WeChat, Alipay, Douyin, and other mini program environments.
-- Sharing atomic CSS conventions across `uni-app` / `uni-app x`, Taro, Mpx, native mini programs, weapp-vite, and related stacks.
-- Handling mini program class escaping, selector compatibility, rpx arbitrary values, CSS fallbacks, and H5/Web output differences in Tailwind CSS v4 projects.
-- Building multi-platform apps that target mini programs, H5/Web, and App WebViews.
-- Extending the same utility-first workflow to React Native and Lynx through `@weapp-tailwindcss/react-native` and `@weapp-tailwindcss/lynx`.
+The goal is simple: use one Tailwind input and generate the correct artifact for each target, instead of maintaining disconnected class rules for every platform.
 
-## Current Support
+## Support Matrix
 
-| Area              | Support                                                                                    |
-| ----------------- | ------------------------------------------------------------------------------------------ |
-| Tailwind CSS      | Tailwind CSS v4                                                                            |
-| Build tools       | Vite, Webpack 5, Rspack, Rollup, Rolldown, Gulp, and Node API                              |
-| Frameworks        | uni-app / uni-app x, Taro, Mpx, native mini programs, weapp-vite, and related integrations |
-| Output targets    | Mini programs, H5/Web, App WebView, and related platform differences                       |
-| Runtime ecosystem | merge, variants, cva, runtime, typography, theme-transition, ui, and related packages      |
-| Node.js           | Node.js `>=22.12.0` is required starting with `weapp-tailwindcss@5.2.0`                    |
+| Target | Recommended entry | Use it for |
+| --- | --- | --- |
+| Web / H5 | `weapp-tailwindcss/vite`, `/webpack`, `/rspack`, `/gulp`, or the Node API | Browser CSS, H5, and regular Web builds |
+| Mini programs | The matching builder entry, or `@weapp-tailwindcss/cli --target weapp` | WeChat, Alipay, Douyin, QQ, and other mini-program CSS |
+| App WebView | `weapp-tailwindcss` framework integrations | App WebView builds from frameworks such as uni-app and Taro |
+| uni-app x | `weapp-tailwindcss/vite` | Native Android, iOS, and HarmonyOS application builds |
+| React Native / Expo | `@weapp-tailwindcss/react-native` | Metro, Babel, and React Native style manifests |
+| ReactLynx / Rspeedy | `@weapp-tailwindcss/lynx` | Lynx CSS and Rspeedy builds |
 
-Starting with `weapp-tailwindcss@5.2.0`, the minimum Node.js version is `22.12.0`, where loading ESM from CommonJS is enabled by default. Projects using HBuilderX with `uni-app` or `uni-app x` must also upgrade to HBuilderX `5.11` or later so the IDE runtime can load ESM dependencies correctly.
+The current mainline targets Tailwind CSS v4. Each integration reuses the core generator, while CSS properties and selectors still need to be verified against the real target runtime.
 
-## Documentation
+## Quick Start
+
+### 1. Install Tailwind CSS and the core package
+
+```bash
+pnpm add -D tailwindcss weapp-tailwindcss
+```
+
+### 2. Create a CSS-first entry
+
+```css
+@import "tailwindcss";
+
+@source "./**/*.{html,js,ts,jsx,tsx,vue}";
+@source not "../node_modules";
+@source not "../dist";
+```
+
+The entry must be imported by the project. `cssEntries` tells the generator which Tailwind entry to track; it does not replace the bundler module graph.
+
+### 3. Register the builder integration
+
+With Vite, register the framework plugin first and `WeappTailwindcss` after it:
+
+```ts
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { WeappTailwindcss } from 'weapp-tailwindcss/vite'
+
+const projectRoot = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [
+    // Put your framework plugin here first, for example uni().
+    WeappTailwindcss({
+      cssEntries: [resolve(projectRoot, 'src/app.css')],
+      cssOptions: {
+        rem2rpx: true,
+      },
+    }),
+  ],
+})
+```
+
+See the [framework integration guides](https://tw.icebreaker.top/docs/quick-start/frameworks/uni-app-vite) for Webpack, Rspack, Gulp, Taro, uni-app, Mpx, and native mini-program projects.
+
+## CLI
+
+For standalone CSS builds, watch mode, or canonicalization, install `@weapp-tailwindcss/cli`:
+
+```bash
+pnpm add -D @weapp-tailwindcss/cli weapp-tailwindcss tailwindcss
+
+# Generate Web CSS by default
+pnpm exec weapp-tw -i src/app.css -o dist/output.css
+
+# Explicitly generate mini-program-compatible CSS
+pnpm exec weapp-tw -i src/app.css -o dist/app.wxss --target weapp
+```
+
+The CLI defaults to `web` and supports stdin/stdout, watch mode, native watchers, `--poll`, minify, optimize, source maps, and `canonicalize`. `--target weapp` is CSS-only: it does not scan or rewrite WXML, JS, TS, JSX, or TSX, and it does not replace a full project builder integration.
+
+See the complete [weapp-tw CLI guide](https://tw.icebreaker.top/docs/tools/weapp-tw-cli) for all options and compatibility commands.
+
+## Choose The Right Package
+
+| Need | Package |
+| --- | --- |
+| Tailwind CSS generation, class transforms, and builder integrations | `weapp-tailwindcss` |
+| Standalone CSS CLI, watch, and canonicalize | `@weapp-tailwindcss/cli` |
+| PostCSS AST transforms, selector compatibility, and CSS platform transforms | `@weapp-tailwindcss/postcss` |
+| React Native / Expo compilation | `@weapp-tailwindcss/react-native` |
+| ReactLynx / Rspeedy integration | `@weapp-tailwindcss/lynx` |
+| Runtime `twMerge`, `tv`, and `cva` utilities | `@weapp-tailwindcss/runtime`, `@weapp-tailwindcss/merge`, `@weapp-tailwindcss/variants`, `@weapp-tailwindcss/cva` |
+| Typography, theme transitions, and cross-platform UI | `@weapp-tailwindcss/typography`, `theme-transition`, `@weapp-tailwindcss/ui` |
+
+## Important Boundaries
+
+- Tailwind CSS v4 generation is owned by `weapp-tailwindcss`. Do not register `tailwindcss`, `@tailwindcss/postcss`, or `@tailwindcss/vite` as a second generator in mini-program builds.
+- JS and WXML classes are transformed only when they belong to the exact candidate set confirmed by the Tailwind generator. Ordinary business strings are not rewritten heuristically.
+- Builder integrations use Vite, Webpack, Rspack, and Gulp lifecycle APIs to preserve source, style, dependency, and watch relationships instead of reconstructing state from a post-build directory scan.
+- React Native, Lynx, and mini-program CSS capabilities are not identical to browser CSS. Validate unsupported properties, selectors, and runtime behavior on the actual target.
+
+## Requirements
+
+- Node.js `>=22.12.0`
+- Tailwind CSS `>=4.0.0`
+- HBuilderX `>=5.11` for `uni-app` / `uni-app x` projects using HBuilderX
+
+## Documentation And Examples
 
 - [Official website](https://tw.icebreaker.top)
-- [Quick start](https://tw.icebreaker.top/docs/quick-start/install)
-- [Tailwind CSS v4 setup](https://tw.icebreaker.top/docs/quick-start/v4)
-- [Framework integration](https://tw.icebreaker.top/docs/quick-start/frameworks/uni-app-vite)
-- [uni-app x guide](https://tw.icebreaker.top/docs/uni-app-x)
+- [Install and quick start](https://tw.icebreaker.top/docs/quick-start/install)
+- [Tailwind CSS v4 guide](https://tw.icebreaker.top/docs/quick-start/v4)
+- [Framework integrations](https://tw.icebreaker.top/docs/quick-start/frameworks/uni-app-vite)
+- [React Native / Expo](https://tw.icebreaker.top/docs/quick-start/react-native-expo)
+- [ReactLynx / Rspeedy](https://tw.icebreaker.top/docs/quick-start/frameworks/lynx)
 - [Multi-platform guide](https://tw.icebreaker.top/docs/multi-platform)
-- [Configuration reference](https://tw.icebreaker.top/docs/api/interfaces/UserDefinedOptions)
-- [FAQ](https://tw.icebreaker.top/docs/issues)
+- [API reference](https://tw.icebreaker.top/docs/api/interfaces/UserDefinedOptions)
+- [CLI guide](https://tw.icebreaker.top/docs/tools/weapp-tw-cli)
+- [Framework examples](https://github.com/sonofmagic/weapp-tailwindcss/tree/main/demo)
+- [React Native and Lynx examples](https://github.com/sonofmagic/weapp-tailwindcss/tree/main/examples)
 - [Mirror documentation](https://ice-tw.netlify.app/)
 
-## Core Packages
+## AI Skills
 
-| Package                           | Purpose                                                            |
-| --------------------------------- | ------------------------------------------------------------------ |
-| `weapp-tailwindcss`               | Core transform and bundler integration entry                       |
-| `@weapp-tailwindcss/postcss`      | CSS AST processing, selector compatibility, and platform fallbacks |
-| `@weapp-tailwindcss/postcss-calc` | Safe reduction for `calc()` expressions                            |
-| `@weapp-tailwindcss/reset`        | Reset stylesheet assets for mini program frameworks                |
-| `tailwindcss-config`              | Tailwind CSS config loading                                        |
-| `tailwindcss-injector`            | Tailwind directive injection and WXML dependency tracking          |
-| `weapp-style-injector`            | Style entry injection for mini program build artifacts             |
-
-## Runtime And UI Ecosystem
-
-| Package                          | Purpose                                                                       |
-| -------------------------------- | ----------------------------------------------------------------------------- |
-| `@weapp-tailwindcss/runtime`     | Shared runtime layer for escape/unescape, caching, and rpx transforms         |
-| `@weapp-tailwindcss/merge`       | Mini program runtime wrapper for Tailwind Merge v3                            |
-| `@weapp-tailwindcss/variants`    | Mini program runtime wrapper for tailwind-variants                            |
-| `@weapp-tailwindcss/cva`         | Mini program runtime wrapper for class-variance-authority                     |
-| `@weapp-tailwindcss/typography`  | Mini program adapted version of Tailwind Typography                           |
-| `theme-transition`               | Theme transition runtime and Tailwind plugin                                  |
-| `@weapp-tailwindcss/ui`          | Atomic UI runtime layer for mini programs                                     |
-
-Each package now uses Chinese as its default `README.md` and provides an English `README.en.md`.
-
-## AI Skill
-
-The official skills are now split by task: setup, migration, troubleshooting, runtime classes, custom builds, and React Native. The original `weapp-tailwindcss` name remains as a compatibility router. Install the complete suite with:
+The official skills are split by setup, migration, troubleshooting, runtime classes, custom builds, and React Native. Install the complete suite with:
 
 ```bash
 npx skills add sonofmagic/skills \
@@ -102,7 +173,7 @@ npx skills add sonofmagic/skills \
   -y
 ```
 
-The previous single-skill command remains available and routes requests to the appropriate specialized skill:
+The original single-skill command remains available:
 
 ```bash
 npx skills add sonofmagic/skills --skill weapp-tailwindcss
@@ -112,13 +183,7 @@ Read more in the [Skill documentation](https://tw.icebreaker.top/docs/ai/basics/
 
 ## Contributing
 
-Issues and pull requests are welcome:
-
-- Report reproducible problems.
-- Improve framework examples or documentation.
-- Improve transforms, compatibility behavior, runtime packages, or test coverage.
-
-Before contributing, read the repository `AGENTS.md` and the closest `AGENTS.md` under the target directory.
+Issues, reproducible bug reports, framework examples, documentation improvements, transform fixes, and tests are welcome. Before contributing, read the root `AGENTS.md` and the closest `AGENTS.md` for the target directory, then run the relevant `pnpm` checks locally.
 
 ## License
 

--- a/README_en.md
+++ b/README_en.md
@@ -7,7 +7,7 @@
 <h1 align="center">weapp-tailwindcss</h1>
 
 <p align="center">
-  <strong>Bring Tailwind CSS to mini programs and multi-platform apps.</strong>
+  <strong>Bring Tailwind CSS to every platform!</strong>
 </p>
 
 <p align="center">
@@ -25,7 +25,7 @@
 
 ## What It Is
 
-`weapp-tailwindcss` adapts Tailwind CSS for mini program ecosystems. It transforms Tailwind-generated selectors, utility classes, and selected CSS capabilities into forms that mini programs and multi-platform frameworks can consume more reliably.
+`weapp-tailwindcss` is a cross-platform Tailwind CSS toolchain. The core package owns Web and mini-program style generation, class transforms, and builder integrations, while ecosystem packages extend the same utility-first experience to React Native, Lynx, runtime class utilities, and cross-platform UI.
 
 It is designed for:
 
@@ -33,6 +33,7 @@ It is designed for:
 - Sharing atomic CSS conventions across `uni-app` / `uni-app x`, Taro, Mpx, native mini programs, weapp-vite, and related stacks.
 - Handling mini program class escaping, selector compatibility, rpx arbitrary values, CSS fallbacks, and H5/Web output differences in Tailwind CSS v4 projects.
 - Building multi-platform apps that target mini programs, H5/Web, and App WebViews.
+- Extending the same utility-first workflow to React Native and Lynx through `@weapp-tailwindcss/react-native` and `@weapp-tailwindcss/lynx`.
 
 ## Current Support
 

--- a/packages-runtime/cva/package.json
+++ b/packages-runtime/cva/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/cva",
   "type": "module",
   "version": "0.1.7",
-  "description": "class-variance-authority 的运行时封装，自动完成小程序 escape/unescape。",
+  "description": "Cross-platform class-variance-authority runtime for Tailwind CSS. 面向跨端 Tailwind CSS 的 class-variance-authority 运行时封装。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/community/merge/cva-and-variants",

--- a/packages-runtime/merge/package.json
+++ b/packages-runtime/merge/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/merge",
   "type": "module",
   "version": "2.2.1",
-  "description": "Tailwind Merge v3 的 weapp 运行时封装，自动处理 escape/unescape。",
+  "description": "Cross-platform Tailwind CSS class merging runtime with mini-program compatibility. 兼容小程序的跨端 Tailwind CSS 类名合并运行时。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/community/merge/overview",

--- a/packages-runtime/runtime/package.json
+++ b/packages-runtime/runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/runtime",
   "type": "module",
   "version": "0.1.6",
-  "description": "Shared runtime helpers (transformers, clsx wrappers, metadata) for weapp-tailwindcss 在小程序运行时的适配层。",
+  "description": "Shared runtime adapters for cross-platform Tailwind CSS class utilities. 跨端 Tailwind CSS 类名工具的共享运行时适配层。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/community/merge/runtime-api",

--- a/packages-runtime/theme-transition/package.json
+++ b/packages-runtime/theme-transition/package.json
@@ -2,7 +2,7 @@
   "name": "theme-transition",
   "type": "module",
   "version": "2.0.4",
-  "description": "提供 CSS/SCSS/Tailwind 插件的主题过渡能力，适配 weapp-tailwindcss。",
+  "description": "Cross-platform CSS, SCSS, and Tailwind CSS theme transition utilities. 跨端 CSS、SCSS 与 Tailwind CSS 主题过渡工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/community/theme-transition",

--- a/packages-runtime/typography/package.json
+++ b/packages-runtime/typography/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/typography",
   "type": "module",
   "version": "1.0.2",
-  "description": "The tailwindcss typography plugin for weapp",
+  "description": "Tailwind CSS Typography plugin and markup transforms for cross-platform apps. 面向跨端应用的 Tailwind CSS Typography 插件与标记转换工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/community/typography",

--- a/packages-runtime/ui/package.json
+++ b/packages-runtime/ui/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/ui",
   "type": "module",
   "version": "0.0.10",
-  "description": "Atomic utility-first CSS component library for WeChat mini programs.",
+  "description": "Cross-platform utility-first UI components for Tailwind CSS. 面向跨端 Tailwind CSS 的 utility-first UI 组件库。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "ISC",
   "homepage": "https://tw.icebreaker.top/docs/community/ui",

--- a/packages-runtime/variants/package.json
+++ b/packages-runtime/variants/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/variants",
   "type": "module",
   "version": "0.2.3",
-  "description": "tailwind-variants 的运行时封装，提供 tv/cn 等 API 的小程序增强版本。",
+  "description": "Cross-platform tailwind-variants runtime with Tailwind CSS class compatibility. 兼容 Tailwind CSS 类名的跨端 tailwind-variants 运行时封装。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/community/merge/cva-and-variants",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.3",
   "private": true,
-  "description": "weapp-tailwindcss babel package",
+  "description": "Babel utilities for cross-platform Tailwind CSS class transforms. 跨端 Tailwind CSS 类名转换的 Babel 工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/build-all/package.json
+++ b/packages/build-all/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.71",
   "private": true,
+  "description": "Internal build aggregation for the weapp-tailwindcss workspace. weapp-tailwindcss 工作区内部聚合构建包。",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
   "version": "5.2.14",
-  "description": "Tailwind CSS CLI-compatible builds with optional mini-program CSS output",
+  "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top/docs/tools/weapp-tw-cli",

--- a/packages/debug-uni-app-x/package.json
+++ b/packages/debug-uni-app-x/package.json
@@ -2,6 +2,7 @@
   "name": "@weapp-tailwindcss/debug-uni-app-x",
   "type": "module",
   "version": "1.0.3",
+  "description": "Vite diagnostics for cross-platform uni-app x Tailwind CSS builds. 用于跨端 uni-app x Tailwind CSS 构建的 Vite 调试工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/experimental",
   "type": "module",
   "version": "0.0.34",
-  "description": "@weapp-tailwindcss/experimental",
+  "description": "Experimental integrations for cross-platform Tailwind CSS. 跨端 Tailwind CSS 实验性集成能力。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "ISC",
   "repository": {

--- a/packages/hbuilderx-runner/package.json
+++ b/packages/hbuilderx-runner/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/hbuilderx-runner",
   "type": "module",
   "version": "0.1.1",
-  "description": "Stable HBuilderX CLI runner utilities for weapp-tailwindcss local e2e workflows.",
+  "description": "HBuilderX runner utilities for cross-platform uni-app Tailwind CSS workflows. 跨端 uni-app Tailwind CSS 工作流的 HBuilderX 运行器工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/init",
   "type": "module",
   "version": "1.0.14",
-  "description": "@weapp-tailwindcss/init",
+  "description": "Project initializer for cross-platform Tailwind CSS with weapp-tailwindcss. 用于初始化跨端 Tailwind CSS 项目的 weapp-tailwindcss 工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/logger",
   "type": "module",
   "version": "2.0.1",
-  "description": "@weapp-tailwindcss/logger",
+  "description": "Shared logging utilities for the weapp-tailwindcss cross-platform toolchain. weapp-tailwindcss 跨端工具链的共享日志工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
   "version": "0.2.0",
-  "description": "Tailwind CSS 4 integration for ReactLynx and Rspeedy.",
+  "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/minify-preserve/package.json
+++ b/packages/minify-preserve/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "private": true,
-  "description": "Examples for keeping weapp-tailwindcss helper names during minification.",
+  "description": "Examples for preserving cross-platform Tailwind CSS helper names during minification. 跨端 Tailwind CSS 辅助函数压缩保名示例。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "keywords": [

--- a/packages/postcss-calc/package.json
+++ b/packages/postcss-calc/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/postcss-calc",
   "version": "1.0.3",
   "type": "module",
-  "description": "PostCSS plugin to reduce calc()",
+  "description": "PostCSS calc reduction utility for cross-platform Tailwind CSS builds. 跨端 Tailwind CSS 构建使用的 PostCSS calc 归约工具。",
   "keywords": [
     "css",
     "postcss",

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/postcss",
   "type": "module",
   "version": "3.2.10",
-  "description": "@weapp-tailwindcss/postcss",
+  "description": "PostCSS transforms that bring Tailwind CSS compatibility to every platform. 将 Tailwind CSS 兼容能力带到全端的 PostCSS 转换工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
   "version": "0.2.1",
-  "description": "Tailwind CSS 4 compiler and Expo Metro integration for React Native.",
+  "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/reset/package.json
+++ b/packages/reset/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/reset",
   "type": "module",
   "version": "0.1.2",
-  "description": "weapp-tailwindcss 的静态 reset 样式资源集合",
+  "description": "Cross-platform reset styles for weapp-tailwindcss projects. weapp-tailwindcss 项目的跨端 reset 样式资源。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,7 +2,7 @@
   "name": "@weapp-tailwindcss/shared",
   "type": "module",
   "version": "2.0.1",
-  "description": "@weapp-tailwindcss/shared",
+  "description": "Shared utilities for the cross-platform weapp-tailwindcss toolchain. weapp-tailwindcss 跨端工具链的共享工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/tailwindcss-config/package.json
+++ b/packages/tailwindcss-config/package.json
@@ -2,7 +2,7 @@
   "name": "tailwindcss-config",
   "type": "module",
   "version": "2.0.2",
-  "description": "load tailwindcss config function",
+  "description": "Tailwind CSS configuration loader for cross-platform toolchains. 跨端工具链的 Tailwind CSS 配置加载器。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/tailwindcss-core-plugins-extractor/package.json
+++ b/packages/tailwindcss-core-plugins-extractor/package.json
@@ -2,7 +2,7 @@
   "name": "tailwindcss-core-plugins-extractor",
   "type": "module",
   "version": "0.2.0",
-  "description": "tailwindcss-core-plugins-extractor",
+  "description": "Tailwind CSS core plugin extractor for cross-platform integrations. 面向跨端集成的 Tailwind CSS 核心插件提取器。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top",

--- a/packages/tailwindcss-injector/package.json
+++ b/packages/tailwindcss-injector/package.json
@@ -2,7 +2,7 @@
   "name": "tailwindcss-injector",
   "type": "module",
   "version": "1.0.15",
-  "description": "tsdown build package template",
+  "description": "Tailwind CSS generation and source injection helpers for cross-platform builds. 跨端构建的 Tailwind CSS 生成与源码注入工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/test-helper/package.json
+++ b/packages/test-helper/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.0.2",
-  "description": "tsdown package template",
+  "description": "Test helpers for cross-platform Tailwind CSS integration suites. 跨端 Tailwind CSS 集成测试辅助工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-style-injector/package.json
+++ b/packages/weapp-style-injector/package.json
@@ -2,7 +2,7 @@
   "name": "weapp-style-injector",
   "type": "module",
   "version": "1.0.2",
-  "description": "weapp-style-injector",
+  "description": "Style entry injection for cross-platform mini-program and Web builds. 面向小程序与 Web 跨端构建的样式入口注入工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-tailwindcss/README.en.md
+++ b/packages/weapp-tailwindcss/README.en.md
@@ -2,7 +2,7 @@
 
 > English | [简体中文](./README.md)
 
-This is the core package that brings Tailwind CSS to mini program ecosystems, handling class transformation, CSS compatibility, framework build adapters, and Tailwind v4 support.
+This is the core compiler and builder package for the cross-platform Tailwind CSS toolchain. It handles Web and mini-program style generation, class transforms, CSS compatibility, and framework build adapters while providing the Tailwind v4 generation foundation used by React Native and Lynx integrations.
 
 ## Website
 

--- a/packages/weapp-tailwindcss/README.md
+++ b/packages/weapp-tailwindcss/README.md
@@ -2,7 +2,7 @@
 
 > 简体中文 | [English](./README.en.md)
 
-这个包是把 Tailwind CSS 带到小程序生态的核心入口，负责类名转译、CSS 兼容、框架构建适配和 Tailwind v4 支持。
+这个包是跨端 Tailwind CSS 工具链的核心编译与构建入口，负责 Web 与小程序的样式生成、类名转译、CSS 兼容和框架构建适配，并为 React Native、Lynx 等生态集成提供 Tailwind v4 生成基础。
 
 ## 官网
 

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -2,7 +2,7 @@
   "name": "weapp-tailwindcss",
   "type": "module",
   "version": "5.2.14",
-  "description": "把 tailwindcss 原子化样式思想，带给小程序开发者们! bring tailwindcss to miniprogram developers!",
+  "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "homepage": "https://tw.icebreaker.top",

--- a/packages/weapp-tw/package.json
+++ b/packages/weapp-tw/package.json
@@ -2,7 +2,7 @@
   "name": "weapp-tw",
   "type": "module",
   "version": "0.0.1",
-  "description": "tsdown bundler template",
+  "description": "Reserved cross-platform Tailwind CSS package name. 跨端 Tailwind CSS 预留包名。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/weapptw/package.json
+++ b/packages/weapptw/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "private": true,
-  "description": "tsdown bundler template",
+  "description": "Reserved internal package name for the cross-platform Tailwind CSS toolchain. 跨端 Tailwind CSS 工具链内部预留包名。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/packages/wetw/package.json
+++ b/packages/wetw/package.json
@@ -2,7 +2,7 @@
   "name": "wetw",
   "type": "module",
   "version": "0.1.4",
-  "description": "tsdown bundler template",
+  "description": "Cross-platform Tailwind CSS component registry and project CLI. 跨端 Tailwind CSS 组件注册与项目 CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",
   "repository": {

--- a/tools/weapp-tailwindcss-scripts/package.json
+++ b/tools/weapp-tailwindcss-scripts/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.0",
   "private": true,
+  "description": "Internal build scripts for the cross-platform weapp-tailwindcss workspace. weapp-tailwindcss 跨端工作区的内部构建脚本。",
   "scripts": {
     "build:css": "tsx src/build-css.ts",
     "build:weapp-theme": "tsx src/build-weapp-theme.ts",

--- a/website/src/css/custom/_homepage.scss
+++ b/website/src/css/custom/_homepage.scss
@@ -295,37 +295,115 @@ html[data-theme='dark'] .homepage .home-cta:hover {
 }
 
 .home-facts {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0;
   border: 1px solid var(--home-line);
   border-radius: var(--home-radius);
-  background: var(--home-surface);
+  background: linear-gradient(90deg, rgb(14 165 233 / 5%), transparent 28%), var(--home-surface);
   overflow: hidden;
 }
 
+.home-facts::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1;
+  height: 2px;
+  background: linear-gradient(90deg, #0ea5e9, #38bdf8 38%, rgb(56 189 248 / 0%) 88%);
+  pointer-events: none;
+}
+
 .home-facts__item {
+  position: relative;
   display: flex;
-  min-height: 76px;
+  min-height: 124px;
   flex-direction: column;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 1rem 1.15rem;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.3rem 1.35rem;
   border-right: 1px solid var(--home-line);
+  transition: background 0.2s ease;
 }
 
 .home-facts__item:nth-child(4) {
   border-right: 0;
 }
 
-.home-facts__item span {
-  color: var(--home-muted);
-  font-size: 0.82rem;
+.home-facts__item:hover {
+  background: rgb(14 165 233 / 5%);
 }
 
-.home-facts__item strong {
+.home-facts__heading {
+  display: grid;
+  grid-template-columns: 1.7rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.home-facts__heading i {
+  display: inline-flex;
+  width: 1.7rem;
+  height: 1.7rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgb(14 165 233 / 20%);
+  border-radius: 7px;
+  background: rgb(14 165 233 / 9%);
+  color: var(--home-accent);
+  font-size: 0.92rem;
+}
+
+.home-facts__heading span {
+  color: var(--home-muted);
+  font-size: 0.76rem;
+  font-weight: 680;
+  text-transform: uppercase;
+}
+
+.home-facts__heading small {
+  color: rgb(100 116 139 / 55%);
+  font:
+    700 0.66rem / 1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+}
+
+.home-facts__values {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.38rem 0;
+}
+
+.home-facts__values strong {
+  display: inline-flex;
+  align-items: center;
   color: var(--home-ink);
-  font-size: 0.98rem;
+  font-size: 0.94rem;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.home-facts__values strong:not(:last-child)::after {
+  content: '/';
+  margin: 0 0.48rem;
+  color: rgb(14 165 233 / 48%);
+  font-weight: 500;
+}
+
+[data-theme='dark'] .home-facts {
+  background: linear-gradient(90deg, rgb(14 165 233 / 8%), transparent 28%), var(--home-surface);
+}
+
+[data-theme='dark'] .home-facts__item:hover {
+  background: rgb(56 189 248 / 6%);
 }
 
 .home-facts__routes {
@@ -1450,10 +1528,10 @@ html[data-theme='dark'] .homepage .home-cta:hover {
 }
 
 .home-facts__item {
-  min-height: 82px;
+  min-height: 132px;
 }
 
-.home-facts__item strong {
+.home-facts__values strong {
   font-size: clamp(0.98rem, 1.18vw, 1.12rem);
   overflow-wrap: anywhere;
   word-break: normal;
@@ -1906,8 +1984,8 @@ html[data-theme='dark'] .homepage .home-cta:hover {
   }
 
   .home-facts__item {
-    min-height: 72px;
-    padding: 0.78rem 0.85rem;
+    min-height: 116px;
+    padding: 1rem;
     border-right: 0;
   }
 
@@ -1915,11 +1993,11 @@ html[data-theme='dark'] .homepage .home-cta:hover {
     border-right: 1px solid var(--home-line);
   }
 
-  .home-facts__item span {
+  .home-facts__heading span {
     font-size: 0.7rem;
   }
 
-  .home-facts__item strong {
+  .home-facts__values strong {
     font-size: 0.92rem;
     line-height: 1.28;
   }
@@ -2183,13 +2261,11 @@ html[data-theme='dark'] .homepage .home-cta:hover {
   }
 
   .home-facts__item {
-    min-height: 64px;
-    align-items: center;
-    padding: 0.68rem 0.56rem;
-    text-align: center;
+    min-height: 108px;
+    padding: 0.85rem;
   }
 
-  .home-facts__item strong {
+  .home-facts__values strong {
     font-size: 0.82rem;
     line-height: 1.2;
     white-space: normal;

--- a/website/src/css/custom/_homepage.scss
+++ b/website/src/css/custom/_homepage.scss
@@ -2106,7 +2106,8 @@ html[data-theme='dark'] .homepage .home-cta:hover {
     font-size: clamp(1.05rem, 4.8vw, 1.22rem);
     line-height: 1.24;
     text-align: center;
-    white-space: nowrap;
+    text-wrap: balance;
+    white-space: normal;
   }
 
   .home-hero__sublead {

--- a/website/src/i18n/siteConfig.ts
+++ b/website/src/i18n/siteConfig.ts
@@ -3,13 +3,13 @@ import { normalizeSiteLocale } from './locale'
 
 const siteConfigCopy = {
   'zh-cn': {
-    tagline: '让 Tailwind CSS 稳定跑在小程序里，覆盖多框架与多构建器链路。',
+    tagline: 'Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！',
     metadata: {
       siteLanguage: 'zh-CN',
       ogLocale: 'zh_CN',
-      defaultMetaTitle: 'weapp-tailwindcss | Tailwind CSS 小程序事实标准工具链',
-      defaultMetaDescription: 'weapp-tailwindcss 为小程序生态提供 Tailwind CSS v4 的精确转译、构建器集成与运行时工具，覆盖 Taro、uni-app、原生小程序、Webpack、Vite 与 Gulp 场景。',
-      themeKeywords: ['weapp', '小程序', 'tailwindcss', '原子类', 'uni-app', 'taro', 'mpx', 'native', 'remax', '原生', 'webpack', 'plugin', 'vite', 'gulp', 'wxss', 'wxml'],
+      defaultMetaTitle: 'weapp-tailwindcss | 把 Tailwind CSS 带到全端',
+      defaultMetaDescription: 'weapp-tailwindcss 将 Tailwind CSS v4 的精确转译、构建器集成与运行时工具带到 Web、小程序、React Native、Lynx 与跨端框架。',
+      themeKeywords: ['weapp', '跨端', 'tailwindcss', '原子类', 'uni-app', 'taro', 'react-native', 'lynx', '原生', 'webpack', 'plugin', 'vite', 'gulp', 'wxss', 'wxml'],
       socialImageAlt: 'weapp-tailwindcss 项目标识',
     },
     geo: {
@@ -65,13 +65,13 @@ const siteConfigCopy = {
     },
   },
   'en': {
-    tagline: 'Bring Tailwind CSS to mini apps with a stable pipeline across frameworks and builders.',
+    tagline: 'Bring Tailwind CSS to every platform! Atomic utility-first development for the entire stack.',
     metadata: {
       siteLanguage: 'en-US',
       ogLocale: 'en_US',
-      defaultMetaTitle: 'weapp-tailwindcss | The Tailwind CSS toolchain for mini apps',
-      defaultMetaDescription: 'weapp-tailwindcss delivers precise Tailwind CSS v4 transforms, builder integrations, and runtime utilities for Taro, uni-app, native mini apps, Webpack, Vite, and Gulp.',
-      themeKeywords: ['weapp', 'mini app', 'mini program', 'tailwindcss', 'utility classes', 'uni-app', 'taro', 'mpx', 'native', 'webpack', 'plugin', 'vite', 'gulp', 'wxss', 'wxml'],
+      defaultMetaTitle: 'weapp-tailwindcss | Tailwind CSS for every platform',
+      defaultMetaDescription: 'weapp-tailwindcss brings precise Tailwind CSS v4 transforms, builder integrations, and runtime utilities to Web, mini programs, React Native, Lynx, and cross-platform frameworks.',
+      themeKeywords: ['weapp', 'cross-platform', 'tailwindcss', 'utility classes', 'uni-app', 'taro', 'react-native', 'lynx', 'native', 'webpack', 'plugin', 'vite', 'gulp', 'wxss', 'wxml'],
       socialImageAlt: 'weapp-tailwindcss project logo',
     },
     geo: {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,7 +15,8 @@ import { ctaButton } from '../features/homepage/variants'
 
 interface FactItem {
   label: string
-  value: string
+  values: string[]
+  icon: string
 }
 
 interface CapabilityItem {
@@ -47,10 +48,14 @@ interface PlatformIconItem {
 const homepageCopy = {
   'zh-cn': {
     facts: [
-      { label: 'Tailwind', value: 'CSS 4 / @source' },
-      { label: '框架', value: 'uni-app / Taro / React Native / Lynx' },
-      { label: '构建器', value: 'Webpack / Vite / Metro / Rspeedy' },
-      { label: '运行时', value: 'merge / cva / variants' },
+      { label: 'Tailwind', values: ['CSS 4', '@source'], icon: 'icon-[mdi--tailwind]' },
+      {
+        label: '框架',
+        values: ['uni-app', 'Taro', 'React Native', 'Lynx'],
+        icon: 'icon-[mdi--transit-connection-variant]',
+      },
+      { label: '构建器', values: ['Webpack', 'Vite', 'Metro', 'Rspeedy'], icon: 'icon-[mdi--hammer-wrench]' },
+      { label: '运行时', values: ['merge', 'cva', 'variants'], icon: 'icon-[mdi--function-variant]' },
     ] satisfies FactItem[],
     routeLinks: [
       {
@@ -161,10 +166,14 @@ const homepageCopy = {
   },
   'en': {
     facts: [
-      { label: 'Tailwind', value: 'CSS 4 / @source' },
-      { label: 'Frameworks', value: 'uni-app / Taro / React Native / Lynx' },
-      { label: 'Builders', value: 'Webpack / Vite / Metro / Rspeedy' },
-      { label: 'Runtime', value: 'merge / cva / variants' },
+      { label: 'Tailwind', values: ['CSS 4', '@source'], icon: 'icon-[mdi--tailwind]' },
+      {
+        label: 'Frameworks',
+        values: ['uni-app', 'Taro', 'React Native', 'Lynx'],
+        icon: 'icon-[mdi--transit-connection-variant]',
+      },
+      { label: 'Builders', values: ['Webpack', 'Vite', 'Metro', 'Rspeedy'], icon: 'icon-[mdi--hammer-wrench]' },
+      { label: 'Runtime', values: ['merge', 'cva', 'variants'], icon: 'icon-[mdi--function-variant]' },
     ] satisfies FactItem[],
     routeLinks: [
       {
@@ -383,10 +392,21 @@ function HomepageHeader() {
 
       {homepage.platformTags && (
         <section className="ui-homepage-platform-tags home-facts" aria-label={copy.factsAria}>
-          {copy.facts.map(fact => (
+          {copy.facts.map((fact, index) => (
             <div className="home-facts__item" key={fact.label}>
-              <span>{fact.label}</span>
-              <strong>{fact.value}</strong>
+              <div className="home-facts__heading">
+                <i aria-hidden="true" className={fact.icon}></i>
+                <span>{fact.label}</span>
+                <small aria-hidden="true">
+                  0
+                  {index + 1}
+                </small>
+              </div>
+              <div className="home-facts__values">
+                {fact.values.map(value => (
+                  <strong key={value}>{value}</strong>
+                ))}
+              </div>
             </div>
           ))}
           <nav className="home-facts__routes" aria-label={copy.routesAria}>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -48,8 +48,8 @@ const homepageCopy = {
   'zh-cn': {
     facts: [
       { label: 'Tailwind', value: 'CSS 4 / @source' },
-      { label: '框架', value: 'uni-app / Taro / Mpx / Weapp-vite' },
-      { label: '构建器', value: 'Webpack / Vite / Gulp' },
+      { label: '框架', value: 'uni-app / Taro / React Native / Lynx' },
+      { label: '构建器', value: 'Webpack / Vite / Metro / Rspeedy' },
       { label: '运行时', value: 'merge / cva / variants' },
     ] satisfies FactItem[],
     routeLinks: [
@@ -79,13 +79,13 @@ const homepageCopy = {
         icon: 'icon-[mdi--target]',
       },
       {
-        title: 'Web / 小程序分端输出',
-        description: '同一份 CSS-first 输入，按环境生成浏览器 CSS 或小程序 CSS。',
+        title: '多端输出目标',
+        description: '按目标端生成 Web CSS、小程序 CSS 或原生样式清单。',
         icon: 'icon-[mdi--source-branch]',
       },
       {
         title: '跨生态落地',
-        description: '覆盖 uni-app、Taro、Mpx、Weapp-vite、原生小程序以及 Webpack、Vite、Gulp 链路。',
+        description: '覆盖 uni-app、Taro、Mpx、Weapp-vite、React Native、Lynx 与原生小程序。',
         icon: 'icon-[mdi--transit-connection-variant]',
       },
       {
@@ -137,12 +137,12 @@ const homepageCopy = {
       { id: 'lynx', label: 'Lynx', href: '/docs/quick-start/frameworks/lynx' },
     ] satisfies PlatformIconItem[],
     hero: {
-      badge: 'Tailwind CSS 4 + 小程序生成链路',
+      badge: 'Tailwind CSS 4 + 全端生成链路',
       copyrightAria: '查看版权与证书页面',
       copyrightTitle: 'G-Star 毕业项目认证',
       copyrightImageAlt: 'AtomGit G-Star 毕业项目认证徽章',
-      lead: '一套 CSS-first 输入，交付 Web 与小程序两端样式。',
-      sublead: '保留 `WeappTailwindcss` 接管生成、转义与运行时边界，不在小程序构建里重复注册官方 Tailwind 插件。',
+      lead: '一套原子化开发体验，交付 Web、小程序与原生跨端应用。',
+      sublead: '按平台复用编译器、构建器集成与运行时适配，同时保留各端真实语义与工程边界。',
       platformAria: '支持平台',
       primaryCta: '开始接入',
       aiEntry: 'AI 学习入口',
@@ -162,8 +162,8 @@ const homepageCopy = {
   'en': {
     facts: [
       { label: 'Tailwind', value: 'CSS 4 / @source' },
-      { label: 'Frameworks', value: 'uni-app / Taro / Mpx / Weapp-vite' },
-      { label: 'Builders', value: 'Webpack / Vite / Gulp' },
+      { label: 'Frameworks', value: 'uni-app / Taro / React Native / Lynx' },
+      { label: 'Builders', value: 'Webpack / Vite / Metro / Rspeedy' },
       { label: 'Runtime', value: 'merge / cva / variants' },
     ] satisfies FactItem[],
     routeLinks: [
@@ -193,13 +193,13 @@ const homepageCopy = {
         icon: 'icon-[mdi--target]',
       },
       {
-        title: 'Web / mini app output targets',
-        description: 'One CSS-first input generates browser CSS or mini app CSS depending on the target.',
+        title: 'Multi-platform output targets',
+        description: 'Generate Web CSS, mini-program CSS, or native style manifests for each target.',
         icon: 'icon-[mdi--source-branch]',
       },
       {
         title: 'Cross-ecosystem delivery',
-        description: 'Supports uni-app, Taro, Mpx, Weapp-vite, native mini apps, plus Webpack, Vite, and Gulp.',
+        description: 'Supports uni-app, Taro, Mpx, Weapp-vite, React Native, Lynx, and native mini programs.',
         icon: 'icon-[mdi--transit-connection-variant]',
       },
       {
@@ -251,12 +251,12 @@ const homepageCopy = {
       { id: 'lynx', label: 'Lynx', href: '/docs/quick-start/frameworks/lynx' },
     ] satisfies PlatformIconItem[],
     hero: {
-      badge: 'Tailwind CSS 4 + mini app generation pipeline',
+      badge: 'Tailwind CSS 4 + cross-platform generation pipeline',
       copyrightAria: 'View the copyright and certificate page',
       copyrightTitle: 'G-Star graduation project certification',
       copyrightImageAlt: 'AtomGit G-Star graduation project badge',
-      lead: 'One CSS-first input, delivered as Web and mini app styles.',
-      sublead: 'Keep `WeappTailwindcss` in charge of generation, escaping, and runtime boundaries without registering the official Tailwind plugin twice in mini app builds.',
+      lead: 'One utility-first workflow for Web, mini programs, and native cross-platform apps.',
+      sublead: 'Reuse compilers, builder integrations, and runtime adapters while preserving each platform\'s native semantics and engineering boundaries.',
       platformAria: 'Supported platforms',
       primaryCta: 'Start setup',
       aiEntry: 'AI entry',


### PR DESCRIPTION
## 变更内容

- 将 26 个公开发布包的 description 统一调整为跨端 Tailwind CSS 工具链定位
- 统一公开包 README 国际化规范：README.md 默认英文，README.zh-CN.md 提供简体中文
- 重写中英文根 README，补齐 Web、小程序与原生跨端能力说明
- 更新 website tagline、SEO、首页 Hero 与支持矩阵文案
- 将首页 Tailwind、框架、构建器和运行时信息重构为响应式能力轨道
- 为公开包添加中文 changeset

## 包 README 国际化

- 核心包、CLI、React Native、Lynx、merge、cva 与 variants 补充安装、快速示例和职责边界
- 移除公开包中 README.en.md 与 README_en.md 两种旧命名
- 新增零依赖 README 校验脚本，检查包名标题、双向语言链接和文件命名
- 新增轻量 Package README Quality workflow，README 变更无需触发完整跨平台构建矩阵
- 旧 generate:readme 命令改为校验，避免过时模板覆盖包文档

## 首页能力轨道

- 桌面端保持连续四列信息带，增加语义图标、序号与技术栈层级
- 移动端采用稳定 2 x 2 布局，长名称可正常换行
- 保持现有深色工业风格，并提供克制的 hover 反馈

## 本地验证

- pnpm lint
- pnpm docs:packages:check
- pnpm generate:readme
- pnpm --filter @weapp-tailwindcss/website typecheck
- pnpm --filter @weapp-tailwindcss/website build
- pnpm pack --dry-run --json：weapp-tailwindcss、@weapp-tailwindcss/cli、@weapp-tailwindcss/react-native
- Playwright：首页中文和英文页面，1440 x 900 与 390 x 844，无横向溢出