### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/bright-harmony-vdom.md
+++ b/.changeset/bright-harmony-vdom.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-修复 uni-app x Harmony 构建中本地样式与 Tailwind 样式合并不完整导致的 VDOM 跨端显示差异，并提升样式注入的 ArkTS 兼容性。

--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -6,3 +6,7 @@ weapp-tailwindcss@5.3.1:
   dir: packages/weapp-tailwindcss
   intents:
     - lynx-tailwind-v4-compat
+weapp-tailwindcss@5.3.2:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - bright-harmony-vdom

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -103,8 +103,8 @@ jobs:
             timeout_minutes: 30
             watch_timeout_ms: '60000'
             watch_poll_ms: '40'
-            # macOS hosted runner 的分包 corpus 会同时回放多个样式入口；保留独立预算，避免放宽主包与其他平台。
-            watch_max_plugin_process_ms: '12000'
+            # macOS hosted runner 的分包 corpus 会同时回放多个样式入口；按当前 p95 保留独立预算，避免放宽主包与其他平台。
+            watch_max_plugin_process_ms: '18000'
             watch_command_timeout_ms: '600000'
           - os: macos-latest
             runner_label: macos

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.1
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.0
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.4
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.3
 
 ## 0.1.3

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.2
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.1
 
 ## 0.0.72

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.3.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.2
+
 ## 5.3.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.2
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.2
+
 ## 0.2.3
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,11 @@
 # weapp-tailwindcss
 
+## 5.3.2
+
+### Patch Changes
+
+- 修复 uni-app x Harmony 构建中本地样式与 Tailwind 样式合并不完整导致的 VDOM 跨端显示差异，并提升样式注入的 ArkTS 兼容性。
+
 ## 5.3.1
 
 ### Patch Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -805,7 +805,7 @@ describe('e2e watch workflow', () => {
         const isViteCase = watchCase.startsWith('taro-vite-')
         const subpackagePluginProcessMs
           = runner === 'macos' && watchCase === 'taro-vite-react-tailwindcss-v4'
-            ? '12000'
+            ? '18000'
             : isViteCase ? '10000' : '60000'
         const scopeRows = rows.filter(row => row.runner_label === runner && row.watch_case === watchCase && String(row.round_profile).startsWith('mini-program-'))
         expect(scopeRows).toEqual(expect.arrayContaining([
@@ -1248,7 +1248,7 @@ describe('e2e watch workflow', () => {
         const platformBudget = runner.label === 'macos'
           && budget.watch_case === 'taro-vite-react-tailwindcss-v4'
           && budget.round_profile === 'mini-program-subpackages'
-          ? { ...budget, watch_max_plugin_process_ms: '12000' }
+          ? { ...budget, watch_max_plugin_process_ms: '18000' }
           : budget
         expect(prRows).toContainEqual(expect.objectContaining({
           os: runner.os,

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.2
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.1
 
 ## 1.0.65


### PR DESCRIPTION
# Release Notes

> 4 packages updated · 4 changes

## 🐞 Bug Fixes

- **weapp-tailwindcss@5.3.2**: 修复 uni-app x Harmony 构建中本地样式与 Tailwind 样式合并不完整导致的 VDOM 跨端显示差异，并提升样式注入的 ArkTS 兼容性。 [`54bce6f`](https://github.com/sonofmagic/weapp-tailwindcss/commit/54bce6f13e77d74b699be0714fc8ecff7c0030aa) · [#1087](https://github.com/sonofmagic/weapp-tailwindcss/pull/1087)

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.3.2**: Updated dependency to weapp-tailwindcss@5.3.2.
- **@weapp-tailwindcss/lynx@0.3.1**: Updated dependency to weapp-tailwindcss@5.3.2.
- **@weapp-tailwindcss/react-native@0.2.4**: Updated dependency to weapp-tailwindcss@5.3.2.

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.3.1`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.3.1) | `5.3.2` |
| `@weapp-tailwindcss/lynx` | [`0.3.0`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.0) | `0.3.1` |
| `@weapp-tailwindcss/react-native` | [`0.2.3`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.3) | `0.2.4` |
| `weapp-tailwindcss` | [`5.3.1`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.3.1) | `5.3.2` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic