### PR TITLE
fix(uni-app-x): 修复 H5 暗色工具类级联

### DIFF
--- a/.changeset/bright-variants-cascade.md
+++ b/.changeset/bright-variants-cascade.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x H5 局部 Tailwind 工具类的级联优先级，确保 `dark` 等条件变体能够覆盖同一元素上的基础工具类。

--- a/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
+++ b/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
@@ -127,7 +127,7 @@
 					@apply 多端写法示例
 				</text>
 			</view>
-			<view class="theme-mode-demo mt-4 rounded bg-white px-4 py-3 text-slate-900 system-dark:bg-slate-900 system-dark:text-slate-100 dark:bg-zinc-900 dark:text-zinc-50">
+			<view class="theme-mode-demo mt-4 rounded bg-white px-4 py-3 text-slate-900 system-dark:bg-slate-900 system-dark:text-slate-100 dark:bg-zinc-950 dark:text-zinc-50">
 				<text>uni-app x Tailwind CSS v4 system dark</text>
 				<view class="theme-dark issue-1091-probe mt-2 rounded bg-[#eccc68] px-3 py-2 text-slate-900 dark:bg-[#3498db] dark:text-zinc-50">
 					<text>uni-app x Tailwind CSS v4 manual dark issue 1091</text>

--- a/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
+++ b/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
@@ -129,8 +129,8 @@
 			</view>
 			<view class="theme-mode-demo mt-4 rounded bg-white px-4 py-3 text-slate-900 system-dark:bg-slate-900 system-dark:text-slate-100 dark:bg-zinc-900 dark:text-zinc-50">
 				<text>uni-app x Tailwind CSS v4 system dark</text>
-				<view class="theme-dark mt-2 rounded bg-white px-3 py-2 text-slate-900 dark:bg-zinc-950 dark:text-zinc-50">
-					<text>uni-app x Tailwind CSS v4 manual dark</text>
+				<view class="theme-dark issue-1091-probe mt-2 rounded bg-[#eccc68] px-3 py-2 text-slate-900 dark:bg-[#3498db] dark:text-zinc-50">
+					<text>uni-app x Tailwind CSS v4 manual dark issue 1091</text>
 				</view>
 			</view>
 			<t-button t-class="bg-[#0977ee] text-[31rpx]" t-class-content="px-[29rpx]">

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -1014,6 +1014,12 @@ export const webCases: WebCase[] = [
         },
       },
       {
+        selector: '.issue-1091-probe',
+        styles: {
+          backgroundColor: 'rgb(52, 152, 219)',
+        },
+      },
+      {
         selector: '.issue-navbar-left',
         styles: {
           backgroundColor: 'rgb(9, 87, 222)',

--- a/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
@@ -282,22 +282,25 @@ export class UniAppXComponentLocalStyleCollector {
     return this.aliasByUtility.size > 0
   }
 
-  toStyleBlock() {
+  toStyleBlock(options: { web?: boolean } = {}) {
     if (!this.hasStyles()) {
       return ''
     }
-    return `<style scoped>\n${this.toStyleRules()}</style>\n`
+    return `<style scoped>\n${this.toStyleRules(options)}</style>\n`
   }
 
-  toStyleRules() {
+  toStyleRules(options: { web?: boolean } = {}) {
     if (!this.hasStyles()) {
       return ''
     }
     const lines: string[] = []
     for (const [utility, alias] of this.aliasByUtility) {
+      // H5 的 Vue scoped 编译会把 :where(.alias) 展开为带 scope attribute 的选择器，
+      // 重新抬高特异性；使用 :global 保持局部 alias 的单类选择器特异性。
+      const localSelector = options.web ? `:global(.${alias})` : `.${alias}`
       const selector = this.deepUtilities.has(utility)
-        ? `.${alias}, :deep(.${alias})`
-        : `.${alias}`
+        ? `${localSelector}, :deep(.${alias})`
+        : localSelector
       lines.push(`${selector} {`)
       lines.push(`  @apply ${serializeApplyUtility(utility)};`)
       lines.push('}')

--- a/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
@@ -368,14 +368,14 @@ export function transformUVue(
     if (localStyleCollector?.hasStyles()) {
       const scopedStyle = descriptor.styles.findLast(style => STYLE_SCOPED_RE.test(style.attrs))
       if (scopedStyle && options.onWebLocalStyleRules) {
-        options.onWebLocalStyleRules(localStyleCollector.toStyleRules())
+        options.onWebLocalStyleRules(localStyleCollector.toStyleRules({ web: true }))
       }
       else if (scopedStyle) {
         const separator = scopedStyle.content.endsWith('\n') ? '' : '\n'
         ms.appendLeft(scopedStyle.end, `${separator}${localStyleCollector.toStyleRules()}`)
       }
       else {
-        ms.append(`\n${localStyleCollector.toStyleBlock()}`)
+        ms.append(`\n${localStyleCollector.toStyleBlock({ web: Boolean(options.onWebLocalStyleRules) })}`)
       }
     }
   }

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -529,6 +529,41 @@ const active = true
     expect(result?.code).toMatch(/\.wtu-[\w-]+ \{\n  @apply bg-\[#123456\];\n\}/)
   })
 
+  it('lowers web local utility specificity so variants can override the base utility', () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const onWebLocalStyleRules = vi.fn()
+    const result = transformUVue(
+      '<template><view class="bg-[#eccc68] dark:bg-[#3498db]" /></template>\n<style scoped>.author { color: red; }</style>',
+      '/src/pages/index/index.uvue',
+      jsHandler,
+      new Set(['bg-[#eccc68]', 'dark:bg-[#3498db]']),
+      {
+        enablePageLocalStyle: true,
+        onWebLocalStyleRules,
+      },
+    )
+
+    expect(result?.code).toContain('class="wtu-')
+    expect(result?.code).toContain('dark_cbg-_b_h3498db_B')
+    expect(onWebLocalStyleRules).toHaveBeenCalledWith(expect.stringMatching(/:global\(\.wtu-[\w-]+\)/))
+  })
+
+  it('uses the same web-safe selector when a page has no scoped author style', () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const result = transformUVue(
+      '<template><view class="bg-[#eccc68]" /></template>',
+      '/src/pages/index/index.uvue',
+      jsHandler,
+      new Set(['bg-[#eccc68]']),
+      {
+        enablePageLocalStyle: true,
+        onWebLocalStyleRules: vi.fn(),
+      },
+    )
+
+    expect(result?.code).toMatch(/<style scoped>\n:global\(\.wtu-[\w-]+\)/)
+  })
+
   it('keeps variant utilities on the global platform pipeline for app-harmony pages', () => {
     process.env.UNI_UTS_PLATFORM = 'app-harmony'
     const { jsHandler } = getCompilerContext({


### PR DESCRIPTION
## 变更

修复 uni-app x H5 页面局部 Tailwind 工具类与 dark variant 的 CSS 级联优先级。Vue scoped 编译会给局部 alias 追加 data-v 属性，导致基础背景覆盖 dark variant；H5 局部输出现在使用 :global 保持单类特异性，原生局部样式行为不变。

## 验证

- `pnpm --filter weapp-tailwindcss test -- --coverage.enabled=false`：314 个测试文件通过，3207 个测试通过
- `pnpm --filter weapp-tailwindcss build`：构建通过
- `pnpm e2e:hbuilderx:local:demo:web`：uni-app Vue3 与 uni-app x H5/HMR 真实浏览器通过
- 真实 H5 断言 `.issue-1091-probe` 计算背景色为 `rgb(52, 152, 219)`

Refs #1091