### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -1,0 +1,8 @@
+"@weapp-tailwindcss/lynx@0.3.0":
+  dir: packages/lynx
+  intents:
+    - lynx-tailwind-v4-compat
+weapp-tailwindcss@5.3.1:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - lynx-tailwind-v4-compat

--- a/.changeset/lynx-tailwind-v4-compat.md
+++ b/.changeset/lynx-tailwind-v4-compat.md
@@ -1,6 +1,0 @@
----
-"@weapp-tailwindcss/lynx": minor
-"weapp-tailwindcss": patch
----
-
-修复 ReactLynx/Rspeedy 多阶段 CSS loader 覆盖 Tailwind CSS 4 入口的问题，兼容 uni-app x 组件局部样式中的前置重要修饰符，并过滤小程序扫描中会生成非法 `:has()` 选择器的 `has-in`/`has-not-in` 变体；新增基于真实 CSS、encoder 与 iOS/Android runtime 报告的完整兼容性实验室。

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.0
+
+## 0.1.2
+
+### Patch Changes
+
 - 📦 **Dependencies** [`c2ba271`](https://github.com/sonofmagic/weapp-tailwindcss/commit/c2ba271ac62ba851c23549a8de1038a71bb868d6)
   → `@weapp-tailwindcss/lynx@0.2.1`
 

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.3
+
+## 0.1.3
+
+### Patch Changes
+
 - 📦 **Dependencies** [`c2ba271`](https://github.com/sonofmagic/weapp-tailwindcss/commit/c2ba271ac62ba851c23549a8de1038a71bb868d6)
   → `@weapp-tailwindcss/react-native@0.2.2`
 

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.1
+
+## 0.0.72
+
+### Patch Changes
+
 - 📦 Updated 13 dependencies [`c2ba271`](https://github.com/sonofmagic/weapp-tailwindcss/commit/c2ba271ac62ba851c23549a8de1038a71bb868d6)
   <details><summary>Details</summary>
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.1
+
 ## 5.3.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.0
+
+### Minor Changes
+
+- 修复 ReactLynx/Rspeedy 多阶段 CSS loader 覆盖 Tailwind CSS 4 入口的问题，兼容 uni-app x 组件局部样式中的前置重要修饰符，并过滤小程序扫描中会生成非法 `:has()` 选择器的 `has-in`/`has-not-in` 变体；新增基于真实 CSS、encoder 与 iOS/Android runtime 报告的完整兼容性实验室。
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.1
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.1
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,11 @@
 # weapp-tailwindcss
 
+## 5.3.1
+
+### Patch Changes
+
+- 修复 ReactLynx/Rspeedy 多阶段 CSS loader 覆盖 Tailwind CSS 4 入口的问题，兼容 uni-app x 组件局部样式中的前置重要修饰符，并过滤小程序扫描中会生成非法 `:has()` 选择器的 `has-in`/`has-not-in` 变体；新增基于真实 CSS、encoder 与 iOS/Android runtime 报告的完整兼容性实验室。
+
 ## 5.3.0
 
 ### Minor Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Patch Changes
 
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.1
+
+## 1.0.65
+
+### Patch Changes
+
 - 📦 Updated 4 dependencies [`c2ba271`](https://github.com/sonofmagic/weapp-tailwindcss/commit/c2ba271ac62ba851c23549a8de1038a71bb868d6)
   <details><summary>Details</summary>
 


### PR DESCRIPTION
# Release Notes

> 4 packages updated · 5 changes

## 🐞 Bug Fixes

- **@weapp-tailwindcss/lynx@0.3.0**: 修复 ReactLynx/Rspeedy 多阶段 CSS loader 覆盖 Tailwind CSS 4 入口的问题，兼容 uni-app x 组件局部样式中的前置重要修饰符，并过滤小程序扫描中会生成非法 :has() 选择器的 has-in/has-not-in 变体；新增基于真实 CSS、encoder 与 iOS/Android runtime 报告的完整兼容性实验室。 [`503a36c`](https://github.com/sonofmagic/weapp-tailwindcss/commit/503a36ce71b15fd8950c2f3dcf2089fc65389767)
- **weapp-tailwindcss@5.3.1**: 修复 ReactLynx/Rspeedy 多阶段 CSS loader 覆盖 Tailwind CSS 4 入口的问题，兼容 uni-app x 组件局部样式中的前置重要修饰符，并过滤小程序扫描中会生成非法 :has() 选择器的 has-in/has-not-in 变体；新增基于真实 CSS、encoder 与 iOS/Android runtime 报告的完整兼容性实验室。 [`503a36c`](https://github.com/sonofmagic/weapp-tailwindcss/commit/503a36ce71b15fd8950c2f3dcf2089fc65389767)

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.3.1**: Updated dependency to weapp-tailwindcss@5.3.1.
- **@weapp-tailwindcss/lynx@0.3.0**: Updated dependency to weapp-tailwindcss@5.3.1. [`503a36c`](https://github.com/sonofmagic/weapp-tailwindcss/commit/503a36ce71b15fd8950c2f3dcf2089fc65389767)
- **@weapp-tailwindcss/react-native@0.2.3**: Updated dependency to weapp-tailwindcss@5.3.1.

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.3.0`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.3.0) | `5.3.1` |
| `@weapp-tailwindcss/lynx` | [`0.2.1`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.2.1) | `0.3.0` |
| `@weapp-tailwindcss/react-native` | [`0.2.2`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.2) | `0.2.3` |
| `weapp-tailwindcss` | [`5.3.0`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.3.0) | `5.3.1` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic