### PR TITLE
fix(uni-app-x): skip empty external WXS scripts

### DIFF
--- a/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
@@ -346,7 +346,7 @@ export function transformUVue(
       })
     }
 
-    if (descriptor.script) {
+    if (descriptor.script && descriptor.script.start < descriptor.script.end) {
       localStyleCollector?.collectRuntimeClasses(descriptor.script.content)
       const { code } = jsHandler(descriptor.script.content, runtimeSet ?? new Set(), defaultCreateJsHandlerOptions)
       ms.update(
@@ -355,7 +355,7 @@ export function transformUVue(
         localStyleCollector ? localStyleCollector.rewriteTransformedCode(code) : code,
       )
     }
-    if (descriptor.scriptSetup) {
+    if (descriptor.scriptSetup && descriptor.scriptSetup.start < descriptor.scriptSetup.end) {
       localStyleCollector?.collectRuntimeClasses(descriptor.scriptSetup.content)
       const { code } = jsHandler(descriptor.scriptSetup.content, runtimeSet ?? new Set(), defaultCreateJsHandlerOptions)
       ms.update(

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -96,6 +96,16 @@ const label = 'hi'
     expect(jsHandler).toHaveBeenCalled()
   })
 
+  it('ignores empty external WXS script blocks', () => {
+    const jsHandler: JsHandler = vi.fn(source => ({ code: source }))
+    const code = `<script module="touch" lang="wxs" src="../../libs/use/useTouch/touch.wxs"></script>
+<script module="wxs" lang="wxs" src="./WX.wxs"></script>`
+
+    const result = transformUVue(code, 'external-wxs.uvue', jsHandler, new Set())
+    expect(result?.code).toBe(code)
+    expect(jsHandler).not.toHaveBeenCalled()
+  })
+
   it('transforms object literal class bindings with whitespace', () => {
     const { jsHandler } = getCompilerContext()
     const runtimeSet = new Set<string>([


### PR DESCRIPTION
## 摘要
修复 uni-app x SFC 中空内容外链 WXS `<script>` 触发 MagicString 零长度区间异常的问题。

## 变更
- 空脚本区间不再进入 JS AST 扫描和 `MagicString.update`。
- 增加两个外链 WXS 脚本的回归测试。

## 验证
- `pnpm --filter weapp-tailwindcss exec vitest run test/uni-app-x test/js`
- `pnpm --filter weapp-tailwindcss build`
- `git diff --check`

Refs #1110