### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/empty-wxs-script.md
+++ b/.changeset/empty-wxs-script.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-修复 uni-app x SFC 中空内容的外链 WXS `<script>` 导致构建失败的问题。

--- a/.changeset/funky-keys-greet.md
+++ b/.changeset/funky-keys-greet.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-优化 Generic Vite Web 非 watch 生产构建，跳过未被消费的 source candidate 扫描与模块级跟踪，同时保留开发、watch、跨框架及 CSS 来源追踪链路；升级 weapp-vite 6.22 后迁移独立分包样式构建并保留单次生成回归。

--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -29,3 +29,8 @@ weapp-tailwindcss@5.3.4:
   dir: packages/weapp-tailwindcss
   intents:
     - social-geckos-roll
+weapp-tailwindcss@5.3.5:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - empty-wxs-script
+    - funky-keys-greet

--- a/examples/react-lynx-promo/CHANGELOG.md
+++ b/examples/react-lynx-promo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @weapp-tailwindcss/example-react-lynx-promo
+
+## 0.0.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.4

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.4
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.3
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.7
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.6
 
 ## 0.1.3

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.5
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.4
 
 ## 0.0.72

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.3.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.5
+
 ## 5.3.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.5
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.5
+
 ## 0.2.6
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,13 @@
 # weapp-tailwindcss
 
+## 5.3.5
+
+### Patch Changes
+
+- 修复 uni-app x SFC 中空内容的外链 WXS `<script>` 导致构建失败的问题。
+
+- 优化 Generic Vite Web 非 watch 生产构建，跳过未被消费的 source candidate 扫描与模块级跟踪，同时保留开发、watch、跨框架及 CSS 来源追踪链路；升级 weapp-vite 6.22 后迁移独立分包样式构建并保留单次生成回归。
+
 ## 5.3.4
 
 ### Patch Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.5
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.4
 
 ## 1.0.65


### PR DESCRIPTION
# Release Notes

> 4 packages updated · 5 changes

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.3.5**: Updated dependency to weapp-tailwindcss@5.3.5.
- **@weapp-tailwindcss/lynx@0.3.4**: Updated dependency to weapp-tailwindcss@5.3.5.
- **@weapp-tailwindcss/react-native@0.2.7**: Updated dependency to weapp-tailwindcss@5.3.5.
- **weapp-tailwindcss@5.3.5**: 修复 uni-app x SFC 中空内容的外链 WXS <script> 导致构建失败的问题。 [`2bd3510`](https://github.com/sonofmagic/weapp-tailwindcss/commit/2bd351085e9c0417846fd86d896ad1b5594878eb)
- **weapp-tailwindcss@5.3.5**: 优化 Generic Vite Web 非 watch 生产构建，跳过未被消费的 source candidate 扫描与模块级跟踪，同时保留开发、watch、跨框架及 CSS 来源追踪链路；升级 weapp-vite 6.22 后迁移独立分包样式构建并保留单次生成回归。 [`fbde54c`](https://github.com/sonofmagic/weapp-tailwindcss/commit/fbde54c2c46a313d1b13e6e227eacb5720d6fe22) · [#1111](https://github.com/sonofmagic/weapp-tailwindcss/pull/1111)

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.3.4`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.3.4) | `5.3.5` |
| `@weapp-tailwindcss/lynx` | [`0.3.3`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.3) | `0.3.4` |
| `@weapp-tailwindcss/react-native` | [`0.2.6`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.6) | `0.2.7` |
| `weapp-tailwindcss` | [`5.3.4`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.3.4) | `5.3.5` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic