### PR TITLE
fix(uni-app-x): 修复 important utility 跨端编译

### DIFF
--- a/.changeset/clever-issues-1113.md
+++ b/.changeset/clever-issues-1113.md
@@ -1,0 +1,6 @@
+---
+"weapp-tailwindcss": patch
+"@weapp-tailwindcss/postcss": patch
+---
+
+修复 uni-app x 中 important utility 与局部 Sass `@apply` 在 Web、Android Vapor 等目标间编译不一致的问题。

--- a/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
+++ b/demo/uni-app-x-hbuilderx-tailwindcss-v4/pages/index/index.uvue
@@ -79,7 +79,7 @@
 			rightClass="issue-navbar-right bg-[#102938] w-[100rpx] h-[100rpx] p-[12rpx]"
 		>
 			<template #left>
-				<image src="/static/logo.png" class="issue-navbar-image w-[100rpx] h-[100rpx]" />
+				<image src="/static/logo.png" class="issue-navbar-image w-[100rpx] h-[100rpx] rounded-[10rpx]" />
 			</template>
 			<template #right>
 				<text class="text-[#f7fbff]">right</text>

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -94,6 +94,7 @@
     "postcss-pxtrans": "^1.0.4",
     "postcss-rem-to-responsive-pixel": "catalog:postcssRem",
     "postcss-rule-unit-converter": "^0.2.3",
+    "postcss-scss": "^4.0.9",
     "postcss-selector-parser": "catalog:buildUtilities",
     "postcss-value-parser": "^4.2.0",
     "tailwindcss-config": "workspace:*"

--- a/packages/postcss/src/compat/uni-app-x.ts
+++ b/packages/postcss/src/compat/uni-app-x.ts
@@ -2,7 +2,12 @@
 import type { Result as PostcssResult, Rule } from 'postcss'
 import type { Node, Pseudo } from 'postcss-selector-parser'
 import type { IStyleHandlerOptions } from '../types'
+import { splitCandidateTokens } from '@tailwindcss-mangle/engine'
 import postcss from 'postcss'
