### PR TITLE
fix(uni-app-x): 支持自定义局部样式路径匹配

### DIFF
--- a/.changeset/fuzzy-layouts-match.md
+++ b/.changeset/fuzzy-layouts-match.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+支持通过 `uniAppX.componentLocalStyles.componentMatcher` 和 `pageMatcher` 为 `layouts` 等自定义目录启用局部 Tailwind 样式，并保持 Web、原生 App 与鸿蒙构建的路径匹配行为一致。

--- a/packages/weapp-tailwindcss/src/types/user-defined-options/important.ts
+++ b/packages/weapp-tailwindcss/src/types/user-defined-options/important.ts
@@ -15,6 +15,13 @@ import type { TailwindCssRuntimeOptions } from '@/tailwindcss/runtime-types'
 
 export interface UniAppXComponentLocalStylesOptions {
   /**
+   * 判断模块是否按组件局部样式处理。
+   *
+   * @remarks
+   * 回调接收已移除 query/hash 并统一为正斜杠的模块路径。配置后会覆盖默认的 `components` 目录匹配规则。
+   */
+  componentMatcher?: ((id: string) => boolean) | undefined
+  /**
    * 是否开启组件级局部 Tailwind 样式注入。
    *
    * @default true
@@ -26,6 +33,13 @@ export interface UniAppXComponentLocalStylesOptions {
    * @default true
    */
   onlyWhenStyleIsolationVersion2?: boolean | undefined
+  /**
+   * 判断模块是否按页面局部样式处理。
+   *
+   * @remarks
+   * 回调接收已移除 query/hash 并统一为正斜杠的模块路径。配置后会覆盖默认的 `pages` 目录匹配规则。
+   */
+  pageMatcher?: ((id: string) => boolean) | undefined
 }
 
 export interface UniAppXOptions {

--- a/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
@@ -19,8 +19,6 @@ interface RewriteCodeOptions {
 
 const EXPRESSION_WRAPPER_PREFIX = '(\n'
 const EXPRESSION_WRAPPER_SUFFIX = '\n)'
-const COMPONENT_RE = /(?:^|[/\\])components(?:[/\\].+)?\.(?:uvue|nvue)$/
-const PAGE_RE = /(?:^|[/\\])pages(?:[/\\].+)?\.(?:uvue|nvue)$/
 
 function createStableHash(input: string) {
   let hash = 2166136261
@@ -110,14 +108,6 @@ export function hasTopLevelVariant(candidate: string) {
     }
   }
   return false
-}
-
-export function shouldEnableComponentLocalStyle(id: string) {
-  return COMPONENT_RE.test(id)
-}
-
-export function shouldEnablePageLocalStyle(id: string) {
-  return PAGE_RE.test(id)
 }
 
 export class UniAppXComponentLocalStyleCollector {

--- a/packages/weapp-tailwindcss/src/uni-app-x/local-style-matcher.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/local-style-matcher.ts
@@ -1,0 +1,26 @@
+import { cleanUrl, ensurePosix } from '@weapp-tailwindcss/shared'
+
+export type UniAppXLocalStyleMatcher = (id: string) => boolean
+
+const COMPONENT_RE = /(?:^|\/)components(?:\/.+)?\.(?:uvue|nvue)$/
+const PAGE_RE = /(?:^|\/)pages(?:\/.+)?\.(?:uvue|nvue)$/
+
+export function normalizeUniAppXLocalStyleId(id: string) {
+  return ensurePosix(cleanUrl(id))
+}
+
+export function shouldEnableComponentLocalStyle(
+  id: string,
+  matcher?: UniAppXLocalStyleMatcher,
+) {
+  const normalizedId = normalizeUniAppXLocalStyleId(id)
+  return matcher ? matcher(normalizedId) : COMPONENT_RE.test(normalizedId)
+}
+
+export function shouldEnablePageLocalStyle(
+  id: string,
+  matcher?: UniAppXLocalStyleMatcher,
+) {
+  const normalizedId = normalizeUniAppXLocalStyleId(id)
+  return matcher ? matcher(normalizedId) : PAGE_RE.test(normalizedId)
+}

--- a/packages/weapp-tailwindcss/src/uni-app-x/options.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/options.ts
@@ -11,8 +11,10 @@ const DISABLED_COMPONENT_LOCAL_STYLES_OPTIONS: ResolvedUniAppXComponentLocalStyl
 }
 
 export interface ResolvedUniAppXComponentLocalStylesOptions {
+  componentMatcher?: ((id: string) => boolean) | undefined
   enabled: boolean
   onlyWhenStyleIsolationVersion2: boolean
+  pageMatcher?: ((id: string) => boolean) | undefined
 }
 
 export interface ResolvedUniAppXOptions {
@@ -44,8 +46,10 @@ function resolveComponentLocalStyles(
   }
 
   return {
+    ...(componentLocalStyles.componentMatcher ? { componentMatcher: componentLocalStyles.componentMatcher } : {}),
     enabled: componentLocalStyles.enabled !== false,
     onlyWhenStyleIsolationVersion2: componentLocalStyles.onlyWhenStyleIsolationVersion2 !== false,
+    ...(componentLocalStyles.pageMatcher ? { pageMatcher: componentLocalStyles.pageMatcher } : {}),
   }
 }
 

--- a/packages/weapp-tailwindcss/src/uni-app-x/style-asset/harmony-global.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/style-asset/harmony-global.ts
@@ -1,4 +1,9 @@
+import type { UniAppXLocalStyleMatcher } from '../local-style-matcher'
 import type { StyleValue } from './style-value'
+import {
+  normalizeUniAppXLocalStyleId,
+  shouldEnableComponentLocalStyle,
+} from '../local-style-matcher'
 import {
   createMergedStyleValue,
   createMergedStyleValues,
@@ -17,10 +22,31 @@ const STYLE_DECL_RE = /const\s+(_style_\d+)\s*=\s*\{/g
 const EXPORT_SFC_RE = /_export_sfc\(_sfc_main\s*,\s*\[/
 
 export interface HarmonyStyleInjectOptions {
+  componentMatcher?: UniAppXLocalStyleMatcher | undefined
   cssSources?: Iterable<string | undefined> | undefined
   styleAssetFiles?: Iterable<string | undefined> | ((file: string) => Iterable<string | undefined>) | undefined
   excludeComponents?: boolean | undefined
   mapSources?: Iterable<string | undefined> | undefined
+}
+
+function resolveSfcSourceId(code: string) {
+  const match = code.match(/\[\s*["']__file["']\s*,\s*(["'])(.*?)\1\s*\]/)
+  return match?.[2] ? normalizeUniAppXLocalStyleId(match[2]) : undefined
+}
+
+function shouldExcludeComponent(file: string, code: string, options: HarmonyStyleInjectOptions) {
+  if (!options.excludeComponents) {
+    return false
+  }
+  const sourceId = resolveSfcSourceId(code)
+  if (sourceId) {
+    return shouldEnableComponentLocalStyle(sourceId, options.componentMatcher)
+  }
+  const normalizedFile = normalizeUniAppXLocalStyleId(file)
+  if (options.componentMatcher?.(normalizedFile)) {
+    return true
+  }
+  return COMPONENT_JS_RE.test(normalizedFile)
 }
 
 interface StyleObjectDecl {
@@ -192,7 +218,7 @@ export function injectUniAppXHarmonyGlobalStyles(
   if (!JS_RE.test(file) || APP_JS_RE.test(file)) {
     return code
   }
-  if (options.excludeComponents && COMPONENT_JS_RE.test(file)) {
+  if (shouldExcludeComponent(file, code, options)) {
     return code
   }
   const appSource = getBundleSource?.('assets/App.js') ?? getBundleSource?.('App.js')

--- a/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
@@ -7,10 +7,12 @@ import MagicString from 'magic-string'
 import { generateCode, replaceWxml } from '@/wxml'
 import { createAttributeMatcher } from '@/wxml/custom-attributes'
 import {
-  shouldEnableComponentLocalStyle,
-  shouldEnablePageLocalStyle,
   UniAppXComponentLocalStyleCollector,
 } from './component-local-style'
+import {
+  shouldEnableComponentLocalStyle,
+  shouldEnablePageLocalStyle,
+} from './local-style-matcher'
 
 interface SfcBlock {
   content: string
@@ -122,19 +124,21 @@ function updateDirectiveExpressionWithLocalStyle(
 }
 
 interface TransformUVueOptions {
+  componentMatcher?: (id: string) => boolean
   customAttributesEntities?: ICustomAttributesEntities
   disabledDefaultTemplateHandler?: boolean
   enableComponentLocalStyle?: boolean
   enablePageLocalStyle?: boolean
+  pageMatcher?: (id: string) => boolean
   webCustomAttributeDeep?: boolean
   onWebLocalStyleRules?: (rules: string) => void
 }
 
 function shouldEnableLocalStyle(id: string, options: TransformUVueOptions) {
-  if (options.enableComponentLocalStyle && shouldEnableComponentLocalStyle(id)) {
+  if (options.enableComponentLocalStyle && shouldEnableComponentLocalStyle(id, options.componentMatcher)) {
     return true
   }
-  if (options.enablePageLocalStyle && shouldEnablePageLocalStyle(id)) {
+  if (options.enablePageLocalStyle && shouldEnablePageLocalStyle(id, options.pageMatcher)) {
     return true
   }
   return false

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
@@ -17,8 +17,8 @@ import { toAbsoluteOutputPath } from '@/bundlers/shared/module-graph'
 import { parseVueRequest } from '@/bundlers/vite/query'
 import { cleanUrl, formatPostcssSourceMap, isCSSRequest, normalizePath } from '@/bundlers/vite/utils'
 import { logger } from '@/logger'
-import { shouldEnablePageLocalStyle as isPageLocalStyleFile } from '@/uni-app-x/component-local-style'
 import { isUniAppXHarmonyOutDir } from '@/uni-app-x/harmony'
+import { shouldEnablePageLocalStyle as isPageLocalStyleFile } from '@/uni-app-x/local-style-matcher'
 import { resolveUniUtsPlatform } from '@/utils'
 import { omitUndefined } from '@/utils/object'
 import { isUniAppXEnabled, resolveUniAppXOptions } from './options'
@@ -120,7 +120,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     return componentLocalStyleEnabled
   }
   function shouldEnablePageLocalStyleForFile(id: string) {
-    return resolvedUniAppXOptions.componentLocalStyles.enabled && (isNativeAppBuildTarget(id) || isPageLocalStyleFile(id))
+    return resolvedUniAppXOptions.componentLocalStyles.enabled && (isNativeAppBuildTarget(id) || isPageLocalStyleFile(id, resolvedUniAppXOptions.componentLocalStyles.pageMatcher))
   }
   function isHarmonyBuildTarget() {
     if (resolveUniUtsPlatform().isAppHarmony) {
@@ -281,10 +281,12 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     nativeHmrReloader.remember(currentRuntimeSet)
     const transformUVue = await loadTransformUVue()
     const transformOptions = omitUndefined({
+      componentMatcher: resolvedUniAppXOptions.componentLocalStyles.componentMatcher,
       ...(customAttributesEntities.length > 0 ? { customAttributesEntities } : {}),
       ...(disabledDefaultTemplateHandler ? { disabledDefaultTemplateHandler } : {}),
       ...(enableComponentLocalStyle ? { enableComponentLocalStyle } : {}),
       ...(enablePageLocalStyle ? { enablePageLocalStyle } : {}),
+      pageMatcher: resolvedUniAppXOptions.componentLocalStyles.pageMatcher,
       ...(isWebGeneratorTarget() && customAttributesEntities.length > 0 ? { webCustomAttributeDeep: true } : {}),
       ...(isWebGeneratorTarget() ? { onWebLocalStyleRules: (rules: string) => webLocalStyle.remember(id, rules) } : {}),
     })
@@ -394,6 +396,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
           }
           injectUniAppXHarmonyBundleStyles(bundle, {
             cssSources,
+            componentMatcher: resolvedUniAppXOptions.componentLocalStyles.componentMatcher,
             excludeComponents: shouldEnableComponentLocalStyle(),
           })
         }

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -5,6 +5,10 @@ import { beforeEach, afterEach } from 'vitest'
 import { vi } from 'vitest'
 import { getCompilerContext } from '@/context'
 import { transformUVue } from '@/uni-app-x'
+import {
+  shouldEnableComponentLocalStyle,
+  shouldEnablePageLocalStyle,
+} from '@/uni-app-x/local-style-matcher'
 import { replaceWxml } from '@/wxml'
 
 const getCase = createGetCase(fixturesRootPath)
@@ -275,6 +279,48 @@ const condition = true
     const result = transformUVue('<template><view/></template>', 'App.vue', jsHandler, new Set())
     expect(result).toBeUndefined()
     expect(jsHandler).not.toHaveBeenCalled()
+  })
+
+  it('normalizes local style matcher ids and preserves default directories', () => {
+    expect(shouldEnableComponentLocalStyle('/project/src/components/card.uvue?vue&type=template')).toBe(true)
+    expect(shouldEnableComponentLocalStyle('C:\\project\\src\\components\\card.nvue#source')).toBe(true)
+    expect(shouldEnablePageLocalStyle('C:\\project\\src\\pages\\index.uvue?vue&type=template')).toBe(true)
+    expect(shouldEnableComponentLocalStyle('/project/src/layouts/default.uvue')).toBe(false)
+
+    const matcher = vi.fn((id: string) => id.endsWith('/layouts/default.uvue'))
+    expect(shouldEnableComponentLocalStyle('C:\\project\\src\\layouts\\default.uvue?vue&type=template', matcher)).toBe(true)
+    expect(matcher).toHaveBeenCalledWith('C:/project/src/layouts/default.uvue')
+  })
+
+  it('enables local styles for custom component directories only when matched', () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const code = '<template><view class="px-4" /></template>'
+    const componentMatcher = (id: string) => id.endsWith('/layouts/default.uvue')
+    const matched = transformUVue(
+      code,
+      '/project/src/layouts/default.uvue?vue&type=template',
+      jsHandler,
+      new Set(['px-4']),
+      {
+        componentMatcher,
+        enableComponentLocalStyle: true,
+      },
+    )
+    const unmatched = transformUVue(
+      code,
+      '/project/src/views/default.uvue',
+      jsHandler,
+      new Set(['px-4']),
+      {
+        componentMatcher,
+        enableComponentLocalStyle: true,
+      },
+    )
+
+    expect(matched?.code).toContain('class="wtu-')
+    expect(matched?.code).toContain('@apply px-4;')
+    expect(unmatched?.code).toContain('class="px-4"')
+    expect(unmatched?.code).not.toContain('@apply px-4;')
   })
 
   it('does not expand static space-y utility in uvue template', () => {

--- a/packages/weapp-tailwindcss/test/uni-app-x/options.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/options.test.ts
@@ -47,6 +47,23 @@ describe('uni-app-x options', () => {
     })
   })
 
+  it('preserves custom local style matchers', () => {
+    const componentMatcher = (id: string) => id.includes('/layouts/')
+    const pageMatcher = (id: string) => id.includes('/screens/')
+
+    expect(resolveUniAppXOptions({
+      componentLocalStyles: {
+        componentMatcher,
+        pageMatcher,
+      },
+    }).componentLocalStyles).toEqual({
+      componentMatcher,
+      enabled: true,
+      onlyWhenStyleIsolationVersion2: true,
+      pageMatcher,
+    })
+  })
+
   it('keeps unsupported utility mode defaulted to warn', () => {
     expect(resolveUniAppXOptions({ enabled: true }).uvueUnsupported).toBe('warn')
     expect(resolveUniAppXOptions({ enabled: true, uvueUnsupported: 'silent' }).uvueUnsupported).toBe('silent')

--- a/packages/weapp-tailwindcss/test/uni-app-x/style-asset.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/style-asset.test.ts
@@ -161,6 +161,36 @@ describe('uni-app-x style asset helpers', () => {
     expect(next).toContain('green')
   })
 
+  it('excludes custom component directories using harmony source metadata', () => {
+    const layoutCode = [
+      'const _sfc_main = { class: "green" };',
+      'export default _export_sfc(_sfc_main, [["__file", "layouts/default.uvue"]]);',
+    ].join('\n')
+    const matcher = (id: string) => id.startsWith('layouts/')
+
+    expect(injectUniAppXHarmonyGlobalStyles(
+      'assets/layouts/default.js',
+      layoutCode,
+      undefined,
+      {
+        componentMatcher: matcher,
+        cssSources: ['.green{color:green}'],
+        excludeComponents: true,
+      },
+    )).toBe(layoutCode)
+
+    expect(injectUniAppXHarmonyGlobalStyles(
+      'assets/views/default.js',
+      layoutCode.replace('layouts/default.uvue', 'views/default.uvue'),
+      undefined,
+      {
+        componentMatcher: matcher,
+        cssSources: ['.green{color:green}'],
+        excludeComponents: true,
+      },
+    )).toContain('const _style_wt =')
+  })
+
   it('inserts generated style declarations at a statement boundary and remains idempotent', () => {
     const code = 'const cls = "green"; const page = /* @__PURE__ */ _export_sfc(_sfc_main, [["__file","pages/index.uvue"]]);'
     const next = injectUniAppXHarmonyGlobalStyles('pages/index.js', code, undefined, {

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
@@ -1042,6 +1042,53 @@ describe('uni-app-x vite plugins', () => {
     }
   })
 
+  it('passes custom local style matchers to the uvue transform', async () => {
+    const runtimeSet = new Set(['px-4'])
+    const jsHandler = vi.fn()
+    const componentMatcher = (id: string) => id.endsWith('/layouts/default.uvue')
+    const pageMatcher = (id: string) => id.endsWith('/screens/home.uvue')
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => true),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler,
+      ensureRuntimeClassSet: vi.fn(async () => runtimeSet),
+      getResolvedConfig: () => ({ command: 'build', build: { watch: false }, root: '/project' } as ResolvedConfig),
+      uniAppX: {
+        enabled: true,
+        componentLocalStyles: {
+          componentMatcher,
+          onlyWhenStyleIsolationVersion2: false,
+          pageMatcher,
+        },
+      },
+    })
+    const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
+    transformUVueMock.mockClear()
+    transformUVueMock.mockReturnValue({ code: 'transformed', map: null } as TransformResult)
+
+    await getTransformHandler(nvuePlugin)?.call(
+      nvuePlugin,
+      '<template><view class="px-4" /></template>',
+      '/project/src/layouts/default.uvue?vue&type=template',
+    )
+
+    expect(transformUVueMock).toHaveBeenLastCalledWith(
+      '<template><view class="px-4" /></template>',
+      '/project/src/layouts/default.uvue?vue&type=template',
+      jsHandler,
+      runtimeSet,
+      {
+        componentMatcher,
+        enableComponentLocalStyle: true,
+        pageMatcher,
+      },
+    )
+  })
+
   it('enables page local style transform on app-harmony without styleIsolationVersion=2', async () => {
     const originalPlatform = process.env.UNI_UTS_PLATFORM
     process.env.UNI_UTS_PLATFORM = 'app-harmony'
@@ -1468,7 +1515,9 @@ describe('uni-app-x vite plugins', () => {
         getResolvedConfig: () => ({ command: 'build', build: { watch: false }, root } as ResolvedConfig),
         uniAppX: {
           enabled: true,
-          componentLocalStyles: true,
+          componentLocalStyles: {
+            componentMatcher: id => /(?:^|\/)(?:components|layouts)\//.test(id),
+          },
         },
       })
       const placeholderPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:style-placeholder')
@@ -1476,6 +1525,7 @@ describe('uni-app-x vite plugins', () => {
       const bundle = {
         'assets/App.js': createChunk('const _style_0 = {"px-4":{"":{"paddingLeft":"32rpx","paddingRight":"32rpx"}}};'),
         'assets/components/Logo.js': createChunk('function render(){return createElementVNode("view", { class: "px-4" })}\nconst Logo = _export_sfc(_sfc_main, [["render", render], ["__file", "components/Logo.uvue"]]);'),
+        'assets/layouts/default.js': createChunk('function render(){return createElementVNode("view", { class: "px-4" })}\nconst layout = _export_sfc(_sfc_main, [["render", render], ["__file", "layouts/default.uvue"]]);'),
         'assets/pages/index/index.js': createChunk('const _style_0 = {};\nfunction render(){return createElementVNode("view", { class: "px-4" })}\nconst index = _export_sfc(_sfc_main, [["render", render], ["styles", [_style_0]], ["__file", "pages/index/index.uvue"]]);'),
       }
 
@@ -1483,6 +1533,8 @@ describe('uni-app-x vite plugins', () => {
 
       expect(bundle['assets/components/Logo.js'].code).not.toContain('const _style_wt')
       expect(bundle['assets/components/Logo.js'].code).not.toContain('"px-4":{"":{"paddingLeft":"32rpx"')
+      expect(bundle['assets/layouts/default.js'].code).not.toContain('const _style_wt')
+      expect(bundle['assets/layouts/default.js'].code).not.toContain('"px-4":{"":{"paddingLeft":"32rpx"')
       expect(bundle['assets/pages/index/index.js'].code).toContain('"px-4":{"":{"paddingLeft":"32rpx"')
     }
     finally {

--- a/website/docs/quick-start/frameworks/uni-app-x.mdx
+++ b/website/docs/quick-start/frameworks/uni-app-x.mdx
@@ -137,6 +137,20 @@ Tailwind CSS 生成由 `weapp-tailwindcss` 接管，不要再注册 `tailwindcss
 `rem2rpx`、`unitsToPx`、`unitConversion` 是 `uniAppX()` 预设的顶层选项，不要放进 `cssOptions`。
 :::
 
+项目把可复用组件放在 `layouts` 等自定义目录时，可以显式扩展局部样式匹配范围：
+
+```ts title="vite.config.ts"
+uniAppX({
+  base: projectRoot,
+  cssEntries: [resolve(projectRoot, 'main.css')],
+  componentLocalStyles: {
+    componentMatcher: id => /(?:^|\/)layouts\/.+\.(?:uvue|nvue)$/.test(id),
+  },
+})
+```
+
+`componentMatcher` 会覆盖默认的 `components` 目录规则；需要同时保留默认组件目录时，应在回调中一并匹配 `components` 和自定义目录。页面目录可通过同级的 `pageMatcher` 调整。两个回调收到的路径都已移除 query/hash，并统一为正斜杠。
+
 ### 4) 配置 Tailwind CSS 入口
 
 Tailwind CSS 4 使用 CSS-first 入口。入口文件应放在项目根目录或源码目录下，并在 `cssEntries` 中使用绝对路径引用：

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/quick-start/frameworks/uni-app-x.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/quick-start/frameworks/uni-app-x.mdx
@@ -106,6 +106,20 @@ The current documentation only maintains Tailwind CSS 4 access instructions.
 `rem2rpx`, `unitsToPx`, and `unitConversion` are top-level options of the `uniAppX()` preset. Do not put them under `cssOptions`.
 :::
 
+When reusable components live in a custom directory such as `layouts`, extend the local-style matcher explicitly:
+
+```ts title="vite.config.ts"
+uniAppX({
+  base: projectRoot,
+  cssEntries: [resolve(projectRoot, 'main.css')],
+  componentLocalStyles: {
+    componentMatcher: id => /(?:^|\/)layouts\/.+\.(?:uvue|nvue)$/.test(id),
+  },
+})
+```
+
+`componentMatcher` replaces the default `components` directory rule. Match both `components` and custom directories in the callback when both are needed. Use the sibling `pageMatcher` option for custom page directories. Both callbacks receive paths with query/hash removed and path separators normalized to forward slashes.
+
 ## Tailwind CSS entry
 
 Tailwind CSS 4 uses the CSS-first entry, `@source` to cover pages, components, and script directories that may produce class names:


### PR DESCRIPTION
## 变更说明

- 为 `uniAppX.componentLocalStyles` 增加 `componentMatcher` 与 `pageMatcher`，支持 `layouts` 等自定义目录
- 在调用 matcher 前统一清理 query/hash，并将路径分隔符规范化为正斜杠
- Harmony 构建通过 chunk 的 `__file` 元数据复用组件匹配规则，缺少元数据时保留原有组件目录兜底
- 补充中英文 uni-app x 接入文档与 patch changeset

## 验证

- `pnpm --filter weapp-tailwindcss exec vitest run test/source-line-limit.test.ts test/uni-app-x/index.test.ts test/uni-app-x/options.test.ts test/uni-app-x/style-asset.test.ts test/uni-app-x/vite.test.ts test/presets/uni-app-x.test.ts`
- `pnpm test:core`
- `pnpm build:pkgs`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm --filter @weapp-tailwindcss/website build`
- 变更源码 ESLint 检查

Related to #1095