### PR TITLE
修复 uni-app x Harmony VDOM 样式合并导致的跨端差异

### DIFF
--- a/.changeset/bright-harmony-vdom.md
+++ b/.changeset/bright-harmony-vdom.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x Harmony 构建中本地样式与 Tailwind 样式合并不完整导致的 VDOM 跨端显示差异，并提升样式注入的 ArkTS 兼容性。

--- a/e2e/demo-visual-theme.test.ts
+++ b/e2e/demo-visual-theme.test.ts
@@ -337,4 +337,40 @@ describe('demo visual theme evidence', () => {
     } as never)).not.toThrow()
     expect(results[0].status).toBe('passed')
   })
+
+  it('fails cross-platform comparisons above the configured ratio limit', async () => {
+    const artifactRoot = await fs.mkdtemp(path.join(tmpdir(), 'demo-visual-diff-limit-'))
+    const width = 390
+    const height = 844
+    const createImage = (value: number) => {
+      const png = new PNG({ width, height })
+      png.data.fill(value)
+      return png
+    }
+    const h5 = path.join(artifactRoot, 'h5.png')
+    const harmony = path.join(artifactRoot, 'harmony.png')
+    await fs.writeFile(h5, PNG.sync.write(createImage(0)))
+    await fs.writeFile(harmony, PNG.sync.write(createImage(255)))
+    const results = [
+      { name: 'demo', platform: 'h5' as const, status: 'passed' as const, screenshot: h5 },
+      { name: 'demo', platform: 'app-harmony' as const, status: 'passed' as const, screenshot: harmony },
+    ]
+
+    const { createCrossPlatformComparisons } = await import('../scripts/demo-visual-e2e-report/report')
+    createCrossPlatformComparisons(results, {
+      artifactRoot,
+      viewport: { width, height },
+      maxCrossPlatformDiffRatio: 0.05,
+    } as never)
+
+    expect(results[0].status).toBe('failed')
+    expect(results[1].status).toBe('failed')
+    expect(results[1].error).toContain('超过上限 0.05')
+    expect(results[1].comparison).toMatchObject({
+      maxRatio: 0.05,
+      target: 'h5',
+      withinLimit: false,
+    })
+    await fs.rm(artifactRoot, { recursive: true, force: true })
+  })
 })

--- a/packages/weapp-tailwindcss/src/uni-app-x/style-asset.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/style-asset.ts
@@ -1,35 +1,38 @@
 import type { OutputAsset, OutputChunk } from 'rollup'
-import type { StyleValue } from './style-asset/style-value'
+import type { HarmonyStyleInjectOptions } from './style-asset/harmony-global'
 import { postcss } from '@weapp-tailwindcss/postcss'
 import { expandUniAppXHarmonyApplyStyles } from './style-asset/harmony-apply'
+import {
+  injectUniAppXHarmonyGlobalStyles,
+  resolveStyleAssetFile,
+  resolveStylePlaceholderFallbackFiles,
+} from './style-asset/harmony-global'
 import {
   collectChunkMapSourcesContent,
   collectUniAppXHarmonyApplyStyleSourcesFromSource,
   collectUniAppXHarmonyApplyUtilitiesFromSources,
-  createMergedStyleValue,
-  createMergedStyleValues,
-  createStyleValueFromApplySources,
   createUtsStyleArrayFromAppStyles,
   cssSourceToStyleValue,
   mergeStyleValues,
   parseSourceMapSourcesContent,
-  parseStyleObject,
   styleExportToUtsMap,
-
 } from './style-asset/style-value'
 
 const GEN_STYLES_PLACEHOLDER_RE = /\/\*(Gen[A-Za-z0-9]+Styles)\*\/|const\s+(Gen[A-Za-z0-9]+Styles)\s*=\s*\[\]/
-const UVUE_TS_RE = /\.uvue\.ts$/
-const JS_RE = /\.js$/
 const APP_JS_RE = /(?:^|\/)App\.js$/
-const COMPONENT_JS_RE = /(?:^|\/)components\/.+\.js$/
 const HARMONY_BUNDLE_MARKER_FILES = new Set([
   'import/app-service.ets',
   'import/dynamic.ets',
   'uni_modules/oh-package.json5',
 ])
