### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -20,3 +20,7 @@ weapp-tailwindcss@5.3.3:
     - bright-variants-cascade
     - fuzzy-layouts-match
     - slick-bears-sleep
+weapp-tailwindcss@5.3.4:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - social-geckos-roll

--- a/.changeset/social-geckos-roll.md
+++ b/.changeset/social-geckos-roll.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-修复 uni-app x 小程序构建中组件局部 Tailwind 样式绕过 Sass 预处理、导致 SCSS 变量原样进入样式产物的问题。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           pnpm exec playwright install chromium
 
       - name: E2E Static
-        run: pnpm ci:memory --label e2e-static-${{ matrix.shard }}-${{ matrix.shard_total }} --max-rss-mb 5632 --max-rss-delta-mb 4608 -- pnpm e2e:static --exclude e2e/taro-h5-build-smoke.test.ts --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
+        run: pnpm ci:memory --label e2e-static-${{ matrix.shard }}-${{ matrix.shard_total }} --max-rss-mb 5632 --max-rss-delta-mb 4608 -- pnpm e2e:static --exclude e2e/apps-generator-mode-compare.test.ts --exclude e2e/taro-h5-build-smoke.test.ts --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
       - name: Upload CI memory reports
         if: always()
@@ -229,6 +229,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - case_name: apps-generator
+            command: pnpm e2e:apps-generator
           - case_name: generator-web-parity
             command: pnpm e2e:generator-parity
           - case_name: lynx-rspeedy

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.3
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.2
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.6
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.5
 
 ## 0.1.3

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.4
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.3
 
 ## 0.0.72

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.3.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.4
+
 ## 5.3.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.3
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.4
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.4
+
 ## 0.2.5
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,11 @@
 # weapp-tailwindcss
 
+## 5.3.4
+
+### Patch Changes
+
+- 修复 uni-app x 小程序构建中组件局部 Tailwind 样式绕过 Sass 预处理、导致 SCSS 变量原样进入样式产物的问题。
+
 ## 5.3.3
 
 ### Patch Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -160,12 +160,13 @@ describe('ci workflows', () => {
     expect(staticJob.strategy.matrix.shard_total).toEqual([3])
     expect(staticRuns.join('\n')).toContain('pnpm exec playwright install chromium')
     expect(hasStepRunCommand(staticRuns, 'pnpm build:ci')).toBe(true)
-    expect(hasStepRunCommand(staticRuns, 'pnpm e2e:static --exclude e2e/taro-h5-build-smoke.test.ts --shard=${{ matrix.shard }}/${{ matrix.shard_total }}')).toBe(true)
+    expect(hasStepRunCommand(staticRuns, 'pnpm e2e:static --exclude e2e/apps-generator-mode-compare.test.ts --exclude e2e/taro-h5-build-smoke.test.ts --shard=${{ matrix.shard }}/${{ matrix.shard_total }}')).toBe(true)
     expect(hasStepRunCommand(focusedRuns, 'pnpm build:ci')).toBe(true)
     expect(hasStepRunCommand(multiplatformRuns, 'pnpm build:ci')).toBe(true)
 
     expect(workflow.jobs['e2e-focused'].strategy['fail-fast']).toBe(false)
     expect(matrixCaseNames(focusedRows)).toEqual([
+      'apps-generator',
       'generator-web-parity',
       'lynx-rspeedy',
       'preprocessor-source',
@@ -181,6 +182,7 @@ describe('ci workflows', () => {
       'watch-hmr-coverage-contract',
     ])
     expect(focusedRows.map(row => row.command)).toEqual([
+      'pnpm e2e:apps-generator',
       'pnpm e2e:generator-parity',
       'pnpm e2e:lynx',
       'pnpm e2e:preprocessor',

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.4
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.3
 
 ## 1.0.65


### PR DESCRIPTION
# Release Notes

> 4 packages updated · 4 changes

## 🐞 Bug Fixes

- **weapp-tailwindcss@5.3.4**: 修复 uni-app x 小程序构建中组件局部 Tailwind 样式绕过 Sass 预处理、导致 SCSS 变量原样进入样式产物的问题。 [`1e82a10`](https://github.com/sonofmagic/weapp-tailwindcss/commit/1e82a10f84e4d5a0099840229c888c6b6064fc71) · [#1099](https://github.com/sonofmagic/weapp-tailwindcss/pull/1099)

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.3.4**: Updated dependency to weapp-tailwindcss@5.3.4.
- **@weapp-tailwindcss/lynx@0.3.3**: Updated dependency to weapp-tailwindcss@5.3.4.
- **@weapp-tailwindcss/react-native@0.2.6**: Updated dependency to weapp-tailwindcss@5.3.4.

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.3.3`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.3.3) | `5.3.4` |
| `@weapp-tailwindcss/lynx` | [`0.3.2`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.2) | `0.3.3` |
| `@weapp-tailwindcss/react-native` | [`0.2.5`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.5) | `0.2.6` |
| `weapp-tailwindcss` | [`5.3.3`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.3.3) | `5.3.4` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic