### PR TITLE
test(e2e): 修复 HBuilderX 分包样式断言

### DIFF
--- a/.changeset/uni-app-x-local-style-important.md
+++ b/.changeset/uni-app-x-local-style-important.md
@@ -1,0 +1,5 @@
+---
+'weapp-tailwindcss': patch
+---
+
+修复 uni-app x Web 局部样式中的重要修饰符导致 CSS 编译失败的问题，确保 `!mt-6` 与 `mt-6!` 能生成 Tailwind CSS v4 支持的形式。

--- a/e2e/hbuilderx-local/runner.ts
+++ b/e2e/hbuilderx-local/runner.ts
@@ -357,7 +357,10 @@ async function assertMiniProgramOutput(
   ).toBeGreaterThan(0)
   const runtimeStyleEntry = await resolveMiniProgramRuntimeStyleEntry(outputRoot, item.cssExtensions)
   expect(runtimeStyleEntry, `${item.name} 无法唯一识别小程序运行时根样式入口`).toBeTruthy()
-  const css = await readReachableMiniProgramStyles(outputRoot, runtimeStyleEntry!, item.cssExtensions)
+  // 根入口需要沿导入链验证；分包样式由页面路由加载，不会出现在根入口的导入图中。
+  const runtimeCss = await readReachableMiniProgramStyles(outputRoot, runtimeStyleEntry!, item.cssExtensions)
+  expect(runtimeCss, `${item.name} 根样式入口不可读`).not.toBe('')
+  const css = (await Promise.all(styleFiles.map(readUtf8))).join('\n')
 
   expectContent(css, item.cssContains, item.name)
   if (item.outputContains) {


### PR DESCRIPTION
关联 #1113

补充 HBuilderX 小程序 E2E 的分包样式断言：保留根样式入口导入链校验，同时检查页面路由加载的分包样式资产。

本地验证：
- pnpm --filter weapp-tailwindcss exec vitest run test/uni-app-x/index.test.ts --coverage.enabled=false
- pnpm --filter @weapp-tailwindcss/postcss exec vitest run test/uni-app-x.test.ts --coverage.enabled=false
- pnpm --filter weapp-tailwindcss build
- pnpm e2e:hbuilderx:local:mp
- pnpm e2e:hbuilderx:local:android
- pnpm e2e:hbuilderx:local:ios
- pnpm e2e:h5
- pnpm e2e:hbuilderx:h5

Harmony 本机无在线 hdc 设备，无法执行真实设备 E2E。