+import scssSyntax from 'postcss-scss'
+
+/** native Sass 可解析、PostCSS 阶段再还原的 important utility 标记。 */
+export const UNI_APP_X_IMPORTANT_APPLY_MARKER = '__weapp_tw_important__'
 
 const UNI_APP_X_BASE_CARRIER_SELECTORS = new Set([
   '*',
@@ -17,6 +22,72 @@ const UNI_APP_X_BASE_CARRIER_SELECTORS = new Set([
 const REQUIRED_TW_VAR_RE = /var\(\s*(--tw-[\w-]+)\s*\)/g
 const CLASS_SELECTOR_RE = /\.[\w-]+/
 const SELECTOR_WHITESPACE_RE = /\s+/g
+
+function rewriteImportantApplyUtility(utility: string, marker: string) {
+  if (utility.startsWith('!') && !utility.startsWith('\\!')) {
+    return `${utility.slice(1)}${marker}`
+  }
+  if (utility.endsWith('!') && !utility.endsWith('\\!')) {
+    return `${utility.slice(0, -1)}${marker}`
+  }
+  return utility
+}
+
+function rewriteApplyParams(params: string, marker: string) {
+  const candidates = splitCandidateTokens(params)
+  if (candidates.length === 0) {
+    return params
+  }
+  let result = params
+  for (const candidate of candidates) {
+    const rewritten = rewriteImportantApplyUtility(candidate, marker)
+    if (rewritten !== candidate) {
+      result = result.replace(candidate, rewritten)
+    }
+  }
+  return result
+}
+
+/** 将 Sass 不可直接解析的 important utility 改写成跨预处理器中间形式。 */
+export function normalizeUniAppXImportantApplyForSass(css: string) {
+  try {
+    const root = postcss.parse(css, { from: undefined, syntax: scssSyntax })
+    let changed = false
+    root.walkAtRules('apply', (rule) => {
+      const params = rewriteApplyParams(rule.params, UNI_APP_X_IMPORTANT_APPLY_MARKER)
+      if (params !== rule.params) {
+        rule.params = params
+        changed = true
+      }
+    })
+    return changed ? root.toString() : css
+  }
+  catch {
+    return css
+  }
+}
+
+/** 在 Tailwind/PostCSS 处理前还原 native important utility 标记。 */
+export function restoreUniAppXImportantApplyMarker(css: string) {
+  if (!css.includes(UNI_APP_X_IMPORTANT_APPLY_MARKER)) {
+    return css
+  }
+  try {
+    const root = postcss.parse(css)
+    let changed = false
+    root.walkAtRules('apply', (rule) => {
+      if (!rule.params.includes(UNI_APP_X_IMPORTANT_APPLY_MARKER)) {
+        return
+      }
+      rule.params = rule.params.split(UNI_APP_X_IMPORTANT_APPLY_MARKER).join('!')
+      changed = true
+    })
+    return changed ? root.toString() : css
+  }
+  catch {
+    return css
+  }
+}
 
 interface TwDefaultDeclaration {
   prop: string

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -45,6 +45,11 @@ export {
 } from './compat/tailwindcss-rpx'
 export { normalizeTailwindcssV4InfinityCalcCss } from './compat/tailwindcss-v4'
 export {
+  normalizeUniAppXImportantApplyForSass,
+  restoreUniAppXImportantApplyMarker,
+  UNI_APP_X_IMPORTANT_APPLY_MARKER,
+} from './compat/uni-app-x'
+export {
   type NormalizedWebCssCompatOptions,
   normalizeWebCssCompatOptions,
   transformWebCssCompat,

--- a/packages/postcss/test/uni-app-x.test.ts
+++ b/packages/postcss/test/uni-app-x.test.ts
@@ -1,11 +1,20 @@
 import fs from 'fs-extra'
 import path from 'pathe'
+import { normalizeUniAppXImportantApplyForSass, restoreUniAppXImportantApplyMarker } from '@/compat/uni-app-x'
 import { applyUniAppXUvueCompatibility } from '@/compat/uni-app-x-uvue'
 import { createStyleHandler, postcss } from '@/index'
 
 const INVALID_UNI_APP_X_BASE_SELECTOR_RE = /(^|,)\s*(?:\*|view|text|::before|::after|:before|:after|::backdrop)\s*(?=,|\{)/m
 
 describe('uni-app-x', () => {
+  it('round-trips important apply utilities across Sass and PostCSS', () => {
+    const source = '.probe { @apply !mt-6 mt-6! text-sm; }'
+    const sassSafe = normalizeUniAppXImportantApplyForSass(source)
+
+    expect(sassSafe).toContain('@apply mt-6__weapp_tw_important__ mt-6__weapp_tw_important__ text-sm;')
+    expect(restoreUniAppXImportantApplyMarker(sassSafe)).toContain('@apply mt-6! mt-6! text-sm;')
+  })
+
   it('accepts Web local important apply syntax', async () => {
     const styleHandler = createStyleHandler({
       appType: 'uni-app-x',

--- a/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/component-local-style.ts
@@ -1,6 +1,7 @@
 import type { NodePath } from '@babel/traverse'
 import type { StringLiteral, TemplateElement } from '@babel/types'
 import { splitCandidateTokens } from '@tailwindcss-mangle/engine'
+import { UNI_APP_X_IMPORTANT_APPLY_MARKER } from '@weapp-tailwindcss/postcss'
 import MagicString from 'magic-string'
 import { analyzeSource, babelParse } from '@/js/babel'
 import { isClassContextLiteralPath } from '@/js/class-context'
@@ -46,8 +47,12 @@ function createAlias(fileId: string, utility: string, index: number) {
   return `wtu-${createStableHash(`${fileId}:${utility}`)}-${index.toString(36)}`
 }
 
-function serializeApplyUtility(utility: string, options: { web?: boolean } = {}) {
-  const importantSuffix = options.web ? '!' : '#{\'!\'}'
+function serializeApplyUtility(utility: string, options: { native?: boolean, web?: boolean } = {}) {
+  const importantSuffix = options.native
+    ? UNI_APP_X_IMPORTANT_APPLY_MARKER
+    : options.web
+      ? '!'
+      : '#{\'!\'}'
   if (utility.startsWith('!') && !utility.startsWith('\\!')) {
     return `${utility.slice(1)}${importantSuffix}`
   }
@@ -283,14 +288,14 @@ export class UniAppXComponentLocalStyleCollector {
     return this.aliasByUtility.size > 0
   }
 
-  toStyleBlock(options: { web?: boolean } = {}) {
+  toStyleBlock(options: { native?: boolean, web?: boolean } = {}) {
     if (!this.hasStyles()) {
       return ''
     }
     return `<style scoped>\n${this.toStyleRules(options)}</style>\n`
   }
 
-  toStyleRules(options: { web?: boolean } = {}) {
+  toStyleRules(options: { native?: boolean, web?: boolean } = {}) {
     if (!this.hasStyles()) {
       return ''
     }

--- a/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
@@ -3,6 +3,7 @@ import type { SourceMapInput } from 'rollup'
 import type { TransformResult } from 'vite'
 import type { CreateJsHandlerOptions, ICustomAttributesEntities, JsHandler } from '@/types'
 import { NodeTypes, parse as parseTemplate } from '@vue/compiler-dom'
+import { normalizeUniAppXImportantApplyForSass } from '@weapp-tailwindcss/postcss'
 import MagicString from 'magic-string'
 import { generateCode, replaceWxml } from '@/wxml'
 import { createAttributeMatcher } from '@/wxml/custom-attributes'
@@ -130,6 +131,7 @@ interface TransformUVueOptions {
   enableComponentLocalStyle?: boolean
   enablePageLocalStyle?: boolean
   pageMatcher?: (id: string) => boolean
+  native?: boolean
   webCustomAttributeDeep?: boolean
   onWebLocalStyleRules?: (rules: string) => void
 }
@@ -273,6 +275,14 @@ export function transformUVue(
   const matchCustomAttribute = createAttributeMatcher(customAttributesEntities)
   const ms = new MagicString(code)
   const descriptor = parseSfc(code)
+  if (options.native || options.onWebLocalStyleRules) {
+    for (const style of descriptor.styles) {
+      const normalized = normalizeUniAppXImportantApplyForSass(style.content)
+      if (normalized !== style.content) {
+        ms.update(style.start, style.end, normalized)
+      }
+    }
+  }
   const localStyleCollector = shouldEnableLocalStyle(id, options)
     ? new UniAppXComponentLocalStyleCollector(id, runtimeSet)
     : undefined
@@ -372,10 +382,14 @@ export function transformUVue(
       }
       else if (scopedStyle) {
         const separator = scopedStyle.content.endsWith('\n') ? '' : '\n'
-        ms.appendLeft(scopedStyle.end, `${separator}${localStyleCollector.toStyleRules()}`)
+        ms.appendLeft(scopedStyle.end, `${separator}${localStyleCollector.toStyleRules({ native: options.native })}`)
       }
       else {
-        ms.append(`\n${localStyleCollector.toStyleBlock({ web: Boolean(options.onWebLocalStyleRules) })}`)
+        // 新增的局部样式块会单独进入预处理器，important utility 统一使用中间标记。
+        ms.append(`\n${localStyleCollector.toStyleBlock({
+          native: options.native || Boolean(options.onWebLocalStyleRules),
+          web: Boolean(options.onWebLocalStyleRules),
+        })}`)
       }
     }
   }

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
@@ -1,19 +1,15 @@
 import type { RawSourceMap } from '@ampproject/remapping'
-import type { ExistingRawSourceMap, OutputAsset, SourceMap } from 'rollup'
+import type { ExistingRawSourceMap, SourceMap } from 'rollup'
 import type { Plugin, TransformResult } from 'vite'
 import type { CreateUniAppXPluginsOptions } from './vite/plugin-options'
-import type { ICreateCacheReturnType } from '@/cache'
-import type {
-  CreateJsHandlerOptions,
-  InternalUserDefinedOptions,
-  JsHandler,
-  LinkedJsModuleResult,
-} from '@/types'
 import path from 'node:path'
 import process from 'node:process'
-import { processCachedTask } from '@/bundlers/shared/cache'
+import {
+  normalizeUniAppXImportantApplyForSass,
+  restoreUniAppXImportantApplyMarker,
+} from '@weapp-tailwindcss/postcss'
 import { hasTailwindApplyDirective, hasTailwindRootDirectives } from '@/bundlers/shared/generator-css/directives'
-import { toAbsoluteOutputPath } from '@/bundlers/shared/module-graph'
+import { extractSfcStyleBlocks } from '@/bundlers/vite/generate-bundle/sfc-style-source'
 import { parseVueRequest } from '@/bundlers/vite/query'
 import { cleanUrl, formatPostcssSourceMap, isCSSRequest, normalizePath } from '@/bundlers/vite/utils'
 import { logger } from '@/logger'
@@ -21,7 +17,7 @@ import { isUniAppXHarmonyOutDir } from '@/uni-app-x/harmony'
 import { shouldEnablePageLocalStyle as isPageLocalStyleFile } from '@/uni-app-x/local-style-matcher'
 import { resolveUniUtsPlatform } from '@/utils'
 import { omitUndefined } from '@/utils/object'
-import { isUniAppXEnabled, resolveUniAppXOptions } from './options'
+import { resolveUniAppXOptions } from './options'
 import {
   collectUniAppXHarmonyApplyStyleSources,
   collectUniAppXHarmonyApplyUtilities,
@@ -38,6 +34,8 @@ import { createUniAppXNativeBuildTargetResolver } from './vite/native-target'
 import { isCssModuleExport, normalizeRelativeTailwindReferences, resolvePreprocessorTransform, resolveUniAppXCssTarget } from './vite/style-request'
 import { createUniAppXWebLocalStyleBridge } from './vite/web-local-style'
 
+export { createUniAppXAssetTask } from './vite/asset-task'
+
 type TransformUVue = typeof import('./transform')['transformUVue']
 let transformUVuePromise: Promise<TransformUVue> | undefined
 function loadTransformUVue(): Promise<TransformUVue> {
@@ -46,8 +44,8 @@ function loadTransformUVue(): Promise<TransformUVue> {
 }
 const UVUE_NVUE_QUERY_RE = /\.(?:uvue|nvue)(?:\?.*)?$/
 const UVUE_NVUE_RE = /\.(?:uvue|nvue)$/
-function resolveUniAppXJsTransformEnabled(uniAppX: InternalUserDefinedOptions['uniAppX'] | undefined) {
-  return uniAppX === undefined ? true : isUniAppXEnabled(uniAppX)
+function hasUniAppXImportantApply(source: string) {
+  return extractSfcStyleBlocks(source).some(style => normalizeUniAppXImportantApplyForSass(style.source) !== style.source)
 }
 
 export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plugin[] {
@@ -92,6 +90,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     }
   }>()
   const nativeLocalStyleModuleIds = new Set<string>()
+  const knownSfcSources = new Map<string, string>()
   const webLocalStyle = createUniAppXWebLocalStyleBridge(isWebGeneratorTarget)
   let componentLocalStyleEnabled: boolean | undefined
   const isNativeAppBuildTarget = createUniAppXNativeBuildTargetResolver(getResolvedConfig)
@@ -169,7 +168,10 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       if (isCssModuleExport(code)) {
         return
       }
-      const sourceCode = normalizeRelativeTailwindReferences(code, id)
+      const sourceCode = normalizeRelativeTailwindReferences(
+        restoreUniAppXImportantApplyMarker(code),
+        id,
+      )
       const hasTailwindRoot = hasTailwindRootDirectives(sourceCode, { importFallback: true })
       const hasTailwindApply = hasTailwindApplyDirective(sourceCode)
       const shouldGenerateCss = hasTailwindRoot || hasTailwindApply
@@ -230,6 +232,22 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
   const cssPrePlugin: Plugin = {
     name: 'weapp-tailwindcss:uni-app-x:css:pre',
     enforce: 'pre',
+    load: {
+      order: 'pre',
+      async handler(id) {
+        const { filename, query } = parseVueRequest(id)
+        if (!query.vue || query.type !== 'style' || !UVUE_NVUE_RE.test(filename)) {
+          return
+        }
+        const source = knownSfcSources.get(filename)
+        const style = source ? extractSfcStyleBlocks(source)[query.index ?? 0] : undefined
+        if (!style) {
+          return
+        }
+        const normalized = normalizeUniAppXImportantApplyForSass(style.source)
+        return normalized === style.source ? undefined : { code: normalized, map: null }
+      },
+    },
     async transform(code, id) {
       if (!isEnabled()) {
         return
@@ -237,14 +255,19 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       await runtimeState.readyPromise
       const { query } = parseVueRequest(id)
       const styleCode = query.vue && query.type === 'style' ? webLocalStyle.appendToStyle(code, id) : code
-      const preprocessor = resolvePreprocessorTransform(styleCode, id, query.lang, {
+      // Vite 热更新会绕过 SFC 主模块，直接把原始样式交给预处理器；先移除
+      // Sass 无法解析的 important utility 后，再由后续 CSS 阶段还原。
+      const preprocessorCode = query.vue && query.type === 'style'
+        ? normalizeUniAppXImportantApplyForSass(styleCode)
+        : styleCode
+      const preprocessor = resolvePreprocessorTransform(preprocessorCode, id, query.lang, {
         isIosPlatform,
         isNativeAppStyleTarget: isNativeAppStyleTarget(),
       })
       if (preprocessor) {
-        return preprocessor.result ?? (styleCode !== code ? { code: styleCode, map: null } : undefined)
+        return preprocessor.result ?? (preprocessorCode !== code ? { code: preprocessorCode, map: null } : undefined)
       }
-      return transformStyle(styleCode, id, query, this)
+      return transformStyle(preprocessorCode, id, query, this)
     },
   }
   const cssPlugin: Plugin = {
@@ -261,6 +284,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
   const cssPlugins = [cssPlugin, cssPrePlugin]
 
   async function transformSfc(code: string, id: string, context: { addWatchFile?: (id: string) => void }) {
+    knownSfcSources.set(cleanUrl(id), code)
     if (isNativeAppBuildTarget(id)) {
       nativeLocalStyleModuleIds.add(id)
       nativeLocalStyleModuleIds.add(cleanUrl(id))
@@ -285,6 +309,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       ...(disabledDefaultTemplateHandler ? { disabledDefaultTemplateHandler } : {}),
       ...(enableComponentLocalStyle ? { enableComponentLocalStyle } : {}),
       ...(enablePageLocalStyle ? { enablePageLocalStyle } : {}),
+      native: true,
       pageMatcher: resolvedUniAppXOptions.componentLocalStyles.pageMatcher,
       ...(isWebGeneratorTarget() && customAttributesEntities.length > 0 ? { webCustomAttributeDeep: true } : {}),
       ...(isWebGeneratorTarget() ? { onWebLocalStyleRules: (rules: string) => webLocalStyle.remember(id, rules) } : {}),
@@ -322,7 +347,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       },
     },
     handleHotUpdate: {
-      order: 'post',
+      order: 'pre',
       async handler(ctx) {
         if (!isEnabled() || getResolvedConfig()?.command !== 'serve') {
           return
@@ -331,7 +356,12 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
           return
         }
         if (isWebGeneratorTarget() && UVUE_NVUE_RE.test(ctx.file) && typeof ctx.read === 'function') {
-          await transformSfc(await ctx.read(), ctx.file, this)
+          const source = await ctx.read()
+          if (hasUniAppXImportantApply(source)) {
+            ctx.server.ws.send({ type: 'full-reload', path: ctx.file })
+            return []
+          }
+          await transformSfc(source, ctx.file, this)
         }
         return webLocalStyle.handleHotUpdate(ctx) ?? nativeHmrReloader.handleHotUpdate(ctx)
       },
@@ -418,82 +448,4 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     nvuePlugin,
     stylePlaceholderPlugin,
   ]
-}
-type ApplyLinkedResults = (linked: Record<string, LinkedJsModuleResult> | undefined) => void
-
-interface CreateUniAppXAssetTaskOptions {
-  cache: ICreateCacheReturnType
-  hashKey?: string
-  hashSalt?: string
-  createHandlerOptions: (absoluteFilename: string, extra?: CreateJsHandlerOptions) => CreateJsHandlerOptions
-  debug: (format: string, ...args: unknown[]) => void
-  jsHandler: JsHandler
-  onUpdate: (filename: string, oldVal: string, newVal: string) => void
-  runtimeSet: Set<string>
-  applyLinkedResults: ApplyLinkedResults
-  uniAppX?: InternalUserDefinedOptions['uniAppX']
-  getAssetSource?: (file: string) => string | undefined
-  getCssSources?: () => Iterable<string | undefined>
-  injectStylePlaceholder?: boolean
-}
-
-export function createUniAppXAssetTask(
-  file: string,
-  originalSource: OutputAsset,
-  outDir: string,
-  options: CreateUniAppXAssetTaskOptions,
-) {
-  return async () => {
-    const {
-      cache,
-      hashKey,
-      createHandlerOptions,
-      debug,
-      getAssetSource,
-      getCssSources,
-      injectStylePlaceholder = true,
-      jsHandler,
-      onUpdate,
-      runtimeSet,
-      applyLinkedResults,
-    } = options
-    const absoluteFile = toAbsoluteOutputPath(file, outDir)
-    const rawSource = originalSource.source.toString()
-    const rawHashSource = options.hashSalt
-      ? `${rawSource}\n/*${options.hashSalt}*/`
-      : rawSource
-    await processCachedTask<string>({
-      cache,
-      cacheKey: file,
-      hashKey,
-      rawSource: rawHashSource,
-      applyResult(source) {
-        originalSource.source = source
-      },
-      onCacheHit() {
-        debug('js cache hit: %s', file)
-      },
-      async transform() {
-        const currentSource = originalSource.source.toString()
-        const { code, linked } = await jsHandler(currentSource, runtimeSet, createHandlerOptions(absoluteFile, {
-          uniAppX: resolveUniAppXJsTransformEnabled(options.uniAppX),
-          babelParserOptions: {
-            plugins: [
-              'typescript',
-            ],
-            sourceType: 'unambiguous',
-          },
-        }))
-        const nextCode = injectStylePlaceholder
-          ? injectUniAppXStylePlaceholder(file, code, getAssetSource, getCssSources?.())
-          : code
-        onUpdate(file, currentSource, nextCode)
-        debug('js handle: %s', file)
-        applyLinkedResults(linked)
-        return {
-          result: nextCode,
-        }
-      },
-    })
-  }
 }

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite/asset-task.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite/asset-task.ts
@@ -1,0 +1,95 @@
+import type { OutputAsset } from 'rollup'
+import type { ICreateCacheReturnType } from '@/cache'
+import type {
+  CreateJsHandlerOptions,
+  InternalUserDefinedOptions,
+  JsHandler,
+  LinkedJsModuleResult,
+} from '@/types'
+import { processCachedTask } from '@/bundlers/shared/cache'
+import { toAbsoluteOutputPath } from '@/bundlers/shared/module-graph'
+import { isUniAppXEnabled } from '../options'
+import { injectUniAppXStylePlaceholder } from '../style-asset'
+
+type ApplyLinkedResults = (linked: Record<string, LinkedJsModuleResult> | undefined) => void
+
+export interface CreateUniAppXAssetTaskOptions {
+  cache: ICreateCacheReturnType
+  hashKey?: string
+  hashSalt?: string
+  createHandlerOptions: (absoluteFilename: string, extra?: CreateJsHandlerOptions) => CreateJsHandlerOptions
+  debug: (format: string, ...args: unknown[]) => void
+  jsHandler: JsHandler
+  onUpdate: (filename: string, oldVal: string, newVal: string) => void
+  runtimeSet: Set<string>
+  applyLinkedResults: ApplyLinkedResults
+  uniAppX?: InternalUserDefinedOptions['uniAppX']
+  getAssetSource?: (file: string) => string | undefined
+  getCssSources?: () => Iterable<string | undefined>
+  injectStylePlaceholder?: boolean
+}
+
+function resolveUniAppXJsTransformEnabled(uniAppX: InternalUserDefinedOptions['uniAppX'] | undefined) {
+  return uniAppX === undefined ? true : isUniAppXEnabled(uniAppX)
+}
+
+export function createUniAppXAssetTask(
+  file: string,
+  originalSource: OutputAsset,
+  outDir: string,
+  options: CreateUniAppXAssetTaskOptions,
+) {
+  return async () => {
+    const {
+      cache,
+      hashKey,
+      createHandlerOptions,
+      debug,
+      getAssetSource,
+      getCssSources,
+      injectStylePlaceholder = true,
+      jsHandler,
+      onUpdate,
+      runtimeSet,
+      applyLinkedResults,
+    } = options
+    const absoluteFile = toAbsoluteOutputPath(file, outDir)
+    const rawSource = originalSource.source.toString()
+    const rawHashSource = options.hashSalt
+      ? `${rawSource}\n/*${options.hashSalt}*/`
+      : rawSource
+    await processCachedTask<string>({
+      cache,
+      cacheKey: file,
+      hashKey,
+      rawSource: rawHashSource,
+      applyResult(source) {
+        originalSource.source = source
+      },
+      onCacheHit() {
+        debug('js cache hit: %s', file)
+      },
+      async transform() {
+        const currentSource = originalSource.source.toString()
+        const { code, linked } = await jsHandler(currentSource, runtimeSet, createHandlerOptions(absoluteFile, {
+          uniAppX: resolveUniAppXJsTransformEnabled(options.uniAppX),
+          babelParserOptions: {
+            plugins: [
+              'typescript',
+            ],
+            sourceType: 'unambiguous',
+          },
+        }))
+        const nextCode = injectStylePlaceholder
+          ? injectUniAppXStylePlaceholder(file, code, getAssetSource, getCssSources?.())
+          : code
+        onUpdate(file, currentSource, nextCode)
+        debug('js handle: %s', file)
+        applyLinkedResults(linked)
+        return {
+          result: nextCode,
+        }
+      },
+    })
+  }
+}

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin-hooks.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin-hooks.unit.test.ts
@@ -356,9 +356,10 @@ describe('bundlers/vite WeappTailwindcss hook coverage', () => {
       '/project/pages/index/index.uvue',
       context.jsHandler,
       expect.any(Set),
-      {
+      expect.objectContaining({
         enablePageLocalStyle: true,
-      },
+        native: true,
+      }),
     )
     expect(result?.code).toContain('uvue:/project/pages/index/index.uvue:')
   })

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.uni-app-x.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.uni-app-x.unit.test.ts
@@ -932,6 +932,12 @@ describe('bundlers/vite WeappTailwindcss uni-app-x', () => {
     await getTransformHandler(nvuePlugin)?.call(nvuePlugin, '<template></template>', 'App.uvue')
     expect(currentContext.tailwindRuntime.extract).toHaveBeenCalledTimes(1)
     expect(currentContext.tailwindRuntime.getClassSetSync).not.toHaveBeenCalled()
-    expect(transformUVueMock).toHaveBeenCalledWith('<template></template>', 'App.uvue', currentContext.jsHandler, runtimeSets[1])
+    expect(transformUVueMock).toHaveBeenCalledWith(
+      '<template></template>',
+      'App.uvue',
+      currentContext.jsHandler,
+      runtimeSets[1],
+      expect.objectContaining({ native: true }),
+    )
   }, TEST_TIMEOUT_MS)
 })

--- a/packages/weapp-tailwindcss/test/fixtures/uni-app-x/issue-1113.uvue
+++ b/packages/weapp-tailwindcss/test/fixtures/uni-app-x/issue-1113.uvue
@@ -1,0 +1,9 @@
+<template>
+  <view class="!mt-6 mt-6!">important utility</view>
+</template>
+
+<style lang="scss">
+.important-apply {
+  @apply !mt-6 mt-6!;
+}
+</style>

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -263,6 +263,35 @@ const condition = true
     expect(result?.code).not.toContain('class="!w-[100rpx]"')
   })
 
+  it('uses a Sass-safe marker for native important local styles', () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const result = transformUVue(
+      '<template><view class="!mt-6 mt-6!">native important</view></template>\n<style lang="scss" scoped>.author { @apply !mt-6 mt-6!; }</style>',
+      '/src/pages/index/index.uvue',
+      jsHandler,
+      new Set(['!mt-6', 'mt-6!']),
+      { enablePageLocalStyle: true, native: true },
+    )
+
+    expect(result?.code).not.toContain('class="!mt-6 mt-6!"')
+    expect(result?.code).toContain('@apply mt-6__weapp_tw_important__ mt-6__weapp_tw_important__;')
+  })
+
+  it('normalizes important utilities across a complete uvue fixture', async () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const source = await getCase('uni-app-x/issue-1113.uvue')
+    const result = transformUVue(
+      source,
+      '/src/pages/issue-1113/index.uvue',
+      jsHandler,
+      new Set(['!mt-6', 'mt-6!']),
+      { enablePageLocalStyle: true, native: true },
+    )
+
+    expect(result?.code).not.toContain('class="!mt-6 mt-6!"')
+    expect(result?.code).toContain('@apply mt-6__weapp_tw_important__ mt-6__weapp_tw_important__;')
+  })
+
   it('serializes important utilities with CSS-safe syntax for Web local styles', async () => {
     const { jsHandler } = getCompilerContext({ uniAppX: true })
     const onWebLocalStyleRules = vi.fn()
@@ -292,6 +321,20 @@ const condition = true
       appType: 'uni-app-x',
       uniAppX: true,
     })).resolves.toBeDefined()
+  })
+
+  it('uses a Sass-safe marker for Web-generated local style blocks', () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const result = transformUVue(
+      '<template><view class="!mt-6">Web generated style</view></template>',
+      '/src/pages/index/index.uvue',
+      jsHandler,
+      new Set(['!mt-6']),
+      { enablePageLocalStyle: true, onWebLocalStyleRules: vi.fn() },
+    )
+
+    expect(result?.code).toContain('@apply mt-6__weapp_tw_important__;')
+    expect(result?.code).not.toContain('@apply mt-6!;')
   })
 
   it('honors disabledDefaultTemplateHandler with custom class rules', () => {

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
@@ -146,7 +146,7 @@ describe('uni-app-x vite plugins', () => {
     const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
     const placeholderPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:style-placeholder')
 
-    await preCssPlugin!.transform?.('.a{}', '/foo.css')
+    await getTransformHandler(preCssPlugin)?.call(preCssPlugin, '.a{}', '/foo.css')
     await cssPlugin!.transform?.('.a{}', '/foo.css')
     await nvuePlugin!.buildStart?.()
     await getTransformHandler(nvuePlugin)?.call(nvuePlugin, '<template/>', '/foo.uvue')
@@ -192,8 +192,8 @@ describe('uni-app-x vite plugins', () => {
     })
     const preCssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
 
-    await preCssPlugin!.transform?.('$color: red;', '/pages/index/index.lang.less.css')
-    await preCssPlugin!.transform?.('$color: red;', '/pages/index/theme.less?direct')
+    await getTransformHandler(preCssPlugin)?.call(preCssPlugin, '$color: red;', '/pages/index/index.lang.less.css')
+    await getTransformHandler(preCssPlugin)?.call(preCssPlugin, '$color: red;', '/pages/index/theme.less?direct')
 
     expect(styleHandler).not.toHaveBeenCalled()
   })
@@ -335,11 +335,11 @@ describe('uni-app-x vite plugins', () => {
 
       const scssId = '/pages/index/index.uvue?vue&type=style&index=0&lang.scss'
 
-      const preResult = await preCssPlugin!.transform?.('$color: red;', scssId)
+      const preResult = await getTransformHandler(preCssPlugin)?.call(preCssPlugin, '$color: red;', scssId)
       expect(preResult).toBeUndefined()
       expect(styleHandler).not.toHaveBeenCalled()
 
-      const generatedApplyResult = await preCssPlugin!.transform?.(
+      const generatedApplyResult = await getTransformHandler(preCssPlugin)?.call(preCssPlugin,
         '.issue-1002-apply { border-radius: calc(infinity * 1px); }',
         scssId,
       )
@@ -391,7 +391,7 @@ describe('uni-app-x vite plugins', () => {
     expect(preCssPlugin).toBeDefined()
 
     const scssId = '/pages/index/index.uvue?vue&type=style&index=0&lang.scss'
-    await preCssPlugin!.transform?.('$color: red;', scssId)
+    await getTransformHandler(preCssPlugin)?.call(preCssPlugin, '$color: red;', scssId)
     expect(styleHandler).not.toHaveBeenCalled()
   })
 
@@ -431,7 +431,7 @@ describe('uni-app-x vite plugins', () => {
     const id = '/components/line/line.uvue?vue&type=style&index=0&lang.scss&scoped=true'
     const source = '.wtu-transform { @apply transform; }'
 
-    const result = await preCssPlugin!.transform?.(source, id)
+    const result = await getTransformHandler(preCssPlugin)?.call(preCssPlugin, source, id)
 
     expect(generateCss).toHaveBeenCalledWith(id, source, expect.objectContaining({
       disableSourceScan: true,
@@ -478,11 +478,38 @@ describe('uni-app-x vite plugins', () => {
       '.wtu-transform { @apply transform; }',
     ].join('\n')
 
-    const result = await preCssPlugin!.transform?.(source, id)
+    const result = await getTransformHandler(preCssPlugin)?.call(preCssPlugin, source, id)
 
     expect(result).toBeUndefined()
     expect(generateCss).not.toHaveBeenCalled()
     expect(styleHandler).not.toHaveBeenCalled()
+  })
+
+  it('normalizes important @apply before the Web Sass HMR preprocessor', async () => {
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => false),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      isWebGeneratorTarget: () => true,
+      getResolvedConfig: () => ({
+        command: 'serve',
+        build: { outDir: '/project/unpackage/dist/dev/web', watch: false },
+      } as ResolvedConfig),
+    })
+    const preCssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
+    const id = '/pages/index/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss'
+
+    const result = await getTransformHandler(preCssPlugin)?.call(preCssPlugin, '.probe { @apply !mt-6 mt-6!; }', id)
+
+    expect(result).toEqual({
+      code: '.probe { @apply mt-6__weapp_tw_important__ mt-6__weapp_tw_important__; }',
+      map: null,
+    })
   })
 
   it.each(Object.entries(preprocessorSources))('leaves mini-program %s variables and local @apply to the framework preprocessor', async ([lang, source]) => {
@@ -509,7 +536,7 @@ describe('uni-app-x vite plugins', () => {
     const preCssPlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
     const id = `/uni_modules/uview-ultra/components/up-checkbox/up-checkbox.uvue?vue&type=style&index=0&scoped=abc&lang=${lang}`
 
-    const result = await preCssPlugin!.transform?.(source, id)
+    const result = await getTransformHandler(preCssPlugin)?.call(preCssPlugin, source, id)
 
     expect(result).toBeUndefined()
     expect(generateCss).not.toHaveBeenCalled()
@@ -734,6 +761,7 @@ describe('uni-app-x vite plugins', () => {
       {
         customAttributesEntities,
         disabledDefaultTemplateHandler: true,
+        native: true,
       },
     )
     expect(transformResult).toEqual({ code: 'transformed', map: null })
@@ -1057,6 +1085,34 @@ describe('uni-app-x vite plugins', () => {
     })
   })
 
+  it('falls back to a full reload for Web HMR when an SFC contains important Sass apply', async () => {
+    const send = vi.fn()
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => true),
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet: vi.fn(async () => new Set<string>()),
+      isWebGeneratorTarget: () => true,
+      getResolvedConfig: () => ({ command: 'serve', root: '/project' } as ResolvedConfig),
+    })
+    const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
+    const context = {
+      file: '/project/pages/index/index.uvue',
+      modules: [],
+      read: vi.fn(async () => '<template><view /></template><style lang="scss">.probe { @apply mt-6!; }</style>'),
+      server: { ws: { send } },
+    } as unknown as HmrContext
+
+    const modules = await getHotUpdateHandler(nvuePlugin)?.call(nvuePlugin, context)
+
+    expect(modules).toEqual([])
+    expect(send).toHaveBeenCalledWith({ type: 'full-reload', path: context.file })
+  })
+
   it('enables component local style transform when manifest.json sets styleIsolationVersion=2', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-tw-issue-822-'))
     try {
@@ -1101,6 +1157,7 @@ describe('uni-app-x vite plugins', () => {
         runtimeSet,
         {
           enableComponentLocalStyle: true,
+          native: true,
         },
       )
     }
@@ -1149,11 +1206,12 @@ describe('uni-app-x vite plugins', () => {
       '/project/src/layouts/default.uvue?vue&type=template',
       jsHandler,
       runtimeSet,
-      {
-        componentMatcher,
-        enableComponentLocalStyle: true,
-        pageMatcher,
-      },
+        {
+          componentMatcher,
+          enableComponentLocalStyle: true,
+          native: true,
+          pageMatcher,
+        },
     )
   })
 
@@ -1199,6 +1257,7 @@ describe('uni-app-x vite plugins', () => {
         runtimeSet,
         {
           enablePageLocalStyle: true,
+          native: true,
         },
       )
     }
@@ -1258,6 +1317,7 @@ describe('uni-app-x vite plugins', () => {
           customAttributesEntities: [['a-navbar', ['leftClass']]],
           enableComponentLocalStyle: true,
           enablePageLocalStyle: true,
+          native: true,
           onWebLocalStyleRules: expect.any(Function),
           webCustomAttributeDeep: true,
         },
@@ -1319,6 +1379,7 @@ describe('uni-app-x vite plugins', () => {
         {
           enableComponentLocalStyle: true,
           enablePageLocalStyle: true,
+          native: true,
         },
       )
     }
@@ -1422,6 +1483,9 @@ describe('uni-app-x vite plugins', () => {
         '/src/components/foo.uvue',
         jsHandler,
         runtimeSet,
+        {
+          native: true,
+        },
       )
     }
     finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4405,6 +4405,9 @@ importers:
       postcss-rule-unit-converter:
         specifier: ^0.2.3
         version: 0.2.3(postcss@8.5.26)
+      postcss-scss:
+        specifier: ^4.0.9
+        version: 4.0.9(postcss@8.5.26)
       postcss-selector-parser:
         specifier: catalog:buildUtilities
         version: 7.1.5


### PR DESCRIPTION
## 变更
- 修复 `!mt-6`、`mt-6!` 与局部 Sass `@apply` 在 uni-app x Web/原生链路中的编译顺序问题。
- 使用 AST 中间标记跨过 Sass，再在 PostCSS 阶段恢复 important 语义。
- 补充 Web/native/HMR 回归测试与最小 `.uvue` fixture。

## 验证
- `pnpm exec vitest run packages/postcss/test/uni-app-x.test.ts packages/weapp-tailwindcss/test/uni-app-x/index.test.ts packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm --filter @weapp-tailwindcss/postcss build`
- Android Vapor 与 Web 初次编译已在本地复现项目验证。
- HBuilderX Web HMR 自动化当前受 IDE 进程无输出阻塞，代码已加入 pre 阶段 full reload 保护。

Refs #1113