### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -34,3 +34,7 @@ weapp-tailwindcss@5.3.5:
   intents:
     - empty-wxs-script
     - funky-keys-greet
+weapp-tailwindcss@5.3.6:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - uni-app-x-local-style-important

--- a/.changeset/uni-app-x-local-style-important.md
+++ b/.changeset/uni-app-x-local-style-important.md
@@ -1,5 +1,0 @@
----
-'weapp-tailwindcss': patch
----
-
-修复 uni-app x Web 局部样式中的重要修饰符导致 CSS 编译失败的问题，确保 `!mt-6` 与 `mt-6!` 能生成 Tailwind CSS v4 支持的形式。

--- a/examples/react-lynx-promo/CHANGELOG.md
+++ b/examples/react-lynx-promo/CHANGELOG.md
@@ -5,4 +5,11 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.5
+
+## 0.0.0
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.4

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.5
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.4
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.8
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.7
 
 ## 0.1.3

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.6
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.5
 
 ## 0.0.72

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.3.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.6
+
 ## 5.3.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.6
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.3.6
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "repository": {

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,11 @@
 # weapp-tailwindcss
 
+## 5.3.6
+
+### Patch Changes
+
+- 修复 uni-app x Web 局部样式中的重要修饰符导致 CSS 编译失败的问题，确保 `!mt-6` 与 `mt-6!` 能生成 Tailwind CSS v4 支持的形式。
+
 ## 5.3.5
 
 ### Patch Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.3.6
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.3.5
 
 ## 1.0.65


### PR DESCRIPTION
# Release Notes

> 4 packages updated · 4 changes

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.3.6**: Updated dependency to weapp-tailwindcss@5.3.6.
- **@weapp-tailwindcss/lynx@0.3.5**: Updated dependency to weapp-tailwindcss@5.3.6.
- **@weapp-tailwindcss/react-native@0.2.8**: Updated dependency to weapp-tailwindcss@5.3.6.
- **weapp-tailwindcss@5.3.6**: 修复 uni-app x Web 局部样式中的重要修饰符导致 CSS 编译失败的问题，确保 !mt-6 与 mt-6! 能生成 Tailwind CSS v4 支持的形式。 [`4a49826`](https://github.com/sonofmagic/weapp-tailwindcss/commit/4a49826f1e77cea96f05bb1c300ede5e22a75c01) · [#1115](https://github.com/sonofmagic/weapp-tailwindcss/pull/1115)

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.3.5`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.3.5) | `5.3.6` |
| `@weapp-tailwindcss/lynx` | [`0.3.4`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.4) | `0.3.5` |
| `@weapp-tailwindcss/react-native` | [`0.2.7`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.7) | `0.2.8` |
| `weapp-tailwindcss` | [`5.3.5`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.3.5) | `5.3.6` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic