### PR TITLE
feat(website): 增加可排期的赞助广告

### DIFF
--- a/website/src/components/AdsContainer/index.tsx
+++ b/website/src/components/AdsContainer/index.tsx
@@ -4,9 +4,11 @@ import React from 'react'
 function AdsContainer() {
   return (
     <div className={`
+      hidden min-h-[224px]
       border-t
       border-[color:var(--ifm-toc-border-color)]
       pt-4
+      lg:block
     `}
     >
       <AdsContainerElement />

--- a/website/src/components/AdsContainerElement/campaigns.test.ts
+++ b/website/src/components/AdsContainerElement/campaigns.test.ts
@@ -1,0 +1,76 @@
+import type { PaidCampaign } from './campaigns'
+import { describe, expect, it } from 'vitest'
+import {
+  assertNoCampaignOverlaps,
+  fallbackCampaign,
+  selectActiveCampaign,
+  selectDisplayCampaign,
+} from './campaigns'
+
+function createCampaign(
+  id: string,
+  startsAt: string,
+  endsAt: string,
+  site: PaidCampaign['site'] = 'weapp-tailwindcss',
+): PaidCampaign {
+  return {
+    creative: fallbackCampaign.creative,
+    endsAt,
+    href: `https://example.com/${id}`,
+    id,
+    site,
+    startsAt,
+  }
+}
+
+describe('sponsor campaign scheduling', () => {
+  const monthly = createCampaign(
+    'monthly',
+    '2026-09-01T00:00:00.000Z',
+    '2026-10-01T00:00:00.000Z',
+  )
+  const quarterly = createCampaign(
+    'quarterly',
+    '2026-09-01T00:00:00.000Z',
+    '2026-11-30T00:00:00.000Z',
+    'weapp-vite',
+  )
+
+  it('uses the fallback before and after a paid campaign', () => {
+    expect(selectDisplayCampaign([monthly], monthly.site, fallbackCampaign, new Date('2026-08-31T23:59:59.999Z'))).toBe(fallbackCampaign)
+    expect(selectDisplayCampaign([monthly], monthly.site, fallbackCampaign, new Date('2026-10-01T00:00:00.000Z'))).toBe(fallbackCampaign)
+  })
+
+  it('treats the start as inclusive and the end as exclusive for 30-day campaigns', () => {
+    expect(selectActiveCampaign([monthly], monthly.site, new Date('2026-09-01T00:00:00.000Z'))).toBe(monthly)
+    expect(selectActiveCampaign([monthly], monthly.site, new Date('2026-09-30T23:59:59.999Z'))).toBe(monthly)
+    expect(selectActiveCampaign([monthly], monthly.site, new Date('2026-10-01T00:00:00.000Z'))).toBeUndefined()
+  })
+
+  it('keeps the same boundary rules for 90-day campaigns', () => {
+    expect(selectActiveCampaign([quarterly], quarterly.site, new Date('2026-09-01T00:00:00.000Z'))).toBe(quarterly)
+    expect(selectActiveCampaign([quarterly], quarterly.site, new Date('2026-11-29T23:59:59.999Z'))).toBe(quarterly)
+    expect(selectActiveCampaign([quarterly], quarterly.site, new Date('2026-11-30T00:00:00.000Z'))).toBeUndefined()
+  })
+
+  it('rejects overlapping campaigns on the same site', () => {
+    const overlapping = createCampaign(
+      'overlapping',
+      '2026-09-30T12:00:00.000Z',
+      '2026-10-30T12:00:00.000Z',
+    )
+
+    expect(() => assertNoCampaignOverlaps([monthly, overlapping])).toThrow(/overlap/)
+    expect(() => selectActiveCampaign([monthly, overlapping], monthly.site, new Date('2026-09-30T18:00:00.000Z'))).toThrow(/Multiple active/)
+  })
+
+  it('allows adjacent campaigns and independent schedules on different sites', () => {
+    const adjacent = createCampaign(
+      'adjacent',
+      monthly.endsAt,
+      '2026-10-31T00:00:00.000Z',
+    )
+
+    expect(() => assertNoCampaignOverlaps([monthly, adjacent, quarterly])).not.toThrow()
+  })
+})

--- a/website/src/components/AdsContainerElement/campaigns.ts
+++ b/website/src/components/AdsContainerElement/campaigns.ts
@@ -1,0 +1,121 @@
+import type { SiteLocale } from '../../i18n/locale'
+
+export type CampaignSite = 'weapp-tailwindcss' | 'weapp-vite'
+
+export interface CampaignCreative {
+  brand: string
+  copy: string
+  logoAlt: string
+  logoDarkSrc?: string
+  logoSrc: string
+}
+
+export interface DisplayCampaign {
+  creative: Record<SiteLocale, CampaignCreative>
+  href: string
+  id: string
+  site: CampaignSite
+}
+
+export interface PaidCampaign extends DisplayCampaign {
+  endsAt: string
+  startsAt: string
+}
+
+export const paidCampaigns: PaidCampaign[] = []
+
+export const fallbackCampaign: DisplayCampaign = {
+  creative: {
+    'en': {
+      brand: 'Easysearch',
+      copy: 'Distributed search infrastructure for production teams',
+      logoAlt: 'Easysearch',
+      logoDarkSrc: '/img/ads/easysearch-dark.svg',
+      logoSrc: '/img/ads/easysearch.svg',
+    },
+    'zh-cn': {
+      brand: 'Easysearch',
+      copy: '企业级的分布式搜索型数据库',
+      logoAlt: 'Easysearch',
+      logoDarkSrc: '/img/ads/easysearch-dark.svg',
+      logoSrc: '/img/ads/easysearch.svg',
+    },
+  },
+  href: 'https://easysearch.cn/',
+  id: 'easysearch-fallback',
+  site: 'weapp-tailwindcss',
+}
+
+function toTimestamp(value: string, campaignId: string, field: 'startsAt' | 'endsAt'): number {
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) {
+    throw new TypeError(`Campaign "${campaignId}" has an invalid ${field}`)
+  }
+  return timestamp
+}
+
+function getCampaignInterval(campaign: PaidCampaign): [number, number] {
+  const startsAt = toTimestamp(campaign.startsAt, campaign.id, 'startsAt')
+  const endsAt = toTimestamp(campaign.endsAt, campaign.id, 'endsAt')
+  if (startsAt >= endsAt) {
+    throw new RangeError(`Campaign "${campaign.id}" must end after it starts`)
+  }
+  return [startsAt, endsAt]
+}
+
+export function assertNoCampaignOverlaps(campaigns: readonly PaidCampaign[]): void {
+  const campaignsBySite = new Map<CampaignSite, Array<{ campaign: PaidCampaign, endsAt: number, startsAt: number }>>()
+
+  for (const campaign of campaigns) {
+    const [startsAt, endsAt] = getCampaignInterval(campaign)
+    const siteCampaigns = campaignsBySite.get(campaign.site) ?? []
+    siteCampaigns.push({ campaign, endsAt, startsAt })
+    campaignsBySite.set(campaign.site, siteCampaigns)
+  }
+
+  for (const siteCampaigns of campaignsBySite.values()) {
+    siteCampaigns.sort((left, right) => left.startsAt - right.startsAt)
+    for (let index = 1; index < siteCampaigns.length; index += 1) {
+      const previous = siteCampaigns[index - 1]
+      const current = siteCampaigns[index]
+      if (current.startsAt < previous.endsAt) {
+        throw new RangeError(`Campaigns "${previous.campaign.id}" and "${current.campaign.id}" overlap on ${current.campaign.site}`)
+      }
+    }
+  }
+}
+
+export function selectActiveCampaign(
+  campaigns: readonly PaidCampaign[],
+  site: CampaignSite,
+  now: Date = new Date(),
+): PaidCampaign | undefined {
+  const timestamp = now.getTime()
+  if (!Number.isFinite(timestamp)) {
+    throw new TypeError('Campaign selection requires a valid date')
+  }
+
+  const activeCampaigns = campaigns.filter((campaign) => {
+    if (campaign.site !== site) {
+      return false
+    }
+    const [startsAt, endsAt] = getCampaignInterval(campaign)
+    return startsAt <= timestamp && timestamp < endsAt
+  })
+
+  if (activeCampaigns.length > 1) {
+    throw new RangeError(`Multiple active campaigns found for ${site}`)
+  }
+  return activeCampaigns[0]
+}
+
+export function selectDisplayCampaign(
+  campaigns: readonly PaidCampaign[],
+  site: CampaignSite,
+  fallback: DisplayCampaign,
+  now: Date = new Date(),
+): DisplayCampaign {
+  return selectActiveCampaign(campaigns, site, now) ?? fallback
+}
+
+assertNoCampaignOverlaps(paidCampaigns)

--- a/website/src/components/AdsContainerElement/index.tsx
+++ b/website/src/components/AdsContainerElement/index.tsx
@@ -1,344 +1,88 @@
-import Link from '@docusaurus/Link'
+import type { DisplayCampaign } from './campaigns'
 import { useCurrentSiteLocale } from '@site/src/i18n/runtime'
-import Aizex from '@site/static/img/ads/aizex-mini.png'
-import clsx from 'clsx'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import {
+  fallbackCampaign,
+  paidCampaigns,
+  selectDisplayCampaign,
+} from './campaigns'
 
-const adItems = {
-  'zh-cn': [
-    {
-      badge: 'SPONSORED',
-      cardClassName: `
-      overflow-hidden border-[#8b7bff]/20
-      bg-[radial-gradient(circle_at_12%_18%,rgba(139,123,255,0.20),transparent_32%),radial-gradient(circle_at_88%_14%,rgba(14,165,233,0.16),transparent_24%),linear-gradient(145deg,rgba(255,255,255,0.97),rgba(245,243,255,0.98))]
-      text-slate-900 shadow-[0_20px_44px_rgba(99,102,241,0.16)]
-      hover:shadow-[0_24px_54px_rgba(99,102,241,0.2)]
-      dark:border-[#8b7bff]/35 dark:text-white
-      dark:shadow-[0_24px_56px_rgba(14,165,233,0.14),0_10px_30px_rgba(76,29,149,0.24)]
-      dark:hover:shadow-[0_30px_70px_rgba(99,102,241,0.32),0_12px_36px_rgba(14,165,233,0.18)]
-      dark:bg-[radial-gradient(circle_at_14%_18%,rgba(139,123,255,0.34),transparent_34%),radial-gradient(circle_at_88%_18%,rgba(52,211,153,0.18),transparent_28%),linear-gradient(145deg,rgba(15,23,42,0.98),rgba(30,41,59,0.94))]
-    `,
-      description: '企业级的分布式搜索型数据库',
-      href: 'https://easysearch.cn/',
-      imageWrapperClassName: `
-      relative z-10 px-1 pt-5 pb-1
-    `,
-      logoClassName: 'h-10 w-auto',
-      metaClassName: 'hidden',
-      titleClassName: 'hidden',
-      descriptionClassName: 'mx-auto max-w-[15ch] text-center text-[12px] leading-5 text-slate-600 dark:text-[#ddd6fe]',
-      footerClassName: 'hidden',
-      renderLogo: () => (
-        <>
-          <img
-            className="
-            h-10 w-auto
-            dark:hidden
-          "
-            src="/img/ads/easysearch.svg"
-            alt="Easysearch"
-          >
-          </img>
-          <img
-            className="
-            hidden h-10 w-auto
-            dark:block
-          "
-            src="/img/ads/easysearch-dark.svg"
-            alt="Easysearch"
-          >
-          </img>
-        </>
-      ),
-      title: 'Easysearch',
-      tone: 'hero',
-    },
-    {
-      badge: '亲测推荐',
-      cardClassName: '',
-      description: '更好用的「GPT-5 x Claude」使用方式',
-      href: 'https://aizex.cn/0LcJ7G',
-      imageWrapperClassName: `
-      rounded-xl bg-white/70 px-2 py-1
-      dark:bg-slate-900/30
-    `,
-      logoClassName: 'h-14 w-auto',
-      metaClassName: 'hidden',
-      titleClassName: 'text-base font-semibold tracking-[0.01em]',
-      descriptionClassName: 'text-xs text-sky-600 dark:text-sky-300',
-      footerClassName: 'hidden',
-      renderLogo: () => <img className="h-14 w-auto" src={Aizex} alt="aizex"></img>,
-      title: 'Aizex 合租面板',
-      tone: 'default',
-    },
-  ],
-  'en': [
-    {
-      badge: 'SPONSORED',
-      cardClassName: `
-      overflow-hidden border-[#8b7bff]/20
-      bg-[radial-gradient(circle_at_12%_18%,rgba(139,123,255,0.20),transparent_32%),radial-gradient(circle_at_88%_14%,rgba(14,165,233,0.16),transparent_24%),linear-gradient(145deg,rgba(255,255,255,0.97),rgba(245,243,255,0.98))]
-      text-slate-900 shadow-[0_20px_44px_rgba(99,102,241,0.16)]
-      hover:shadow-[0_24px_54px_rgba(99,102,241,0.2)]
-      dark:border-[#8b7bff]/35 dark:text-white
-      dark:shadow-[0_24px_56px_rgba(14,165,233,0.14),0_10px_30px_rgba(76,29,149,0.24)]
-      dark:hover:shadow-[0_30px_70px_rgba(99,102,241,0.32),0_12px_36px_rgba(14,165,233,0.18)]
-      dark:bg-[radial-gradient(circle_at_14%_18%,rgba(139,123,255,0.34),transparent_34%),radial-gradient(circle_at_88%_18%,rgba(52,211,153,0.18),transparent_28%),linear-gradient(145deg,rgba(15,23,42,0.98),rgba(30,41,59,0.94))]
-    `,
-      description: 'Distributed search infrastructure for production teams',
-      href: 'https://easysearch.cn/',
-      imageWrapperClassName: `
-      relative z-10 px-1 pt-5 pb-1
-    `,
-      logoClassName: 'h-10 w-auto',
-      metaClassName: 'hidden',
-      titleClassName: 'hidden',
-      descriptionClassName: 'mx-auto max-w-[18ch] text-center text-[12px] leading-5 text-slate-600 dark:text-[#ddd6fe]',
-      footerClassName: 'hidden',
-      renderLogo: () => (
-        <>
-          <img
-            className="
-            h-10 w-auto
-            dark:hidden
-          "
-            src="/img/ads/easysearch.svg"
-            alt="Easysearch"
-          >
-          </img>
-          <img
-            className="
-            hidden h-10 w-auto
-            dark:block
-          "
-            src="/img/ads/easysearch-dark.svg"
-            alt="Easysearch"
-          >
-          </img>
-        </>
-      ),
-      title: 'Easysearch',
-      tone: 'hero',
-    },
-    {
-      badge: 'Recommended',
-      cardClassName: '',
-      description: 'A smoother way to combine GPT-5 and Claude',
-      href: 'https://aizex.cn/0LcJ7G',
-      imageWrapperClassName: `
-      rounded-xl bg-white/70 px-2 py-1
-      dark:bg-slate-900/30
-    `,
-      logoClassName: 'h-14 w-auto',
-      metaClassName: 'hidden',
-      titleClassName: 'text-base font-semibold tracking-[0.01em]',
-      descriptionClassName: 'text-xs text-sky-600 dark:text-sky-300',
-      footerClassName: 'hidden',
-      renderLogo: () => <img className="h-14 w-auto" src={Aizex} alt="aizex"></img>,
-      title: 'Aizex shared panel',
-      tone: 'default',
-    },
-  ],
-} as const
+const CAMPAIGN_REFRESH_INTERVAL = 60_000
 
 function AdsContainerElement() {
   const locale = useCurrentSiteLocale()
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const [isCompact, setIsCompact] = useState(false)
-  const currentAdItems = adItems[locale]
+  const [campaign, setCampaign] = useState<DisplayCampaign>(fallbackCampaign)
 
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.ResizeObserver === 'undefined') {
-      return
+    const refreshCampaign = () => {
+      setCampaign(selectDisplayCampaign(
+        paidCampaigns,
+        'weapp-tailwindcss',
+        fallbackCampaign,
+      ))
     }
 
-    const element = containerRef.current
-    if (!element) {
-      return
-    }
-
-    const updateCompactState = (width: number) => {
-      setIsCompact(width < 300)
-    }
-
-    updateCompactState(element.getBoundingClientRect().width)
-
-    const observer = new window.ResizeObserver((entries) => {
-      const entry = entries[0]
-      if (entry) {
-        updateCompactState(entry.contentRect.width)
-      }
-    })
-
-    observer.observe(element)
-    return () => observer.disconnect()
+    refreshCampaign()
+    const timer = window.setInterval(refreshCampaign, CAMPAIGN_REFRESH_INTERVAL)
+    return () => window.clearInterval(timer)
   }, [])
 
+  const creative = campaign.creative[locale]
+
   return (
-    <div ref={containerRef} className="space-y-4 px-4">
-      {/* 暂时仅展示 Easysearch 赞助位，保留 Aizex 配置以便后续恢复。 */}
-      {currentAdItems.filter(item => item.title === 'Easysearch').map(item => (
-        <a
-          key={item.title}
-          className={clsx(
-            `
-              relative flex rounded-2xl border border-slate-200/70
-              bg-[linear-gradient(135deg,rgba(255,255,255,0.96),rgba(241,245,249,0.9))]
-              p-4 text-slate-900 shadow-[0_18px_36px_rgba(15,23,42,0.06)]
-              transition-all duration-300
-              hover:-translate-y-0.5 hover:no-underline
-              hover:shadow-[0_22px_44px_rgba(14,165,233,0.14)]
-              dark:border-slate-700/70
-              dark:bg-[linear-gradient(135deg,rgba(15,23,42,0.9),rgba(30,41,59,0.86))]
-              dark:text-slate-100 dark:shadow-[0_22px_44px_rgba(2,8,23,0.34)]
-              dark:hover:shadow-[0_24px_52px_rgba(56,189,248,0.18)]
-            `,
-            item.cardClassName,
-            item.tone === 'hero'
-              ? 'flex-col items-center gap-2 px-3.5 pb-3.5 pt-2'
-              : (isCompact
-                  ? 'flex-col gap-3'
-                  : `items-center justify-between gap-4`),
-          )}
-          target="_blank"
-          href={item.href}
-          rel="noopener sponsored nofollow"
-        >
-          {item.tone === 'hero'
-            ? (
-                <>
-                  <div className="
-                    absolute inset-0
-                    bg-[linear-gradient(120deg,rgba(255,255,255,0.08),transparent_32%,transparent_66%,rgba(56,189,248,0.14))]
-                    opacity-90
-                  "
-                  >
-                  </div>
-                  <div className="
-                    bg-[#8b7bff]/16
-                    dark:bg-[#8b7bff]/18
-                    absolute -right-8 bottom-1 h-16 w-16 rounded-full blur-2xl
-                  "
-                  >
-                  </div>
-                  <div className="
-                    absolute left-3 top-2 text-[10px] font-semibold uppercase
-                    tracking-[0.22em] text-slate-500
-                    dark:text-white
-                    dark:[text-shadow:0_1px_12px_rgba(15,23,42,0.58)]
-                  "
-                  >
-                    {item.badge}
-                  </div>
-                  <div className="
-                    absolute -right-5 top-3 h-7 w-16 rotate-[24deg]
-                    bg-[linear-gradient(90deg,rgba(125,211,252,0.10),rgba(139,123,255,0.28),rgba(139,123,255,0))]
-                    dark:bg-[linear-gradient(90deg,rgba(125,211,252,0.15),rgba(139,123,255,0.4),rgba(139,123,255,0))]
-                  "
-                  >
-                  </div>
-                </>
-              )
-            : null}
-          <div
-            className={clsx(
-              'flex shrink-0 items-center',
-              item.tone === 'hero'
-                ? 'w-full justify-center'
-                : (isCompact ? 'justify-center' : ''),
-            )}
-          >
-            <div className={clsx('flex items-center justify-center', item.imageWrapperClassName)}>
-              {item.renderLogo()}
-            </div>
-          </div>
-          <div
-            className={clsx(
-              'flex flex-1 flex-col justify-around',
-              item.tone === 'hero'
-                ? 'relative z-10 w-full items-center text-center'
-                : (isCompact ? 'text-center' : 'self-stretch'),
-            )}
-          >
-            <div className={clsx('mb-1', item.metaClassName)}>
-              {locale === 'en' ? 'Brand sponsor slot' : '品牌赞助位'}
-            </div>
-            <div className={item.titleClassName}>
-              {item.title}
-            </div>
-            <div className={clsx('mt-1', item.descriptionClassName)}>
-              {item.description}
-            </div>
-            <div className={clsx('mt-2', item.footerClassName)}>
-              {locale === 'en' ? 'Explore search infrastructure' : '探索搜索基础设施'}
-            </div>
-          </div>
-          {item.badge && item.tone !== 'hero'
-            ? (
-                <div
-                  className={`
-                    absolute right-0 top-0 rounded-bl-lg rounded-tr-2xl
-                    bg-sky-500/10 px-2 py-1 text-xs font-medium text-sky-700
-                    dark:bg-sky-400/10 dark:text-sky-300
-                  `}
-                >
-                  {item.badge}
-                </div>
-              )
-            : null}
-        </a>
-      ))}
-      <div className="
-        flex w-full items-center justify-center overflow-visible py-2
-        dark:px-2
-      "
+    <div className="px-4" data-sponsor-campaign={campaign.id}>
+      <a
+        className={`
+          flex h-[176px] w-full flex-col items-center justify-center gap-3
+          overflow-hidden rounded-lg border border-slate-200 bg-white px-4 py-5
+          text-center text-slate-900 shadow-sm transition-colors
+          hover:border-sky-400 hover:no-underline
+          dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100
+          dark:hover:border-sky-500
+        `}
+        href={campaign.href}
+        target="_blank"
+        rel="noopener sponsored nofollow"
+        aria-label={`${creative.brand}: ${creative.copy}`}
       >
-        <div className="group relative overflow-visible">
-          <div
-            className={`
-              absolute -inset-2 rounded-[1rem]
-              bg-[radial-gradient(circle_at_50%_50%,rgba(56,189,248,0.26),rgba(139,92,246,0.18),transparent_72%)]
-              opacity-90 blur-md transition duration-500
-              group-hover:opacity-100
-              dark:bg-[radial-gradient(circle_at_50%_50%,rgba(45,212,191,0.16),rgba(139,92,246,0.34),transparent_72%)]
-              dark:blur-lg
-            `}
+        <span className="text-[10px] font-semibold uppercase text-slate-500 dark:text-slate-400">
+          {locale === 'en' ? 'Sponsored' : '赞助商'}
+        </span>
+        <span className="flex h-12 w-full items-center justify-center">
+          <img
+            className={creative.logoDarkSrc ? 'h-10 max-w-full object-contain dark:hidden' : 'h-10 max-w-full object-contain'}
+            src={creative.logoSrc}
+            alt={creative.logoAlt}
+            width="160"
+            height="40"
           />
-          <button
-            className={`
-              relative overflow-hidden rounded-xl border border-sky-200/70
-              bg-[linear-gradient(135deg,#f8fbff,#eef6ff_45%,#f5f3ff)] px-4 py-2
-              font-semibold text-slate-800
-              shadow-[0_14px_28px_rgba(56,189,248,0.16),inset_0_1px_0_rgba(255,255,255,0.88)]
-              transition duration-300
-              hover:-translate-y-0.5
-              hover:shadow-[0_18px_36px_rgba(99,102,241,0.22),inset_0_1px_0_rgba(255,255,255,0.92)]
-              dark:border-fuchsia-400/20
-              dark:bg-[linear-gradient(135deg,rgba(2,6,23,0.96),rgba(15,23,42,0.92),rgba(49,46,129,0.88))]
-              dark:text-slate-50
-              dark:shadow-[0_16px_32px_rgba(76,29,149,0.34),inset_0_1px_0_rgba(255,255,255,0.08)]
-              dark:hover:shadow-[0_20px_40px_rgba(99,102,241,0.4),inset_0_1px_0_rgba(255,255,255,0.1)]
-            `}
-          >
-            <div className="
-              absolute inset-0
-              bg-[linear-gradient(120deg,rgba(255,255,255,0.58),transparent_35%,transparent_68%,rgba(125,211,252,0.18))]
-              dark:bg-[linear-gradient(120deg,rgba(255,255,255,0.08),transparent_35%,transparent_68%,rgba(125,211,252,0.12))]
-            "
-            >
-            </div>
-            <Link
-              className="
-                relative z-10 text-inherit
-                hover:text-inherit
-              "
-              to={locale === 'en' ? 'https://github.com/sponsors/sonofmagic' : '/docs/sponsor'}
-            >
-              {locale === 'en' ? 'Become a sponsor' : '成为赞助商'}
-            </Link>
-          </button>
-        </div>
-      </div>
+          {creative.logoDarkSrc
+            ? (
+                <img
+                  className="hidden h-10 max-w-full object-contain dark:block"
+                  src={creative.logoDarkSrc}
+                  alt={creative.logoAlt}
+                  width="160"
+                  height="40"
+                />
+              )
+            : null}
+        </span>
+        <strong className="text-sm font-semibold">{creative.brand}</strong>
+        <span className="line-clamp-2 min-h-10 text-xs leading-5 text-slate-600 dark:text-slate-300">
+          {creative.copy}
+        </span>
+      </a>
+      <a
+        className="mt-3 block text-center text-xs font-medium text-sky-700 hover:no-underline dark:text-sky-300"
+        href={locale === 'en'
+          ? 'https://github.com/sonofmagic/sponsors/issues/new?template=business-sponsorship-en.yml'
+          : 'https://github.com/sonofmagic/sponsors/issues/new?template=business-sponsorship-zh.yml'}
+        target="_blank"
+        rel="noopener"
+      >
+        {locale === 'en' ? 'Advertise here' : '申请广告位'}
+      </a>
     </div>
   )
 }


### PR DESCRIPTION
## 变更内容

- 将硬编码广告拆分为独立 campaign 配置与展示组件
- campaign 支持站点、起止时间、中英文品牌与文案、Logo 和目标链接
- 采用 `[startsAt, endsAt)` 时间边界，每站同时最多一个有效付费 campaign
- 配置加载时校验同站排期重叠，运行时发现多个有效 campaign 也会直接失败
- 无有效付费排期时恢复 Easysearch 兜底广告
- 广告卡支持浅色/深色模式、固定高度、桌面展示、移动隐藏与安全外链属性

## 验证

- campaign 单测：生效前、生效中、到期后、兜底、30/90 天边界与排期冲突
- `pnpm --filter @weapp-tailwindcss/website exec vitest run --config vitest.config.ts`（29 项通过）
- `pnpm --filter @weapp-tailwindcss/website typecheck`
- `pnpm --filter @weapp-tailwindcss/website build`
- 相关文件 ESLint 通过
- Playwright 检查桌面/移动、浅色/深色、长文案、Logo、固定高度与横向溢出

## Changeset

纯网站展示改动，不涉及包发布，无需 changeset。