-const STYLE_DECL_RE = /const\s+(_style_\d+)\s*=\s*\{/g
-const EXPORT_SFC_RE = /_export_sfc\(_sfc_main\s*,\s*\[/
+
+function resolveSourceMapFiles(file: string) {
+  return [
+    `${file}.map`,
+    file.startsWith('assets/') ? `${file.slice('assets/'.length)}.map` : undefined,
+    file.startsWith('assets/') ? undefined : `assets/${file}.map`,
+  ].filter((item): item is string => typeof item === 'string')
+}
 
 export const UNI_APP_X_STYLE_PLACEHOLDER_VERSION = 'uni-app-x-style-placeholder-v3'
 
@@ -40,26 +43,11 @@ type OutputChunkWithViteMetadata = OutputChunk & {
   }
 }
 
-interface HarmonyStyleInjectOptions {
-  cssSources?: Iterable<string | undefined> | undefined
-  styleAssetFiles?: Iterable<string | undefined> | ((file: string) => Iterable<string | undefined>) | undefined
-  excludeComponents?: boolean | undefined
-  mapSources?: Iterable<string | undefined> | undefined
-}
-
-interface StyleObjectDecl {
-  end: number
-  objectEnd: number
-  objectStart: number
-  objectText: string
-  start: number
-  varName: string
-}
-
 export {
   collectUniAppXHarmonyApplyStyleSourcesFromSource,
   collectUniAppXHarmonyApplyUtilitiesFromSources,
   expandUniAppXHarmonyApplyStyles,
+  injectUniAppXHarmonyGlobalStyles,
 }
 
 export function createUniAppXHarmonyApplyGeneratorSource(
@@ -138,158 +126,6 @@ export function collectUniAppXHarmonyApplyStyleSources(bundle: Record<string, Bu
   return [...sources]
 }
 
-function resolveStyleAssetFile(file: string) {
-  if (!UVUE_TS_RE.test(file)) {
-    return
-  }
-  return file.replace(/\.uvue\.ts$/, '.uvue')
-}
-
-function resolveStylePlaceholderFallbackFiles(file: string) {
-  const styleAssetFile = resolveStyleAssetFile(file)
-  if (!styleAssetFile) {
-    return []
-  }
-  const base = styleAssetFile.replace(/\.uvue$/, '')
-  return [
-    styleAssetFile,
-    `${base}.wxss`,
-    `${base}.css`,
-  ]
-}
-
-function findBalancedObjectEnd(source: string, start: number) {
-  let depth = 0
-  let quote: string | undefined
-  let escaped = false
-  for (let index = start; index < source.length; index++) {
-    const char = source[index]
-    if (quote) {
-      if (escaped) {
-        escaped = false
-      }
-      else if (char === '\\') {
-        escaped = true
-      }
-      else if (char === quote) {
-        quote = undefined
-      }
-      continue
-    }
-    if (char === '"' || char === '\'' || char === '`') {
-      quote = char
-      continue
-    }
-    if (char === '{') {
-      depth++
-      continue
-    }
-    if (char === '}') {
-      depth--
-      if (depth === 0) {
-        return index + 1
-      }
-    }
-  }
-}
-
-function findStyleObjectDecls(source: string) {
-  STYLE_DECL_RE.lastIndex = 0
-  const declarations: StyleObjectDecl[] = []
-  for (const match of source.matchAll(STYLE_DECL_RE)) {
-    const varName = match[1]
-    if (!varName || match.index === undefined) {
-      continue
-    }
-    const objectStart = source.indexOf('{', match.index)
-    if (objectStart < 0) {
-      continue
-    }
-    const objectEnd = findBalancedObjectEnd(source, objectStart)
-    if (!objectEnd) {
-      continue
-    }
-    const semicolonEnd = source[objectEnd] === ';' ? objectEnd + 1 : objectEnd
-    declarations.push({
-      end: semicolonEnd,
-      objectEnd,
-      objectStart,
-      objectText: source.slice(objectStart, objectEnd),
-      start: match.index,
-      varName,
-    })
-  }
-  return declarations
-}
-
-function resolveCssFallbackFiles(styleAssetFiles: Iterable<string | undefined> = []) {
-  const files = new Set<string>()
-  for (const assetFile of styleAssetFiles) {
-    if (assetFile) {
-      files.add(assetFile)
-    }
-  }
-  return [...files]
-}
-
-function resolveStyleAssetFilesForChunk(file: string, styleAssetFiles: HarmonyStyleInjectOptions['styleAssetFiles']) {
-  return typeof styleAssetFiles === 'function'
-    ? styleAssetFiles(file)
-    : styleAssetFiles
-}
-
-function resolveSourceMapFiles(file: string) {
-  return [
-    `${file}.map`,
-    file.startsWith('assets/') ? `${file.slice('assets/'.length)}.map` : undefined,
-    file.startsWith('assets/') ? undefined : `assets/${file}.map`,
-  ].filter((item): item is string => typeof item === 'string')
-}
-
-function createStyleValueFromBundleSources(
-  file: string,
-  _code: string,
-  getBundleSource?: (file: string) => string | undefined,
-  options: HarmonyStyleInjectOptions = {},
-) {
-  const cssStyles = mergeStyleValues(
-    ...[...(options.cssSources ?? [])].map(source => source ? cssSourceToStyleValue(source) : undefined),
-    ...resolveCssFallbackFiles(resolveStyleAssetFilesForChunk(file, options.styleAssetFiles)).map((cssFile) => {
-      const source = getBundleSource?.(cssFile)
-      return source ? cssSourceToStyleValue(source) : undefined
-    }),
-  )
-  const mapSources = [
-    ...(options.mapSources ?? []),
-    ...resolveSourceMapFiles(file).flatMap((mapFile) => {
-      const source = getBundleSource?.(mapFile)
-      return source ? parseSourceMapSourcesContent(source) : []
-    }),
-  ].filter((source): source is string => typeof source === 'string')
-  return mergeStyleValues(cssStyles, createStyleValueFromApplySources(mapSources, cssStyles))
-}
-
-function injectStyleOption(code: string, styleVarName: string) {
-  const styleOptionMatch = code.match(/(\["styles"\s*,\s*\[)([^\]]*)(\]\])/)
-  if (styleOptionMatch?.index !== undefined) {
-    const styleVars = styleOptionMatch[2]?.trim()
-    if (styleVars?.split(',').map(item => item.trim()).includes(styleVarName)) {
-      return code
-    }
-    const replacement = `${styleOptionMatch[1]}${styleVars ? `${styleVars}, ` : ''}${styleVarName}${styleOptionMatch[3]}`
-    return `${code.slice(0, styleOptionMatch.index)}${replacement}${code.slice(styleOptionMatch.index + styleOptionMatch[0].length)}`
-  }
-  const exportMatch = code.match(EXPORT_SFC_RE)
-  if (!exportMatch || exportMatch.index === undefined) {
-    return code
-  }
-  const fileOptionIndex = code.indexOf('["__file"', exportMatch.index)
-  if (fileOptionIndex < 0) {
-    return code
-  }
-  return `${code.slice(0, fileOptionIndex)}["styles", [${styleVarName}]], ${code.slice(fileOptionIndex)}`
-}
-
 export function injectUniAppXStylePlaceholder(
   file: string,
   code: string,
@@ -321,66 +157,6 @@ export function injectUniAppXStylePlaceholder(
     ? styleArrays[0]
     : `[${styleArrays.map(item => item.slice(1, -1)).filter(Boolean).join(', ')}]`
   return code.replace(GEN_STYLES_PLACEHOLDER_RE, `const ${stylesName} = ${mergedStyleArray}`)
-}
-
-export function injectUniAppXHarmonyGlobalStyles(
-  file: string,
-  code: string,
-  getBundleSource?: (file: string) => string | undefined,
-  options: HarmonyStyleInjectOptions = {},
-) {
-  if (!JS_RE.test(file) || APP_JS_RE.test(file)) {
-    return code
-  }
-  if (options.excludeComponents && COMPONENT_JS_RE.test(file)) {
-    return code
-  }
-  const appSource = getBundleSource?.('assets/App.js') ?? getBundleSource?.('App.js')
-  const appStyle = appSource
-    ? mergeStyleValues(...findStyleObjectDecls(appSource).map(decl => parseStyleObject(decl.objectText)))
-    : undefined
-  const localStyleDecls = findStyleObjectDecls(code)
-  const parseableLocalStyles = localStyleDecls.flatMap((decl) => {
-    const style = parseStyleObject(decl.objectText)
-    return style ? [{ decl, style }] : []
-  })
-  const bundleStyle = createStyleValueFromBundleSources(file, code, getBundleSource, options)
-  const styleSource = mergeStyleValues(bundleStyle, appStyle)
-  if (!styleSource) {
-    return code
-  }
-  const mergedStyles = createMergedStyleValues(
-    code,
-    parseableLocalStyles.map(item => item.style),
-    styleSource as StyleValue,
-  )
-  if (mergedStyles) {
-    let nextCode = code
-    for (let index = parseableLocalStyles.length - 1; index >= 0; index--) {
-      const decl = parseableLocalStyles[index].decl
-      nextCode = `${nextCode.slice(0, decl.objectStart)}${JSON.stringify(mergedStyles[index])}${nextCode.slice(decl.objectEnd)}`
-    }
-    return nextCode
-  }
-  if (parseableLocalStyles.length > 0) {
-    return code
-  }
-  const newStyle = createMergedStyleValue(code, undefined, styleSource as StyleValue)
-  if (!newStyle) {
-    return code
-  }
-  const exportMatch = code.match(EXPORT_SFC_RE)
-  if (!exportMatch || exportMatch.index === undefined) {
-    return code
-  }
-  const styleVarName = '_style_wt'
-  const statementStart = code.lastIndexOf('\n', exportMatch.index)
-  const insertPos = statementStart === -1 ? 0 : statementStart + 1
-  const declarationRE = new RegExp(`\\b(?:const|let|var)\\s+${styleVarName}\\s*=`)
-  const withStyleDecl = declarationRE.test(code)
-    ? code
-    : `${code.slice(0, insertPos)}const ${styleVarName} = ${JSON.stringify(newStyle)};\n${code.slice(insertPos)}`
-  return injectStyleOption(withStyleDecl, styleVarName)
 }
 
 export function injectUniAppXHarmonyBundleStyles(

--- a/packages/weapp-tailwindcss/src/uni-app-x/style-asset.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/style-asset.ts
@@ -374,7 +374,12 @@ export function injectUniAppXHarmonyGlobalStyles(
     return code
   }
   const styleVarName = '_style_wt'
-  const withStyleDecl = `${code.slice(0, exportMatch.index)}const ${styleVarName} = ${JSON.stringify(newStyle)};\n${code.slice(exportMatch.index)}`
+  const statementStart = code.lastIndexOf('\n', exportMatch.index)
+  const insertPos = statementStart === -1 ? 0 : statementStart + 1
+  const declarationRE = new RegExp(`\\b(?:const|let|var)\\s+${styleVarName}\\s*=`)
+  const withStyleDecl = declarationRE.test(code)
+    ? code
+    : `${code.slice(0, insertPos)}const ${styleVarName} = ${JSON.stringify(newStyle)};\n${code.slice(insertPos)}`
   return injectStyleOption(withStyleDecl, styleVarName)
 }
 

--- a/packages/weapp-tailwindcss/src/uni-app-x/style-asset/harmony-global.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/style-asset/harmony-global.ts
@@ -1,0 +1,244 @@
+import type { StyleValue } from './style-value'
+import {
+  createMergedStyleValue,
+  createMergedStyleValues,
+  createStyleValueFromApplySources,
+  cssSourceToStyleValue,
+  mergeStyleValues,
+  parseSourceMapSourcesContent,
+  parseStyleObject,
+} from './style-value'
+
+const UVUE_TS_RE = /\.uvue\.ts$/
+const JS_RE = /\.js$/
+const APP_JS_RE = /(?:^|\/)App\.js$/
+const COMPONENT_JS_RE = /(?:^|\/)components\/.+\.js$/
+const STYLE_DECL_RE = /const\s+(_style_\d+)\s*=\s*\{/g
+const EXPORT_SFC_RE = /_export_sfc\(_sfc_main\s*,\s*\[/
+
+export interface HarmonyStyleInjectOptions {
+  cssSources?: Iterable<string | undefined> | undefined
+  styleAssetFiles?: Iterable<string | undefined> | ((file: string) => Iterable<string | undefined>) | undefined
+  excludeComponents?: boolean | undefined
+  mapSources?: Iterable<string | undefined> | undefined
+}
+
+interface StyleObjectDecl {
+  end: number
+  objectEnd: number
+  objectStart: number
+  objectText: string
+  start: number
+  varName: string
+}
+
+export function resolveStyleAssetFile(file: string) {
+  if (!UVUE_TS_RE.test(file)) {
+    return
+  }
+  return file.replace(/\.uvue\.ts$/, '.uvue')
+}
+
+export function resolveStylePlaceholderFallbackFiles(file: string) {
+  const styleAssetFile = resolveStyleAssetFile(file)
+  if (!styleAssetFile) {
+    return []
+  }
+  const base = styleAssetFile.replace(/\.uvue$/, '')
+  return [
+    styleAssetFile,
+    `${base}.wxss`,
+    `${base}.css`,
+  ]
+}
+
+function findBalancedObjectEnd(source: string, start: number) {
+  let depth = 0
+  let quote: string | undefined
+  let escaped = false
+  for (let index = start; index < source.length; index++) {
+    const char = source[index]
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      }
+      else if (char === '\\') {
+        escaped = true
+      }
+      else if (char === quote) {
+        quote = undefined
+      }
+      continue
+    }
+    if (char === '"' || char === '\'' || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '{') {
+      depth++
+      continue
+    }
+    if (char === '}') {
+      depth--
+      if (depth === 0) {
+        return index + 1
+      }
+    }
+  }
+}
+
+function findStyleObjectDecls(source: string) {
+  STYLE_DECL_RE.lastIndex = 0
+  const declarations: StyleObjectDecl[] = []
+  for (const match of source.matchAll(STYLE_DECL_RE)) {
+    const varName = match[1]
+    if (!varName || match.index === undefined) {
+      continue
+    }
+    const objectStart = source.indexOf('{', match.index)
+    if (objectStart < 0) {
+      continue
+    }
+    const objectEnd = findBalancedObjectEnd(source, objectStart)
+    if (!objectEnd) {
+      continue
+    }
+    const semicolonEnd = source[objectEnd] === ';' ? objectEnd + 1 : objectEnd
+    declarations.push({
+      end: semicolonEnd,
+      objectEnd,
+      objectStart,
+      objectText: source.slice(objectStart, objectEnd),
+      start: match.index,
+      varName,
+    })
+  }
+  return declarations
+}
+
+function resolveCssFallbackFiles(styleAssetFiles: Iterable<string | undefined> = []) {
+  const files = new Set<string>()
+  for (const assetFile of styleAssetFiles) {
+    if (assetFile) {
+      files.add(assetFile)
+    }
+  }
+  return [...files]
+}
+
+function resolveStyleAssetFilesForChunk(file: string, styleAssetFiles: HarmonyStyleInjectOptions['styleAssetFiles']) {
+  return typeof styleAssetFiles === 'function'
+    ? styleAssetFiles(file)
+    : styleAssetFiles
+}
+
+function resolveSourceMapFiles(file: string) {
+  return [
+    `${file}.map`,
+    file.startsWith('assets/') ? `${file.slice('assets/'.length)}.map` : undefined,
+    file.startsWith('assets/') ? undefined : `assets/${file}.map`,
+  ].filter((item): item is string => typeof item === 'string')
+}
+
+function createStyleValueFromBundleSources(
+  file: string,
+  getBundleSource?: (file: string) => string | undefined,
+  options: HarmonyStyleInjectOptions = {},
+) {
+  const cssStyles = mergeStyleValues(
+    ...[...(options.cssSources ?? [])].map(source => source ? cssSourceToStyleValue(source) : undefined),
+    ...resolveCssFallbackFiles(resolveStyleAssetFilesForChunk(file, options.styleAssetFiles)).map((cssFile) => {
+      const source = getBundleSource?.(cssFile)
+      return source ? cssSourceToStyleValue(source) : undefined
+    }),
+  )
+  const mapSources = [
+    ...(options.mapSources ?? []),
+    ...resolveSourceMapFiles(file).flatMap((mapFile) => {
+      const source = getBundleSource?.(mapFile)
+      return source ? parseSourceMapSourcesContent(source) : []
+    }),
+  ].filter((source): source is string => typeof source === 'string')
+  return mergeStyleValues(cssStyles, createStyleValueFromApplySources(mapSources, cssStyles))
+}
+
+function injectStyleOption(code: string, styleVarName: string) {
+  const styleOptionMatch = code.match(/(\["styles"\s*,\s*\[)([^\]]*)(\]\])/)
+  if (styleOptionMatch?.index !== undefined) {
+    const styleVars = styleOptionMatch[2]?.trim()
+    if (styleVars?.split(',').map(item => item.trim()).includes(styleVarName)) {
+      return code
+    }
+    const replacement = `${styleOptionMatch[1]}${styleVars ? `${styleVars}, ` : ''}${styleVarName}${styleOptionMatch[3]}`
+    return `${code.slice(0, styleOptionMatch.index)}${replacement}${code.slice(styleOptionMatch.index + styleOptionMatch[0].length)}`
+  }
+  const exportMatch = code.match(EXPORT_SFC_RE)
+  if (!exportMatch || exportMatch.index === undefined) {
+    return code
+  }
+  const fileOptionIndex = code.indexOf('["__file"', exportMatch.index)
+  if (fileOptionIndex < 0) {
+    return code
+  }
+  return `${code.slice(0, fileOptionIndex)}["styles", [${styleVarName}]], ${code.slice(fileOptionIndex)}`
+}
+
+export function injectUniAppXHarmonyGlobalStyles(
+  file: string,
+  code: string,
+  getBundleSource?: (file: string) => string | undefined,
+  options: HarmonyStyleInjectOptions = {},
+) {
+  if (!JS_RE.test(file) || APP_JS_RE.test(file)) {
+    return code
+  }
+  if (options.excludeComponents && COMPONENT_JS_RE.test(file)) {
+    return code
+  }
+  const appSource = getBundleSource?.('assets/App.js') ?? getBundleSource?.('App.js')
+  const appStyle = appSource
+    ? mergeStyleValues(...findStyleObjectDecls(appSource).map(decl => parseStyleObject(decl.objectText)))
+    : undefined
+  const localStyleDecls = findStyleObjectDecls(code)
+  const parseableLocalStyles = localStyleDecls.flatMap((decl) => {
+    const style = parseStyleObject(decl.objectText)
+    return style ? [{ decl, style }] : []
+  })
+  const bundleStyle = createStyleValueFromBundleSources(file, getBundleSource, options)
+  const styleSource = mergeStyleValues(bundleStyle, appStyle)
+  if (!styleSource) {
+    return code
+  }
+  const mergedStyles = createMergedStyleValues(
+    code,
+    parseableLocalStyles.map(item => item.style),
+    styleSource as StyleValue,
+  )
+  if (mergedStyles) {
+    let nextCode = code
+    for (let index = parseableLocalStyles.length - 1; index >= 0; index--) {
+      const decl = parseableLocalStyles[index].decl
+      nextCode = `${nextCode.slice(0, decl.objectStart)}${JSON.stringify(mergedStyles[index])}${nextCode.slice(decl.objectEnd)}`
+    }
+    return nextCode
+  }
+  if (parseableLocalStyles.length > 0) {
+    return code
+  }
+  const newStyle = createMergedStyleValue(code, undefined, styleSource as StyleValue)
+  if (!newStyle) {
+    return code
+  }
+  const exportMatch = code.match(EXPORT_SFC_RE)
+  if (!exportMatch || exportMatch.index === undefined) {
+    return code
+  }
+  const styleVarName = '_style_wt'
+  const statementStart = code.lastIndexOf('\n', exportMatch.index)
+  const insertPos = statementStart === -1 ? 0 : statementStart + 1
+  const declarationRE = new RegExp(`\\b(?:const|let|var)\\s+${styleVarName}\\s*=`)
+  const withStyleDecl = declarationRE.test(code)
+    ? code
+    : `${code.slice(0, insertPos)}const ${styleVarName} = ${JSON.stringify(newStyle)};\n${code.slice(insertPos)}`
+  return injectStyleOption(withStyleDecl, styleVarName)
+}

--- a/packages/weapp-tailwindcss/src/uni-app-x/style-asset/style-value.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/style-asset/style-value.ts
@@ -14,6 +14,32 @@ const CLASS_SELECTOR_PREFIX_RE = /^\.((?:\\[^\n\r\f]|[\w-])+)(?=$|[.:#[])/
 type StyleDeclarations = Record<string, string | number>
 export type StyleValue = Record<string, Record<string, StyleDeclarations>>
 
+function cloneStyleEntry(entry: Record<string, StyleDeclarations>): Record<string, StyleDeclarations> {
+  return Object.fromEntries(
+    Object.entries(entry).map(([state, declarations]) => [state, { ...declarations }]),
+  )
+}
+
+function mergeStyleEntry(
+  local: Record<string, StyleDeclarations> | undefined,
+  generated: Record<string, StyleDeclarations>,
+) {
+  const merged = local ? cloneStyleEntry(local) : {}
+  for (const [state, declarations] of Object.entries(generated)) {
+    merged[state] = {
+      ...(merged[state] ?? {}),
+      ...declarations,
+    }
+  }
+  return merged
+}
+
+function cloneStyleValue(style: StyleValue): StyleValue {
+  return Object.fromEntries(
+    Object.entries(style).map(([className, entry]) => [className, cloneStyleEntry(entry)]),
+  )
+}
+
 function toCamelCase(prop: string) {
   return prop.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())
 }
@@ -329,15 +355,18 @@ export function createMergedStyleValue(code: string, localStyle: StyleValue | un
   if (used.size === 0) {
     return
   }
-  const merged: StyleValue = {
-    ...(localStyle ?? {}),
-  }
+  const merged = localStyle ? cloneStyleValue(localStyle) : {}
   let changed = false
   for (const className of used) {
-    if (merged[className] || !appStyle[className]) {
+    const generatedStyle = appStyle[className]
+    if (!generatedStyle) {
       continue
     }
-    merged[className] = appStyle[className]
+    const next = mergeStyleEntry(merged[className], generatedStyle)
+    if (JSON.stringify(next) === JSON.stringify(merged[className])) {
+      continue
+    }
+    merged[className] = next
     changed = true
   }
   return changed ? merged : undefined
@@ -351,7 +380,7 @@ export function createMergedStyleValues(code: string, localStyles: StyleValue[],
   if (used.size === 0) {
     return
   }
-  const merged = localStyles.map(style => ({ ...style }))
+  const merged = localStyles.map(cloneStyleValue)
   let changed = false
   for (const className of used) {
     const generatedStyle = appStyle[className]
@@ -360,15 +389,16 @@ export function createMergedStyleValues(code: string, localStyles: StyleValue[],
     }
     const indexes = merged.flatMap((style, index) => style[className] ? [index] : [])
     if (indexes.length === 0) {
-      merged[0][className] = generatedStyle
+      merged[0][className] = mergeStyleEntry(undefined, generatedStyle)
       changed = true
       continue
     }
     for (const index of indexes) {
-      if (JSON.stringify(merged[index][className]) === JSON.stringify(generatedStyle)) {
+      const next = mergeStyleEntry(merged[index][className], generatedStyle)
+      if (JSON.stringify(merged[index][className]) === JSON.stringify(next)) {
         continue
       }
-      merged[index][className] = generatedStyle
+      merged[index][className] = next
       changed = true
     }
   }

--- a/packages/weapp-tailwindcss/test/uni-app-x/style-asset.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/style-asset.test.ts
@@ -161,6 +161,33 @@ describe('uni-app-x style asset helpers', () => {
     expect(next).toContain('green')
   })
 
+  it('inserts generated style declarations at a statement boundary and remains idempotent', () => {
+    const code = 'const cls = "green"; const page = /* @__PURE__ */ _export_sfc(_sfc_main, [["__file","pages/index.uvue"]]);'
+    const next = injectUniAppXHarmonyGlobalStyles('pages/index.js', code, undefined, {
+      cssSources: ['.green{color:green}'],
+    })
+
+    expect(next).toMatch(/^const _style_wt = .*;\nconst cls = "green"; const page = \/\* @__PURE__ \*\//)
+    expect(next.match(/const _style_wt\s*=/g)).toHaveLength(1)
+    expect(next.match(/\["styles", \[_style_wt\]\]/g)).toHaveLength(1)
+    expect(injectUniAppXHarmonyGlobalStyles('pages/index.js', next, undefined, {
+      cssSources: ['.green{color:green}'],
+    })).toBe(next)
+
+    const existingStyle = 'let _style_wt = {"green":{"":{"color":"green"}}};const page = _export_sfc(_sfc_main, [["styles", [_style_wt]], ["__file","pages/index.uvue"]]);'
+    expect(injectUniAppXHarmonyGlobalStyles('pages/index.js', existingStyle, undefined, {
+      cssSources: ['.green{color:green}'],
+    })).toBe(existingStyle)
+
+    const existingDeclaration = 'var _style_wt = {"green":{"":{"color":"green"}}};const page = _export_sfc(_sfc_main, [["__file","pages/index.uvue"]]);'
+    const withExistingDeclaration = injectUniAppXHarmonyGlobalStyles('pages/index.js', existingDeclaration, undefined, {
+      cssSources: ['.green{color:green}'],
+    })
+    expect(withExistingDeclaration).toContain('var _style_wt = {"green":{"":{"color":"green"}}};')
+    expect(withExistingDeclaration).toContain('[["styles", [_style_wt]], ["__file"')
+    expect(withExistingDeclaration.match(/(?:const|let|var) _style_wt\s*=/g)).toHaveLength(1)
+  })
+
   it('reconciles generated styles across every parseable harmony style object', () => {
     const code = [
       'const _style_0 = {"local":{"":{"color":"red"}},"shared":{"":{"borderRadius":9999}}};',
@@ -287,7 +314,16 @@ describe('uni-app-x style asset helpers', () => {
     expect(collectUniAppXHarmonyApplyStyleSourcesFromSource('<style>.a{@apply flex}</style><style>.b{color:red}</style>')).toEqual(['.a{@apply flex}'])
     expect([...collectUniAppXHarmonyApplyUtilitiesFromSources(['.a{@apply flex block}', '.broken{'])]).toEqual(['flex', 'block'])
     expect(createMergedStyleValue('const cls = "app"', undefined, { app: { '': { color: 'red' } } })?.app[''].color).toBe('red')
-    expect(createMergedStyleValue('const cls = "app"', { app: { '': { color: 'blue' } } }, { app: { '': { color: 'red' } } })).toBeUndefined()
+    expect(createMergedStyleValue('const cls = "app"', { app: { '': { color: 'blue' } } }, { app: { '': { color: 'red' } } })).toEqual({
+      app: { '': { color: 'red' } },
+    })
+    expect(createMergedStyleValue('const cls = "app"', {
+      app: { '': { color: 'blue', padding: 12 }, dark: { color: 'white' } },
+    }, {
+      app: { '': { color: 'red', margin: 8 }, dark: { backgroundColor: 'black' } },
+    })).toEqual({
+      app: { '': { color: 'red', padding: 12, margin: 8 }, dark: { color: 'white', backgroundColor: 'black' } },
+    })
     expect(createMergedStyleValue('const cls = "none"', undefined, { app: { '': { color: 'red' } } })).toBeUndefined()
     expect(createMergedStyleValues('const cls = "app added"', [
       { app: { '': { color: 'blue' } } },
@@ -298,6 +334,15 @@ describe('uni-app-x style asset helpers', () => {
     })).toEqual([
       { app: { '': { color: 'red' } }, added: { '': { height: 20 } } },
       { app: { '': { color: 'red' } }, untouched: { '': { width: 10 } } },
+    ])
+    expect(createMergedStyleValues('const cls = "shared"', [
+      { shared: { '': { color: 'blue', padding: 12 } } },
+      { shared: { '': { borderRadius: 4 } } },
+    ], {
+      shared: { '': { color: 'red', margin: 8 } },
+    })).toEqual([
+      { shared: { '': { color: 'red', padding: 12, margin: 8 } } },
+      { shared: { '': { borderRadius: 4, color: 'red', margin: 8 } } },
     ])
   })
 })

--- a/scripts/demo-visual-e2e-report.ts
+++ b/scripts/demo-visual-e2e-report.ts
@@ -16,11 +16,15 @@ import { resolveScreenshotsRoot } from './demo-visual-e2e-report/screenshots.ts'
 
 const repoRoot = path.resolve(import.meta.dirname, '..')
 const defaultArtifactRoot = 'e2e/.artifacts/demo-visual/full'
+const configuredCrossPlatformDiffRatio = Number(process.env['DEMO_VISUAL_MAX_CROSS_PLATFORM_DIFF_RATIO'])
 const context: RuntimeContext = {
   artifactRoot: path.resolve(repoRoot, defaultArtifactRoot),
   repoRoot,
   timeoutMs: Number(process.env['DEMO_VISUAL_TIMEOUT_MS'] ?? 180_000),
   viewport: { width: 390, height: 844 },
+  ...(Number.isFinite(configuredCrossPlatformDiffRatio) && configuredCrossPlatformDiffRatio >= 0
+    ? { maxCrossPlatformDiffRatio: configuredCrossPlatformDiffRatio }
+    : {}),
 }
 
 const uniH5Cases = [
@@ -87,6 +91,7 @@ function printHelp() {
     '  DEMO_VISUAL_IDE_SETTLE_MS=800       清理 DevTools 后等待时间',
     '  DEMO_VISUAL_IDE_SCREENSHOT_COMMAND_TIMEOUT_MS=30000  单次 DevTools 截图命令超时',
     '  DEMO_VISUAL_HMR_OUTPUT_TIMEOUT_MS    小程序 visual HMR 初始/增量产物等待超时',
+    '  DEMO_VISUAL_MAX_CROSS_PLATFORM_DIFF_RATIO  H5 与其他端的最大归一化截图差异比例',
     '',
   ].join('\n'))
 }

--- a/scripts/demo-visual-e2e-report/compare.ts
+++ b/scripts/demo-visual-e2e-report/compare.ts
@@ -4,6 +4,14 @@ import path from 'pathe'
 import pixelmatch from 'pixelmatch'
 import { PNG } from 'pngjs'
 
+export interface ImageComparison {
+  diff: string
+  differentPixels: number
+  ratio: number
+  maxRatio?: number
+  withinLimit?: boolean
+}
+
 function resizePng(source: PNG, width: number, height: number) {
   if (source.width === width && source.height === height) {
     return source
@@ -25,7 +33,7 @@ function resizePng(source: PNG, width: number, height: number) {
   return resized
 }
 
-export function compareImages(actual: string, expected: string, name: string, context: RuntimeContext) {
+export function compareImages(actual: string, expected: string, name: string, context: RuntimeContext): ImageComparison {
   const diff = path.join(context.artifactRoot, 'diffs', `${name}.png`)
   const width = context.viewport.width
   const height = context.viewport.height
@@ -37,9 +45,16 @@ export function compareImages(actual: string, expected: string, name: string, co
   })
   fs.mkdirSync(path.dirname(diff), { recursive: true })
   fs.writeFileSync(diff, PNG.sync.write(diffPng))
+  const ratio = Math.round((differentPixels / (width * height)) * 10000) / 10000
   return {
     diff,
     differentPixels,
-    ratio: Math.round((differentPixels / (width * height)) * 10000) / 10000,
+    ratio,
+    ...(context.maxCrossPlatformDiffRatio === undefined
+      ? {}
+      : {
+          maxRatio: context.maxCrossPlatformDiffRatio,
+          withinLimit: ratio <= context.maxCrossPlatformDiffRatio,
+        }),
   }
 }

--- a/scripts/demo-visual-e2e-report/report.ts
+++ b/scripts/demo-visual-e2e-report/report.ts
@@ -22,10 +22,21 @@ export function createCrossPlatformComparisons(results: CaseResult[], context: R
       }
       const comparisonName = `${key.replace(/[^\w.-]+/g, '-')}-${platform}`
       const compared = compareImages(h5.screenshot, target.screenshot, comparisonName, context)
-      h5.comparison = { target: platform, ...compared }
+      const comparison = {
+        target: platform,
+        ...compared,
+      }
+      h5.comparison = comparison
       h5.diff = compared.diff
-      target.comparison = { target: 'h5', ...compared }
+      target.comparison = { ...comparison, target: 'h5' }
       target.diff = compared.diff
+      if (compared.withinLimit === false) {
+        const message = `${platform} 与 H5 截图差异比例 ${compared.ratio} 超过上限 ${context.maxCrossPlatformDiffRatio}`
+        h5.status = 'failed'
+        h5.error = [h5.error, message].filter(Boolean).join('\n')
+        target.status = 'failed'
+        target.error = [target.error, message].filter(Boolean).join('\n')
+      }
     }
   }
 }
@@ -51,7 +62,7 @@ export async function writeReport(results: CaseResult[], context: RuntimeContext
     const hmrAfter = item.hmrAfterScreenshot ? renderImageLink(context, item.hmrAfterScreenshot, `${altPrefix}-hmr-after`) : ''
     const hmrSteps = renderHmrStepLinks(context, item)
     const diff = renderDiffLinks(context, item)
-    const comparison = item.comparison ? `ratio=${item.comparison.ratio}` : ''
+    const comparison = renderComparison(item)
     const error = item.error ? item.error.split('\n')[0] : ''
     return `| ${item.name} | ${item.platform} | ${item.styleIsolationVariant ?? ''} | ${item.status} | ${screenshot} | ${themeLight} | ${themeManualDark} | ${hmrBefore} | ${hmrAfter} | ${hmrSteps} | ${diff} | ${comparison} | ${error} |`
   })
@@ -63,7 +74,7 @@ export async function writeReport(results: CaseResult[], context: RuntimeContext
     const hmrAfter = item.hmrAfterScreenshot ? `[HMR 后](${path.relative(context.artifactRoot, item.hmrAfterScreenshot)})` : ''
     const hmrSteps = renderHmrStepTextLinks(context, item)
     const diff = renderDiffTextLinks(context, item)
-    const comparison = item.comparison ? `ratio=${item.comparison.ratio}` : ''
+    const comparison = renderComparison(item)
     const error = item.error ? item.error.split('\n')[0] : ''
     return `| ${item.name} | ${item.platform} | ${item.styleIsolationVariant ?? ''} | ${item.status} | ${screenshot} | ${themeLight} | ${themeManualDark} | ${hmrBefore} | ${hmrAfter} | ${hmrSteps} | ${diff} | ${comparison} | ${error} |`
   })
@@ -224,6 +235,17 @@ function renderDiffTextLinks(context: RuntimeContext, item: CaseResult) {
     item.diff ? `[跨端 diff](${path.relative(context.artifactRoot, item.diff)})` : '',
   ].filter(Boolean)
   return links.join('<br />')
+}
+
+function renderComparison(item: CaseResult) {
+  if (!item.comparison) {
+    return ''
+  }
+  const parts = [`ratio=${item.comparison.ratio}`]
+  if (item.comparison.maxRatio !== undefined) {
+    parts.push(`max=${item.comparison.maxRatio}`, `withinLimit=${item.comparison.withinLimit}`)
+  }
+  return parts.join(' ')
 }
 
 function renderHmrStepTextLinks(context: RuntimeContext, item: CaseResult) {

--- a/scripts/demo-visual-e2e-report/types.ts
+++ b/scripts/demo-visual-e2e-report/types.ts
@@ -28,6 +28,7 @@ export interface RuntimeContext {
     width: number
     height: number
   }
+  maxCrossPlatformDiffRatio?: number
 }
 
 export interface MiniProgramHmrMutation {


### PR DESCRIPTION
## 变更概述

Issue #1086 的根因是 uni-app x Harmony VDOM 对同名 class 按整个 style object 覆盖，导致本地样式和 Tailwind 生成样式互相丢失；此前还需要直接修改 node_modules/dist 才能避开 ArkTS 注入解析问题。

本 PR：

- 将 Harmony _style_wt 注入改为源码级、完整语句边界、幂等插入，兼容 /* @__PURE__ */、前置变量和已有 styles 数组。
- 按 style state 和 CSS property 声明粒度合并本地与 Tailwind 样式；冲突属性由 Tailwind 生成值覆盖，本地未冲突属性保留。
- 统一单对象和多 style object 路径，补充未使用 class、非默认 state、多对象同名 class 和注入幂等回归测试。
- 为视觉报告增加可配置的跨端最大差异比例，DEMO_VISUAL_MAX_CROSS_PLATFORM_DIFF_RATIO=0.05 超限时标记失败并输出 diff。

## 验证结果

已通过：

- pnpm --filter weapp-tailwindcss exec vitest run test/uni-app-x/style-asset.test.ts test/uni-app-x/vite.test.ts：67 tests passed。
- pnpm exec vitest run -c ./e2e/vitest.e2e.config.ts e2e/demo-visual-theme.test.ts e2e/e2e-matrix.test.ts：54 tests passed。
- pnpm --filter weapp-tailwindcss build。
- ESLint（修改源码和脚本）：无错误。
- git diff --check。

真实端验收记录：

- Android、iOS：此前已完成真实 VDOM 编译并取得部分截图，但现有 HMR/marker 探针未通过，不能宣称完整端到端通过。
- H5：theme-dark 结构探针未通过。
- 微信小程序：HBuilderX 5.24 在主线新增的 !w-[100rpx] 前置重要修饰符处报 Invalid declaration: '!'；style isolation 2.0 另有既有 /uvue.wxss 解析错误。
- Harmony：Mate X7 模拟器已启动并注册为 127.0.0.1:5557，VDOM 真实运行链路已执行；两种 style isolation 均未形成可验收的完整产物/截图，不能伪造 ratio <= 0.05 结论。
- Vapor：当前仓库 runner/HBuilderX CLI 没有可复用的模式切换参数，未取得独立 Vapor 截图。

因此本 PR 不宣称五端像素门槛或 Harmony VDOM/Vapor 已通过；源码、单测、构建和静态矩阵证据已保留，设备阻塞及既有基线问题如上记录。

Related to #1086