### PR TITLE
fix(uni-app-x): 修复 Web 局部样式重要修饰符

### DIFF
--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -6,6 +6,24 @@ import { createStyleHandler, postcss } from '@/index'
 const INVALID_UNI_APP_X_BASE_SELECTOR_RE = /(^|,)\s*(?:\*|view|text|::before|::after|:before|:after|::backdrop)\s*(?=,|\{)/m
 
 describe('uni-app-x', () => {
+  it('accepts Web local important apply syntax', async () => {
+    const styleHandler = createStyleHandler({
+      appType: 'uni-app-x',
+      uniAppX: true,
+      majorVersion: 4,
+    })
+    const options = {
+      appType: 'uni-app-x' as const,
+      uniAppX: true,
+    }
+    const result = await styleHandler('.wtu-important { @apply mt-6!; }', options)
+
+    expect(result.css).toContain('@apply mt-6!;')
+    await expect(
+      styleHandler(".wtu-important { @apply mt-6#{'!'}; }", options),
+    ).rejects.toThrow('Unknown word')
+  })
+
   it('css', async () => {
     const styleHandler = createStyleHandler({
       // uniAppX: true,

--- a/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
@@ -46,14 +46,15 @@ function createAlias(fileId: string, utility: string, index: number) {
   return `wtu-${createStableHash(`${fileId}:${utility}`)}-${index.toString(36)}`
 }
 
-function serializeApplyUtility(utility: string) {
+function serializeApplyUtility(utility: string, options: { web?: boolean } = {}) {
+  const importantSuffix = options.web ? '!' : '#{\'!\'}'
   if (utility.startsWith('!') && !utility.startsWith('\\!')) {
-    return `${utility.slice(1)}#{'!'}`
+    return `${utility.slice(1)}${importantSuffix}`
   }
   if (!utility.endsWith('!') || utility.endsWith('\\!')) {
     return utility
   }
-  return `${utility.slice(0, -1)}#{'!'}`
+  return `${utility.slice(0, -1)}${importantSuffix}`
 }
 
 function isRuntimeCandidate(candidate: string, runtimeSet?: Set<string>) {
@@ -302,7 +303,7 @@ export class UniAppXComponentLocalStyleCollector {
         ? `${localSelector}, :deep(.${alias})`
         : localSelector
       lines.push(`${selector} {`)
-      lines.push(`  @apply ${serializeApplyUtility(utility)};`)
+      lines.push(`  @apply ${serializeApplyUtility(utility, options)};`)
       lines.push('}')
     }
     return `${lines.join('\n')}\n`

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -3,6 +3,7 @@ import { createGetCase, fixturesRootPath } from '#test/util'
 import process from 'node:process'
 import { beforeEach, afterEach } from 'vitest'
 import { vi } from 'vitest'
+import { createStyleHandler } from '@weapp-tailwindcss/postcss'
 import { getCompilerContext } from '@/context'
 import { transformUVue } from '@/uni-app-x'
 import {
@@ -260,6 +261,37 @@ const condition = true
     expect(styleBlock).toContain("@apply w-[100rpx]#{'!'};")
     expect(styleBlock).not.toContain('@apply !w-[100rpx];')
     expect(result?.code).not.toContain('class="!w-[100rpx]"')
+  })
+
+  it('serializes important utilities with CSS-safe syntax for Web local styles', async () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const onWebLocalStyleRules = vi.fn()
+    const runtimeSet = new Set(['!mt-6', 'mt-6!'])
+    const result = transformUVue(
+      '<template><view class="!mt-6 mt-6!">Web important</view></template>\n<style scoped>.author { color: red; }</style>',
+      '/src/pages/index/index.uvue',
+      jsHandler,
+      runtimeSet,
+      {
+        enablePageLocalStyle: true,
+        onWebLocalStyleRules,
+      },
+    )
+
+    const styleRules = onWebLocalStyleRules.mock.calls[0]?.[0] as string | undefined
+    expect(result?.code).not.toContain('class="!mt-6 mt-6!"')
+    expect(styleRules).toContain('@apply mt-6!;')
+    expect(styleRules).not.toContain("#{'!'}")
+
+    const styleHandler = createStyleHandler({
+      appType: 'uni-app-x',
+      uniAppX: true,
+      majorVersion: 4,
+    })
+    await expect(styleHandler(styleRules!, {
+      appType: 'uni-app-x',
+      uniAppX: true,
+    })).resolves.toBeDefined()
   })
 
   it('honors disabledDefaultTemplateHandler with custom class rules', () => {


### PR DESCRIPTION
## 变更说明

修复 uni-app x Web 局部样式桥接将重要修饰符序列化为 Sass 插值，导致 PostCSS 报 `Unknown word "!"` 并使页面 Tailwind 样式缺失的问题。

- Web 局部样式输出 `utility!`
- 原生 App/Harmony 保留 `utility#{'!'}` 兼容行为
- 增加 uni-app x 与 PostCSS 回归测试

## 本地验证

- `pnpm --filter weapp-tailwindcss exec vitest run test/uni-app-x/index.test.ts --coverage.enabled=false`
- `pnpm --filter @weapp-tailwindcss/postcss exec vitest run test/uni-app-x.test.ts --coverage.enabled=false`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm --filter @weapp-tailwindcss/postcss build`

Refs #1113