### PR TITLE
ci(website): 强化 Workers 部署验收

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run SEO/GEO quality gate
         run: pnpm --filter @weapp-tailwindcss/website seo:quality:strict
 
+      - name: Verify Worker routing locally
+        run: pnpm --filter @weapp-tailwindcss/website test:worker
+
       - name: Validate Worker bundle
         run: pnpm --filter @weapp-tailwindcss/website deploy:worker:dry-run
 
@@ -81,7 +84,9 @@ jobs:
       - name: Verify production deployment
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         working-directory: website
-        run: pnpm run verify:deployment -- https://tw.icebreaker.top
+        run: |
+          pnpm run verify:deployment -- https://tw.icebreaker.top
+          pnpm run verify:deployment -- https://weapp-tw.icebreaker.top --canonical-origin https://tw.icebreaker.top
 
       - name: Verify next deployment
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/next'

--- a/website/scripts/deployment-verification-options.test.ts
+++ b/website/scripts/deployment-verification-options.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { parseDeploymentVerificationOptions } from './deployment-verification-options'
+
+describe('parseDeploymentVerificationOptions', () => {
+  it('默认使用待验证站点作为 canonical origin', () => {
+    expect(parseDeploymentVerificationOptions(['--', 'https://tw.icebreaker.top'])).toEqual({
+      canonicalOrigin: 'https://tw.icebreaker.top',
+      siteUrl: new URL('https://tw.icebreaker.top'),
+    })
+  })
+
+  it('允许为 Worker 预览地址指定生产 canonical origin', () => {
+    expect(parseDeploymentVerificationOptions([
+      'https://migration-weapp-tailwindcss.example.workers.dev',
+      '--canonical-origin',
+      'https://tw.icebreaker.top/',
+    ])).toEqual({
+      canonicalOrigin: 'https://tw.icebreaker.top',
+      siteUrl: new URL('https://migration-weapp-tailwindcss.example.workers.dev'),
+    })
+  })
+
+  it('支持等号形式的 canonical origin 参数', () => {
+    expect(parseDeploymentVerificationOptions([
+      'https://weapp-tw.icebreaker.top',
+      '--canonical-origin=https://tw.icebreaker.top',
+    ]).canonicalOrigin).toBe('https://tw.icebreaker.top')
+  })
+
+  it('拒绝缺少值和未知参数', () => {
+    expect(() => parseDeploymentVerificationOptions(['https://example.com', '--canonical-origin'])).toThrow('--canonical-origin 缺少 URL')
+    expect(() => parseDeploymentVerificationOptions(['https://example.com', '--unexpected'])).toThrow('未知参数')
+  })
+})

--- a/website/scripts/deployment-verification-options.ts
+++ b/website/scripts/deployment-verification-options.ts
@@ -1,0 +1,57 @@
+export interface DeploymentVerificationOptions {
+  canonicalOrigin: string
+  siteUrl: URL
+}
+
+function parseUrl(rawUrl: string, label: string) {
+  const url = new URL(rawUrl)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`${label} 必须使用 http 或 https 协议`)
+  }
+  return url
+}
+
+export function parseDeploymentVerificationOptions(args: string[]): DeploymentVerificationOptions {
+  let canonicalOrigin: string | undefined
+  let rawSiteUrl: string | undefined
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--') {
+      continue
+    }
+    if (argument === '--canonical-origin') {
+      const value = args[index + 1]
+      if (!value || value.startsWith('--')) {
+        throw new Error('--canonical-origin 缺少 URL')
+      }
+      canonicalOrigin = parseUrl(value, 'canonical origin').origin
+      index += 1
+      continue
+    }
+    if (argument.startsWith('--canonical-origin=')) {
+      const value = argument.slice('--canonical-origin='.length)
+      if (!value) {
+        throw new Error('--canonical-origin 缺少 URL')
+      }
+      canonicalOrigin = parseUrl(value, 'canonical origin').origin
+      continue
+    }
+    if (argument.startsWith('-')) {
+      throw new Error(`未知参数：${argument}`)
+    }
+    if (rawSiteUrl) {
+      throw new Error(`只能传入一个待验证站点 URL：${argument}`)
+    }
+    rawSiteUrl = argument
+  }
+
+  if (!rawSiteUrl) {
+    throw new Error('请传入待验证的站点 URL')
+  }
+  const siteUrl = parseUrl(rawSiteUrl, '站点 URL')
+  return {
+    canonicalOrigin: canonicalOrigin ?? siteUrl.origin,
+    siteUrl,
+  }
+}

--- a/website/scripts/verify-deployment-assets.ts
+++ b/website/scripts/verify-deployment-assets.ts
@@ -3,6 +3,7 @@ import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
+import { parseDeploymentVerificationOptions } from './deployment-verification-options'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const attempts = 12
@@ -45,19 +46,37 @@ async function expectStatus(siteUrl: URL, pathname: string, status: number) {
   return response
 }
 
-async function verifyHtmlMetadata(siteUrl: URL, pathname: string, locale: 'en-US' | 'zh-CN') {
+async function verifyHtmlMetadata(siteUrl: URL, canonicalOrigin: string, pathname: string, locale: 'en-US' | 'zh-CN') {
   const response = await expectStatus(siteUrl, pathname, 200)
   const html = await response.text()
+  const linkTags = [...html.matchAll(/<link\b[^>]*>/g)].map(match => match[0])
   const canonicalPath = locale === 'zh-CN' ? pathname : pathname.replace(/^\/en(?=\/|$)/, '')
-  assert(html.includes(`rel="canonical" href="${siteUrl.origin}${canonicalPath}`), `${pathname} canonical is missing or incorrect`)
-  assert(html.includes('hreflang="en-US"'), `${pathname} is missing en-US hreflang`)
-  assert(html.includes('hreflang="zh-CN"'), `${pathname} is missing zh-CN hreflang`)
-  assert(html.includes('hreflang="x-default"'), `${pathname} is missing x-default hreflang`)
+  const englishPath = locale === 'zh-CN' ? pathname.replace(/^\/zh-cn(?=\/|$)/, '') || '/' : canonicalPath
+  const chinesePath = locale === 'zh-CN' ? pathname : `/zh-cn${canonicalPath}`
+  const hasLink = (rel: string, href: string, hreflang?: string) => linkTags.some(tag => tag.includes(`rel="${rel}"`)
+    && tag.includes(`href="${href}"`)
+    && (!hreflang || tag.includes(`hreflang="${hreflang}"`)))
+  assert(hasLink('canonical', `${canonicalOrigin}${canonicalPath}`), `${pathname} canonical is missing or incorrect`)
+  assert(hasLink('alternate', `${canonicalOrigin}${englishPath}`, 'en-US'), `${pathname} en-US hreflang is missing or incorrect`)
+  assert(hasLink('alternate', `${canonicalOrigin}${chinesePath}`, 'zh-CN'), `${pathname} zh-CN hreflang is missing or incorrect`)
+  assert(hasLink('alternate', `${canonicalOrigin}${englishPath}`, 'x-default'), `${pathname} x-default hreflang is missing or incorrect`)
   assert(html.includes('"@type":"SoftwareSourceCode"'), `${pathname} is missing SoftwareSourceCode JSON-LD`)
   assert(!html.includes('name="geo.region"') && !html.includes('name="ICBM"'), `${pathname} still contains geographic GEO metadata`)
 }
 
-async function verifyGeoAssets(siteUrl: URL) {
+async function verifySitemap(siteUrl: URL, canonicalOrigin: string, pathname: string, locale: 'en-US' | 'zh-CN') {
+  const sitemap = await (await expectStatus(siteUrl, pathname, 200)).text()
+  const locations = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(match => match[1])
+  assert(locations.length > 0, `${pathname} has no locations`)
+  for (const location of locations) {
+    const url = new URL(location)
+    assert(url.origin === canonicalOrigin, `${pathname} contains a location from an unexpected origin`)
+    const hasChinesePrefix = url.pathname.startsWith('/zh-cn/')
+    assert(locale === 'zh-CN' ? hasChinesePrefix : !hasChinesePrefix, `${pathname} contains a location from an unexpected locale`)
+  }
+}
+
+async function verifyGeoAssets(siteUrl: URL, canonicalOrigin: string) {
   const assets = [
     ['/llms-index.json', 'en-US', 'primary'],
     ['/llms-index-full.json', 'en-US', 'full'],
@@ -70,17 +89,18 @@ async function verifyGeoAssets(siteUrl: URL) {
     assert(payload.locale === locale, `${pathname} locale is incorrect`)
     assert(payload.contentTier === tier, `${pathname} content tier is incorrect`)
     assert(Array.isArray(payload.documents) && payload.documents.length > 0, `${pathname} has no documents`)
+    assert(payload.documents.every(item => new URL(String(item.canonical)).origin === canonicalOrigin), `${pathname} contains canonicals from an unexpected origin`)
     if (locale === 'en-US') {
       assert(payload.documents.every(item => !new URL(String(item.canonical)).pathname.startsWith('/en/')), `${pathname} contains /en canonicals`)
     }
   }
 }
 
-async function verifyOnce(siteUrl: URL, assets: Awaited<ReturnType<typeof getExpectedHashedAssets>>) {
-  await verifyHtmlMetadata(siteUrl, '/', 'en-US')
-  await verifyHtmlMetadata(siteUrl, '/docs/intro', 'en-US')
-  await verifyHtmlMetadata(siteUrl, '/zh-cn/', 'zh-CN')
-  await verifyHtmlMetadata(siteUrl, '/zh-cn/docs/intro', 'zh-CN')
+async function verifyOnce(siteUrl: URL, canonicalOrigin: string, assets: Awaited<ReturnType<typeof getExpectedHashedAssets>>) {
+  await verifyHtmlMetadata(siteUrl, canonicalOrigin, '/', 'en-US')
+  await verifyHtmlMetadata(siteUrl, canonicalOrigin, '/docs/intro', 'en-US')
+  await verifyHtmlMetadata(siteUrl, canonicalOrigin, '/zh-cn/', 'zh-CN')
+  await verifyHtmlMetadata(siteUrl, canonicalOrigin, '/zh-cn/docs/intro', 'zh-CN')
 
   const englishRedirect = await expectStatus(siteUrl, '/en/docs/intro', 301)
   assert(englishRedirect.headers.get('location') === '/docs/intro', '/en redirect location is incorrect')
@@ -91,10 +111,10 @@ async function verifyOnce(siteUrl: URL, assets: Awaited<ReturnType<typeof getExp
   await expectStatus(siteUrl, `/zh-cn/unknown-deployment-${Date.now()}`, 404)
 
   const robots = await (await expectStatus(siteUrl, '/robots.txt', 200)).text()
-  assert(robots.includes('/sitemap.xml') && robots.includes('/zh-cn/sitemap.xml'), 'robots.txt does not declare both sitemaps')
-  await expectStatus(siteUrl, '/sitemap.xml', 200)
-  await expectStatus(siteUrl, '/zh-cn/sitemap.xml', 200)
-  await verifyGeoAssets(siteUrl)
+  assert(robots.includes(`${canonicalOrigin}/sitemap.xml`) && robots.includes(`${canonicalOrigin}/zh-cn/sitemap.xml`), 'robots.txt does not declare both canonical sitemaps')
+  await verifySitemap(siteUrl, canonicalOrigin, '/sitemap.xml', 'en-US')
+  await verifySitemap(siteUrl, canonicalOrigin, '/zh-cn/sitemap.xml', 'zh-CN')
+  await verifyGeoAssets(siteUrl, canonicalOrigin)
 
   const homepage = await (await fetchNoCache(new URL('/', siteUrl))).text()
   for (const asset of assets) {
@@ -102,24 +122,23 @@ async function verifyOnce(siteUrl: URL, assets: Awaited<ReturnType<typeof getExp
       assert(homepage.includes(`href="${asset.pathname}"`), `homepage does not reference ${asset.pathname}`)
     }
     const response = await expectStatus(siteUrl, asset.pathname, 200)
+    if (asset.pathname.startsWith('/assets/')) {
+      assert(response.headers.get('cache-control') === 'public, max-age=31536000, immutable', `${asset.pathname} immutable cache policy is missing or incorrect`)
+    }
     const remoteSha256 = digest(new Uint8Array(await response.arrayBuffer()))
     assert(remoteSha256 === asset.sha256, `${asset.pathname} does not match this build`)
   }
 }
 
 async function main() {
-  const rawSiteUrl = process.argv.slice(2).find(argument => argument !== '--')
-  if (!rawSiteUrl) {
-    throw new Error('请传入待验证的站点 URL')
-  }
-  const siteUrl = new URL(rawSiteUrl)
+  const { canonicalOrigin, siteUrl } = parseDeploymentVerificationOptions(process.argv.slice(2))
   const assets = await getExpectedHashedAssets()
   let lastError: unknown
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      await verifyOnce(siteUrl, assets)
-      console.log(`[website] Workers 部署验证通过：${siteUrl.origin}`)
+      await verifyOnce(siteUrl, canonicalOrigin, assets)
+      console.log(`[website] Workers 部署验证通过：${siteUrl.origin}（canonical: ${canonicalOrigin}）`)
       return
     }
     catch (error) {

--- a/website/scripts/verify-worker-local.ts
+++ b/website/scripts/verify-worker-local.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { readdir } from 'node:fs/promises'
 import { createServer } from 'node:net'
 import path from 'node:path'
 import process from 'node:process'
@@ -47,6 +48,7 @@ async function expectResponse(baseUrl: URL, pathname: string, status: number, lo
   if (location && response.headers.get('location') !== location) {
     throw new Error(`${pathname} expected Location ${location}, received ${response.headers.get('location')}`)
   }
+  return response
 }
 
 async function main() {
@@ -80,7 +82,15 @@ async function main() {
     await expectResponse(baseUrl, '/docs/migrations/v2', 301, '/docs/migrations/v5')
     await expectResponse(baseUrl, '/unknown-worker-route', 404)
     await expectResponse(baseUrl, '/zh-cn/unknown-worker-route', 404)
-    console.log('[website] Wrangler local 200/301/404 verification passed')
+    const cssFiles = (await readdir(path.join(websiteRoot, 'build', 'assets', 'css'))).filter(filename => filename.endsWith('.css')).sort()
+    if (cssFiles.length === 0) {
+      throw new Error('Wrangler 本地测试找不到构建后的 CSS 资源')
+    }
+    const cssResponse = await expectResponse(baseUrl, `/assets/css/${cssFiles[0]}`, 200)
+    if (cssResponse.headers.get('cache-control') !== 'public, max-age=31536000, immutable') {
+      throw new Error('Wrangler 本地静态资源缺少 immutable 缓存策略')
+    }
+    console.log('[website] Wrangler local 200/301/404/cache verification passed')
   }
   catch (error) {
     if (stderr) {

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['scripts/**/*.test.mjs', 'src/**/*.test.ts'],
+    include: ['scripts/**/*.test.{mjs,ts}', 'src/**/*.test.ts'],
     environment: 'node',
   },
 })


### PR DESCRIPTION
## 变更

- 在 Docs Worker 工作流中加入本地 Worker 路由测试，并在生产部署后验证主域名与别名域名
- 扩展部署验证命令，分离访问地址与 canonical origin
- 补充 canonical、hreflang、双语 sitemap、GEO 索引及 immutable 缓存策略校验
- 增加部署参数解析回归测试

## 验证

- `pnpm --filter @weapp-tailwindcss/website test -- --run`
- `pnpm --filter @weapp-tailwindcss/website typecheck`
- `pnpm --filter @weapp-tailwindcss/website build`
- `pnpm --filter @weapp-tailwindcss/website test:worker`
- `pnpm --filter @weapp-tailwindcss/website deploy:worker:dry-run`
- `pnpm run verify:deployment -- https://tw.icebreaker.top`
- `pnpm run verify:deployment -- https://weapp-tw.icebreaker.top --canonical-origin https://tw.icebreaker.top`

不增加 change intent：仅涉及私有 Website、CI 与 Cloudflare 部署流程。