### PR TITLE
test(uni-app-x): 增加 Harmony Vapor leading 回归覆盖

### DIFF
--- a/demo/__tests__/tailwind-path-directives.test.ts
+++ b/demo/__tests__/tailwind-path-directives.test.ts
@@ -21,6 +21,10 @@ const styleFileRE = /\.(?:css|scss|less|mpx|vue|uvue)$/
 const tailwindEntryRE = /@(tailwind\s+(?:base|components|utilities)|import\s+["']tailwindcss(?:\/|["']))/
 const directiveRE = /@(config|source)\s+(not\s+)?["']([^"']+)["']/g
 const subpackageRoots = ['sub-normal', 'sub-independent'] as const
+// Harmony Vapor 最小复现只验证 App 样式注入，不承载小程序分包隔离契约。
+const subpackageCoverageExemptDemoProjects = new Set([
+  'uni-app-x-harmony-vapor-tailwindcss-v4',
+])
 
 function stripCssComments(source: string) {
   let output = ''
@@ -291,10 +295,16 @@ describe('demo Tailwind path directives', () => {
   it('keeps every mini-program demo covering normal and independent subpackage styles', async () => {
     const files = await collectFiles(demoRoot)
     const packageJsonFiles = files.filter(file => path.basename(file) === 'package.json')
-    const demoProjects = packageJsonFiles
+    const allDemoProjects = packageJsonFiles
       .map(file => getDemoProjectFromDemoRelativePath(path.relative(demoRoot, file)))
       .filter(project => !isWebDemoProject(project))
       .sort()
+    const demoProjects = allDemoProjects
+      .filter(project => !subpackageCoverageExemptDemoProjects.has(project))
+
+    for (const project of subpackageCoverageExemptDemoProjects) {
+      expect(allDemoProjects, `${project} should remain a real demo project`).toContain(project)
+    }
 
     expect(demoProjects.length).toBeGreaterThan(0)
 

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/.gitignore
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+unpackage
+debug
+.DS_Store
+.debug

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/.hbuilderx/launch.json
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/.hbuilderx/launch.json
@@ -1,0 +1,17 @@
+{
+    "version" : "1.0",
+    "configurations" : [
+        {
+            "playground" : "standard",
+            "type" : "uni-app:app-ios"
+        },
+        {
+            "playground" : "standard",
+            "type" : "uni-app:app-android"
+        },
+        {
+            "playground" : "standard",
+            "type" : "uni-app:app-ios_simulator"
+        }
+    ]
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/.vscode/settings.json
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "tailwindCSS.includeLanguages": {
+        "wxml": "html",
+        "mpx": "html",
+        "uvue": "html",
+        "uts": "javascript"
+    }
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/App.uvue
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/App.uvue
@@ -1,0 +1,10 @@
+<script setup lang="uts">
+onLaunch(() => console.log('App Launch'))
+onShow(() => console.log('App Show'))
+onHide(() => console.log('App Hide'))
+onExit(() => console.log('App Exit'))
+</script>
+
+<style lang="scss">
+@import './main.css';
+</style>

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/README.md
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/README.md
@@ -1,0 +1,23 @@
+# uni-app-x-harmony-vapor-tailwindcss-v4
+
+`uni-app x + Harmony Vapor + Tailwind CSS v4` 的 #1119 最小回归 demo。
+
+## 关键配置
+
+- `vite.config.ts` 直接注册 `WeappTailwindcss(uniAppX(...))`
+- `main.css` 使用 `@import "tailwindcss"` 与 `@source`
+- `App.uvue` 的全局 `<style>` 使用 `@import './main.css'`，把生成入口加入 HBuilderX 构建图
+- 显式配置 `cssEntries`，使用项目根目录解析主入口和非 App Iconify 入口的绝对路径
+- 不注册 `@tailwindcss/postcss`，也不注册 `@tailwindcss/vite`
+
+## 运行
+
+```bash
+pnpm run dev:app-harmony
+```
+
+也可以直接用 HBuilderX 导入当前目录运行。
+
+## Issue 回归
+
+页面同时保留 Tailwind `leading-[26px]` 和原生 `line-height: 26px` 对照，便于比较生成的 Harmony style bytes。

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/main.css
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/main.css
@@ -1,0 +1,43 @@
+@import "tailwindcss" source(none);
+@config "./tailwind.config.js";
+@plugin "@iconify/tailwind4" {
+  prefix: "i";
+}
+@source "./App.uvue";
+@source "./pages/**/*.{uts,uvue}";
+@source not "./unpackage/**/*";
+@custom-variant system-dark {
+  @media (prefers-color-scheme: dark) {
+    @slot;
+  }
+}
+@custom-variant wx {
+  /*  #ifdef  MP-WEIXIN  */
+  @slot;
+  /*  #endif  */
+}
+@custom-variant not-wx {
+  /*  #ifndef  MP-WEIXIN  */
+  @slot;
+  /*  #endif  */
+}
+@custom-variant any-hover {
+  @media (any-hover: hover) {
+    &:hover {
+      @slot;
+    }
+  }
+}
+@layer components {
+  .template-corpus-apply {
+    display: flex;
+    align-items: center;
+    border-radius: 20px;
+    background-color: #9e58e9;
+    padding-inline: 18px;
+    padding-block: 10px;
+    color: #fff;
+    font-size: 26px;
+  }
+}
+@source inline("bg-[#102938] bg-[#0977ee] text-[#f7fbff] text-[31rpx] px-[29rpx] w-[173px] i-[mdi--github-circle] i-[mdi--star] i-[svg-spinners--180-ring-with-bg] before:content-['现在，让我们开始神奇的_tailwindcss_开发之旅吧！'] before:content-['现在，让我们继续神奇的_tailwindcss_HMR_回归之旅吧！'] theme-mode-demo system-dark: theme-dark dark:bg-zinc-950 dark:bg-[#09090b] t-class --test-color --color-test --font-test --font-sans --font-serif --font-mono --color-red-500 --color-blue-500 --color-slate-900 --spacing --text-base --font-weight-bold --radius-lg --default-font-family");

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/main.uts
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/main.uts
@@ -1,0 +1,9 @@
+import App from './App.uvue'
+
+import { createSSRApp } from 'vue'
+export function createApp() {
+	const app = createSSRApp(App)
+	return {
+		app
+	}
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/manifest.json
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/manifest.json
@@ -1,0 +1,72 @@
+{
+	"name": "uni-app-x-harmony-vapor-tailwindcss-v4",
+	"appid": "__UNI__F1BA2B3",
+	"description": "",
+	"versionName": "1.0.0",
+	"versionCode": "100",
+	"uni-app-x": {
+		"vapor": true,
+		"vapor-render-target": "bytecode"
+	},
+	/* 快应用特有相关 */
+	"quickapp": {},
+	/* 小程序特有相关 */
+	"mp-weixin": {
+		"appid": "wxb3d842a4a7e3440d",
+		"setting": {
+			"urlCheck": false
+		},
+		"usingComponents": true
+	},
+	"mp-alipay": {
+		"usingComponents": true
+	},
+	"mp-baidu": {
+		"usingComponents": true
+	},
+	"mp-toutiao": {
+		"usingComponents": true
+	},
+	"uniStatistics": {
+		"enable": false
+	},
+	"vueVersion": "3",
+	"app": {
+		"distribute": {
+			"icons": {
+				"android": {
+					"hdpi": "",
+					"xhdpi": "",
+					"xxhdpi": "",
+					"xxxhdpi": ""
+				}
+			}
+		}
+	},
+	"app-android": {
+		"distribute": {
+			"modules": {},
+			"icons": {
+				"hdpi": "",
+				"xhdpi": "",
+				"xxhdpi": "",
+				"xxxhdpi": ""
+			},
+			"splashScreens": {
+				"default": {}
+			}
+		}
+	},
+	"app-ios": {
+		"distribute": {
+			"modules": {},
+			"icons": {},
+			"splashScreens": {}
+		}
+	},
+	"web": {
+		"router": {
+			"mode": ""
+		}
+	}
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/package.json
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@weapp-tailwindcss-demo/uni-app-x-harmony-vapor-tailwindcss-v4",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "uni-app x Harmony Vapor regression demo for leading-[26px].",
+  "author": "icebreaker <hi@sonofmagic.top>",
+  "license": "MIT",
+  "scripts": {
+    "dev:app-harmony": "cross-env UNI_APP_X_DOM2=true hbuilderx launch app-harmony --project . --deviceId 127.0.0.1:5557"
+  },
+  "dependencies": {
+    "@dcloudio/uni-app": "3.0.0-alpha-5020220260725001",
+    "@dcloudio/uni-components": "3.0.0-alpha-5020220260725001",
+    "@dcloudio/uni-h5": "3.0.0-alpha-5020220260725001",
+    "vue": "^3.5.41"
+  },
+  "devDependencies": {
+    "@dcloudio/hbuilderx-cli": "^1.2.0",
+    "@dcloudio/uni-uts-v1": "3.0.0-alpha-5020220260725001",
+    "@dcloudio/vite-plugin-uni": "3.0.0-alpha-5020220260725001",
+    "@iconify-json/mdi": "catalog:iconifyJson",
+    "@iconify-json/svg-spinners": "catalog:iconifyJson",
+    "@iconify/tailwind4": "^1.2.3",
+    "@tailwindcss/postcss": "catalog:tailwindcss4",
+    "@weapp-tailwindcss/debug-uni-app-x": "workspace:*",
+    "cross-env": "catalog:crossEnv",
+    "tailwindcss": "catalog:tailwindcss4",
+    "typescript": "catalog:typescript59",
+    "vite": "^5.4.21",
+    "weapp-tailwindcss": "workspace:*"
+  },
+  "packageManager": "pnpm@11.17.0"
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/package.json
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/package.json
@@ -7,7 +7,8 @@
   "author": "icebreaker <hi@sonofmagic.top>",
   "license": "MIT",
   "scripts": {
-    "dev:app-harmony": "cross-env UNI_APP_X_DOM2=true hbuilderx launch app-harmony --project . --deviceId 127.0.0.1:5557"
+    "dev:app-harmony": "cross-env WEAPP_TW_HMR_TIMING=1 UNI_APP_X_DOM2=true hbuilderx launch app-harmony --project . --deviceId 127.0.0.1:5557",
+    "predev:app-harmony": "node ../../scripts/ensure-weapp-tailwindcss-built.mjs"
   },
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-alpha-5020220260725001",

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/pages.json
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/pages.json
@@ -1,0 +1,17 @@
+{
+	"pages": [ //pages数组中第一项表示应用启动页，参考：https://uniapp.dcloud.io/collocation/pages
+		{
+			"path": "pages/index/index",
+			"style": {
+				"navigationBarTitleText": "uni-app x"
+			}
+		}
+	],
+	"globalStyle": {
+		"navigationBarTextStyle": "black",
+		"navigationBarTitleText": "uni-app x",
+		"navigationBarBackgroundColor": "#F8F8F8",
+		"backgroundColor": "#F8F8F8"
+	},
+	"uniIdRouter": {}
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/pages/index/index.uvue
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/pages/index/index.uvue
@@ -1,0 +1,19 @@
+<script setup lang="uts">
+const probeText = 'issue-1119 Vapor line-height probe'
+</script>
+
+<template>
+	<view id="native-hmr-probe" class="hbuilderx-app-native-hmr-probe issue-1119-vapor leading-[26px] text-[18px] text-black bg-[#0e7490]">issue-1119-vapor-leading-26px</view>
+		<view class="issue-1119-vapor leading-[26px] text-[18px] text-black">
+		<text>{{ probeText }}</text>
+	</view>
+	<view class="issue-1119-native text-[18px] text-black">
+		<text>{{ probeText }}</text>
+	</view>
+</template>
+
+<style>
+.issue-1119-native {
+	line-height: 26px;
+}
+</style>

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/shared.js
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/shared.js
@@ -1,0 +1,16 @@
+const path = require('node:path')
+const { resolveUniPlatform } = require('weapp-tailwindcss/framework')
+
+function r(...args) {
+  return path.resolve(__dirname, ...args)
+}
+
+const uniPlatform = resolveUniPlatform()
+const isH5 = uniPlatform.isWeb
+const isApp = uniPlatform.isApp
+
+module.exports = {
+  r,
+  isH5,
+  isApp,
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/tailwind.config.js
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './App.uvue',
+    './pages/**/*.{uts,uvue}',
+    '!./unpackage/**/*',
+  ],
+  theme: { extend: {} },
+  plugins: [],
+  corePlugins: {
+    preflight: false,
+    container: false,
+  },
+}

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/uni.scss
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/uni.scss
@@ -1,0 +1,76 @@
+/**
+ * 这里是uni-app内置的常用样式变量
+ *
+ * uni-app 官方扩展插件及插件市场（https://ext.dcloud.net.cn）上很多三方插件均使用了这些样式变量
+ * 如果你是插件开发者，建议你使用scss预处理，并在插件代码中直接使用这些变量（无需 import 这个文件），方便用户通过搭积木的方式开发整体风格一致的App
+ *
+ */
+
+/**
+ * 如果你是App开发者（插件使用者），你可以通过修改这些变量来定制自己的插件主题，实现自定义主题功能
+ *
+ * 如果你的项目同样使用了scss预处理，你也可以直接在你的 scss 代码中使用如下变量，同时无需 import 这个文件
+ */
+
+/* 颜色变量 */
+
+/* 行为相关颜色 */
+$uni-color-primary: #007aff;
+$uni-color-success: #4cd964;
+$uni-color-warning: #f0ad4e;
+$uni-color-error: #dd524d;
+
+/* 文字基本颜色 */
+$uni-text-color:#333;//基本色
+$uni-text-color-inverse:#fff;//反色
+$uni-text-color-grey:#999;//辅助灰色，如加载更多的提示信息
+$uni-text-color-placeholder: #808080;
+$uni-text-color-disable:#c0c0c0;
+
+/* 背景颜色 */
+$uni-bg-color:#ffffff;
+$uni-bg-color-grey:#f8f8f8;
+$uni-bg-color-hover:#f1f1f1;//点击状态颜色
+$uni-bg-color-mask:rgba(0, 0, 0, 0.4);//遮罩颜色
+
+/* 边框颜色 */
+$uni-border-color:#c8c7cc;
+
+/* 尺寸变量 */
+
+/* 文字尺寸 */
+$uni-font-size-sm:12px;
+$uni-font-size-base:14px;
+$uni-font-size-lg:16px;
+
+/* 图片尺寸 */
+$uni-img-size-sm:20px;
+$uni-img-size-base:26px;
+$uni-img-size-lg:40px;
+
+/* Border Radius */
+$uni-border-radius-sm: 2px;
+$uni-border-radius-base: 3px;
+$uni-border-radius-lg: 6px;
+$uni-border-radius-circle: 50%;
+
+/* 水平间距 */
+$uni-spacing-row-sm: 5px;
+$uni-spacing-row-base: 10px;
+$uni-spacing-row-lg: 15px;
+
+/* 垂直间距 */
+$uni-spacing-col-sm: 4px;
+$uni-spacing-col-base: 8px;
+$uni-spacing-col-lg: 12px;
+
+/* 透明度 */
+$uni-opacity-disabled: 0.3; // 组件禁用态的透明度
+
+/* 文章场景相关 */
+$uni-color-title: #2C405A; // 文章标题颜色
+$uni-font-size-title:20px;
+$uni-color-subtitle: #555555; // 二级标题颜色
+$uni-font-size-subtitle:26px;
+$uni-color-paragraph: #3F536E; // 文章段落颜色
+$uni-font-size-paragraph:15px;

--- a/demo/uni-app-x-harmony-vapor-tailwindcss-v4/vite.config.ts
+++ b/demo/uni-app-x-harmony-vapor-tailwindcss-v4/vite.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from 'vite'
+import uniModule from '@dcloudio/vite-plugin-uni'
+import { debugX } from '@weapp-tailwindcss/debug-uni-app-x'
+import parity from '../official-postcss-parity-plugin.cjs'
+import { uniAppX } from 'weapp-tailwindcss/presets'
+import { WeappTailwindcss } from 'weapp-tailwindcss/vite'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const uni = (uniModule as typeof uniModule & { default?: typeof uniModule }).default ?? uniModule
+const projectRoot = dirname(fileURLToPath(import.meta.url))
+const officialPostcssParity = process.env.WEAPP_TW_OFFICIAL_POSTCSS_PARITY === '1'
+const isNativeApp = process.env.UNI_UTS_PLATFORM?.startsWith('app-') === true
+const weappTailwindcssPlugins = WeappTailwindcss(
+  uniAppX({
+    base: projectRoot,
+    componentLocalStyles: {
+      enabled: true,
+      onlyWhenStyleIsolationVersion2: false,
+    },
+    cssEntries: [
+      resolve(projectRoot, 'main.css'),
+      ...isNativeApp ? [] : [resolve(projectRoot, 'main.iconify.css')],
+    ],
+    cssSourceTrace: true,
+    rem2rpx: true,
+    customAttributes: {
+      '*': [/^t-class(?:-.+)?$/],
+      'a-navbar': ['leftClass', 'rightClass'],
+    },
+    generator: officialPostcssParity ? false : undefined,
+  }),
+) ?? []
+const debugUniAppXPlugins = debugX({
+  cwd: projectRoot,
+})
+
+export default defineConfig({
+  plugins: [
+    uni(),
+    ...weappTailwindcssPlugins,
+    ...debugUniAppXPlugins,
+  ],
+  css: {
+    postcss: {
+      plugins: parity.createOfficialPostcssParityPlugins(),
+    },
+  },
+})

--- a/e2e/demo-visual-theme.test.ts
+++ b/e2e/demo-visual-theme.test.ts
@@ -75,7 +75,7 @@ describe('demo visual theme evidence', () => {
     expect(component).toContain('class="issue-navbar-side" :class="leftClass"')
     expect(component).toContain('<slot name="left" />')
     expect(page).toContain('leftClass="issue-navbar-left bg-primary w-[100rpx] h-[100rpx] px-[30rpx]"')
-    expect(page).toContain('class="issue-navbar-image w-[100rpx] h-[100rpx] rounded-[10rpx]"')
+    expect(page).toContain('class="issue-navbar-image w-[100rpx] h-[100rpx]"')
     expect(page).toContain('<template #left>')
     expect(config).toContain('\'a-navbar\': [\'leftClass\', \'rightClass\']')
   })
@@ -141,7 +141,10 @@ describe('demo visual theme evidence', () => {
     expect(mainCss).not.toContain('text-blue-600/50')
     expect(page).not.toContain('text-blue-600/50')
 
-    for (const item of uniAppXAppCases) {
+    const issue1002AppCases = uniAppXAppCases.filter(
+      item => item.projectDir === 'demo/uni-app-x-hbuilderx-tailwindcss-v4',
+    )
+    for (const item of issue1002AppCases) {
       if (item.platform === 'app-android') {
         expect(item.markerClass).toContain('rounded-[9998px]')
         expect(item.markerTextClass).toContain('text-[39rpx]')

--- a/e2e/demo-visual-theme.test.ts
+++ b/e2e/demo-visual-theme.test.ts
@@ -75,7 +75,7 @@ describe('demo visual theme evidence', () => {
     expect(component).toContain('class="issue-navbar-side" :class="leftClass"')
     expect(component).toContain('<slot name="left" />')
     expect(page).toContain('leftClass="issue-navbar-left bg-primary w-[100rpx] h-[100rpx] px-[30rpx]"')
-    expect(page).toContain('class="issue-navbar-image w-[100rpx] h-[100rpx]"')
+    expect(page).toContain('class="issue-navbar-image w-[100rpx] h-[100rpx] rounded-[10rpx]"')
     expect(page).toContain('<template #left>')
     expect(config).toContain('\'a-navbar\': [\'leftClass\', \'rightClass\']')
   })

--- a/e2e/demoCoverageMatrix.ts
+++ b/e2e/demoCoverageMatrix.ts
@@ -43,6 +43,7 @@ export interface DemoCoverageEntry {
   sourceShape: 'native' | 'tsx' | 'vue-sfc' | 'mpx-sfc' | 'uvue' | 'web-tsx' | 'web-vue-sfc'
   sfcBlocks: Array<'template' | 'script' | 'style'>
   hbuilderxLocal: boolean
+  skipVisualHmr?: boolean
   platforms: DemoPlatformCoverage[]
 }
 
@@ -390,6 +391,15 @@ function uniAppXPlatforms(name: string): DemoPlatformCoverage[] {
   ]
 }
 
+function uniAppXVaporPlatforms(name: string): DemoPlatformCoverage[] {
+  return [local('app-harmony', {
+    devScript: 'dev:app-harmony',
+    evidence: 'hbuilderx local Harmony Vapor case',
+    command: `E2E_HBUILDERX_LOCAL=1 E2E_HBUILDERX_APP_PLATFORM=app-harmony E2E_HBUILDERX_CASE='${name} harmony vapor' pnpm e2e:hbuilderx:local:harmony`,
+    reason: 'Vapor 模式依赖 HBuilderX 5.24 与在线 Harmony 设备，使用独立 case 验证编译日志、产物和运行时截图。',
+  })]
+}
+
 function weappVitePlatforms(name: string): DemoPlatformCoverage[] {
   return [automated('weapp', {
     buildScript: 'build',
@@ -509,6 +519,7 @@ export const DEMO_COVERAGE_MATRIX = [
   entry({ name: 'subpackage-uni-app-vite-tailwindcss-v4', packageJson: pkg('subpackage-uni-app-vite-tailwindcss-v4'), framework: 'uni-app', builder: 'vite', tailwindcss: 'v4', sourceShape: 'vue-sfc', sfcBlocks: ['template', 'script', 'style'], hbuilderxLocal: false, platforms: subpackageUniAppPlatforms('subpackage-uni-app-vite-tailwindcss-v4') }),
   entry({ name: 'uni-app-vite-vue3-hbuilderx-tailwindcss-v4', packageJson: pkg('uni-app-vite-vue3-hbuilderx-tailwindcss-v4'), framework: 'uni-app', builder: 'vite-hbuilderx', tailwindcss: 'v4', sourceShape: 'vue-sfc', sfcBlocks: ['template', 'script', 'style'], hbuilderxLocal: true, platforms: uniAppHBuilderXPlatforms('uni-app-vite-vue3-hbuilderx-tailwindcss-v4') }),
   entry({ name: 'uni-app-x-hbuilderx-tailwindcss-v4', packageJson: pkg('uni-app-x-hbuilderx-tailwindcss-v4'), framework: 'uni-app-x', builder: 'hbuilderx', tailwindcss: 'v4', sourceShape: 'uvue', sfcBlocks: ['template', 'script', 'style'], hbuilderxLocal: true, platforms: uniAppXPlatforms('uni-app-x-hbuilderx-tailwindcss-v4') }),
+  entry({ name: 'uni-app-x-harmony-vapor-tailwindcss-v4', packageJson: pkg('uni-app-x-harmony-vapor-tailwindcss-v4'), framework: 'uni-app-x', builder: 'hbuilderx-vapor', tailwindcss: 'v4', sourceShape: 'uvue', sfcBlocks: ['template', 'script', 'style'], hbuilderxLocal: true, skipVisualHmr: true, platforms: uniAppXVaporPlatforms('uni-app-x-harmony-vapor-tailwindcss-v4') }),
   entry({ name: 'weapp-vite-tailwindcss-v4', packageJson: pkg('weapp-vite-tailwindcss-v4'), framework: 'weapp-vite', builder: 'vite', tailwindcss: 'v4', sourceShape: 'native', sfcBlocks: [], hbuilderxLocal: false, platforms: weappVitePlatforms('weapp-vite-tailwindcss-v4') }),
   entry({ name: 'web/react-vite-tailwindcss-v4', packageJson: pkg('web/react-vite-tailwindcss-v4'), framework: 'web-vite-react', builder: 'vite', tailwindcss: 'v4', sourceShape: 'web-tsx', sfcBlocks: [], hbuilderxLocal: false, platforms: webPlatforms('web/react-vite-tailwindcss-v4') }),
   entry({ name: 'web/vue-vite-tailwindcss-v4', packageJson: pkg('web/vue-vite-tailwindcss-v4'), framework: 'web-vite-vue', builder: 'vite', tailwindcss: 'v4', sourceShape: 'web-vue-sfc', sfcBlocks: ['template', 'script', 'style'], hbuilderxLocal: false, platforms: webPlatforms('web/vue-vite-tailwindcss-v4') }),

--- a/e2e/e2e-matrix.test.ts
+++ b/e2e/e2e-matrix.test.ts
@@ -222,7 +222,7 @@ function collectDemoWeappTailwindcssConfigFiles() {
 
 function readDemoSource(entry: { name: string }) {
   const demoRoot = path.resolve(__dirname, '../demo', entry.name)
-  const ignoredDirs = new Set(['node_modules', 'dist', 'unpackage', '.vite', '.turbo'])
+  const ignoredDirs = new Set(['node_modules', 'dist', 'unpackage', '.debug', '.vite', '.turbo'])
   const sourceExts = new Set(['.css', '.js', '.jsx', '.mpx', '.scss', '.ts', '.tsx', '.uvue', '.vue', '.wxml'])
   const parts: string[] = []
 
@@ -548,6 +548,7 @@ describe('e2e matrix', () => {
       .filter(item => !item.name.startsWith('web/'))
       .filter(item => !item.name.startsWith('subpackage-'))
       .filter(item => item.framework !== 'style-injector')
+      .filter(item => !item.skipVisualHmr)
       .map(item => item.name)
       .sort()
     const ideCaseNames = getFrameworkIdeCases().map(item => item.name).sort()
@@ -628,6 +629,7 @@ describe('e2e matrix', () => {
       .filter(item => !item.name.startsWith('web/'))
       .filter(item => !item.name.startsWith('subpackage-'))
       .filter(item => item.framework !== 'style-injector')
+      .filter(item => !item.skipVisualHmr)
       .map(item => item.name)
       .sort()
     const expectedH5Names = DEMO_COVERAGE_MATRIX

--- a/e2e/framework-ci-support.test.ts
+++ b/e2e/framework-ci-support.test.ts
@@ -200,6 +200,7 @@ describeFrameworkCi('framework support matrix ci', () => {
       'uni-app-x-hbuilderx-tailwindcss-v4 android',
       'uni-app-x-hbuilderx-tailwindcss-v4 ios',
       'uni-app-x-hbuilderx-tailwindcss-v4 harmony',
+      'uni-app-x-harmony-vapor-tailwindcss-v4 harmony vapor',
     ])
     for (const item of appCases) {
       expect(item.transformedContains.length, `${item.name} should verify initial App dev output`).toBeGreaterThan(0)

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -948,6 +948,63 @@ export const uniAppXAppCases: AppCase[] = [
     runtimeLogContains: ['App Launch'],
     logNotContains: [...issue1002AppLogNotContains, ...iconifyNativeLogNotContains, ...nativeScopedAuthorLogNotContains],
   },
+  {
+    name: 'uni-app-x-harmony-vapor-tailwindcss-v4 harmony vapor',
+    platform: 'app-harmony',
+    projectDir: 'demo/uni-app-x-harmony-vapor-tailwindcss-v4',
+    outputDir: 'unpackage/dist/dev/.app-harmony',
+    outputDirCandidates: [
+      'unpackage/dist/dev/.app-harmony',
+      'unpackage/dist/dev/app-harmony',
+    ],
+    sourceFile: 'pages/index/index.uvue',
+    markerAnchor: '<view class="issue-1119-vapor',
+    markerClass: 'issue-1119-vapor leading-[26px] text-[18px] text-black bg-[#0e7490]',
+    markerText: 'issue-1119-vapor-leading-26px',
+    hmrMarkerClass: 'issue-1119-vapor leading-[26px] text-[18px] text-black bg-[#164e63]',
+    hmrMarkerText: 'issue-1119-vapor-hmr-leading-26px',
+    launchArgs: defaultHarmonyLaunchArgs,
+    launchEnv: {
+      UNI_APP_X_DOM2: 'true',
+    },
+    requiredFiles: [
+      'manifest.json',
+      'app-service.js',
+      'App.uvue',
+      'assets/pages/index/index.js',
+      'bytes/GenPagesIndexIndexSharedData.style.bytes',
+    ],
+    transformedFiles: [
+      'unpackage/dist/dev/.app-harmony/App.uvue',
+    ],
+    transformedOutputFiles: [
+      'assets/pages/index/index.js',
+    ],
+    transformedContains: [
+      'issue-1119-vapor-leading-26px',
+      /\.leading-_b26px_B\s*\{[\s\S]*?--tw-leading:\s*26px;[\s\S]*?line-height:\s*26px;/,
+    ],
+    transformedNotContains: [
+      'leading-[26px]',
+    ],
+    styleOutputFiles: [
+      'bytes/GenPagesIndexIndexSharedData.style.bytes',
+    ],
+    styleContains: [
+      'wtu-',
+      '--tw-leading',
+      '26px',
+    ],
+    styleNotContains: [
+      'leading-[26px]',
+    ],
+    hmrTransformedContains: [
+      'issue-1119-vapor-hmr-leading-26px',
+      'wtu-',
+    ],
+    runtimeLogContains: ['App Launch', '蒸汽模式', '当前视图层编译目标'],
+    logNotContains: [...issue1002AppLogNotContains, ...iconifyNativeLogNotContains, ...nativeScopedAuthorLogNotContains],
+  },
 ]
 
 export const webCases: WebCase[] = [

--- a/e2e/multiplatform-build-output/targets.ts
+++ b/e2e/multiplatform-build-output/targets.ts
@@ -187,6 +187,16 @@ function createUniAppXTargets(project: string): MultiplatformTarget[] {
   }))
 }
 
+function createUniAppXVaporTargets(project: string): MultiplatformTarget[] {
+  return [target({
+    framework: 'uni-app-x',
+    projectDir: `demo/${project}`,
+    platform: 'app-harmony',
+    coverage: 'local',
+    reason: 'Harmony Vapor 产物依赖本地 HBuilderX 5.24 与在线 Harmony 设备，使用独立 Vapor case 验证。',
+  })]
+}
+
 export const MULTIPLATFORM_TARGETS: MultiplatformTarget[] = [
   ...createGulpTargets('gulp-tailwindcss-v4'),
   ...createUniAppTargets('uni-app-vite-tailwindcss-v4', uniAppV4Platforms),
@@ -242,4 +252,5 @@ export const MULTIPLATFORM_TARGETS: MultiplatformTarget[] = [
     coverage: 'default-ci',
   }),
   ...createUniAppXTargets('uni-app-x-hbuilderx-tailwindcss-v4'),
+  ...createUniAppXVaporTargets('uni-app-x-harmony-vapor-tailwindcss-v4'),
 ]

--- a/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
@@ -36,6 +36,10 @@ describe('benchmark ci report', () => {
     const { benchmarkProjects } = await import('../../../../benchmark/version-compare/scripts/projects.mjs')
 
     const repoRoot = path.resolve(__dirname, '../../../..')
+    // 仅依赖本机 HBuilderX 与 Harmony 设备的复现项目不进入通用版本 benchmark。
+    const localOnlyBenchmarkExemptProjects = new Set([
+      'demo/uni-app-x-harmony-vapor-tailwindcss-v4',
+    ])
     const collectPackageDirs = (dir: string): string[] => {
       return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
         const full = path.join(dir, entry.name)
@@ -62,8 +66,12 @@ describe('benchmark ci report', () => {
       .filter(project => !project.startsWith('demo/style-injector-'))
       .filter(project => project !== 'demo/web/nuxt-vite-tailwindcss-v4')
       .filter(project => !project.startsWith('demo/web/') || project.includes('-vite-'))
+      .filter(project => !localOnlyBenchmarkExemptProjects.has(project))
     const benchmarkProjectDirs = Array.from(new Set(benchmarkProjects.map(project => project.project))).sort()
 
+    for (const project of localOnlyBenchmarkExemptProjects) {
+      expect(fs.existsSync(path.join(repoRoot, project, 'package.json')), `${project} should remain a real demo project`).toBe(true)
+    }
     expect(benchmarkProjectDirs).toEqual(demoProjects)
     expect(benchmarkProjects.map(project => project.key)).toEqual(expect.arrayContaining([
       'demo-web-react-vite-tailwindcss-v4__web',

--- a/packages/weapp-tailwindcss/test/uni-app-x/style-asset.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/style-asset.test.ts
@@ -319,13 +319,20 @@ describe('uni-app-x style asset helpers', () => {
     expect(styleExportToUtsMap({
       btn: { '': { 'font-size': '12px', color: 'rgb(1, 2, 3)' } },
     })).toContain('"fontSize", 12')
+    expect(styleExportToUtsMap({
+      'leading-_b26px_B': { '': { '--tw-leading': '26px', 'line-height': '26px' } },
+    })).toBe('[_uM([["leading-_b26px_B", _pS(_uM([["-TwLeading", 26], ["lineHeight", 26]]))]])]')
   })
 
   it('creates and merges style values from css, app styles, and apply sources', () => {
-    const utilityStyles = cssSourceToStyleValue('.flex{display:flex}.w-\\[12px\\]{width:12px}')!
+    const utilityStyles = cssSourceToStyleValue('.flex{display:flex}.w-\\[12px\\]{width:12px}.leading-_b26px_B{--tw-leading:26px;line-height:26px}')!
     expect(cssSourceToStyleValue('.broken{')).toBeUndefined()
     expect(utilityStyles.flex['']).toMatchObject({ display: 'flex' })
     expect(utilityStyles['w-[12px]']['']).toMatchObject({ width: 12 })
+    expect(utilityStyles['leading-_b26px_B']['']).toMatchObject({
+      '-TwLeading': 26,
+      lineHeight: 26,
+    })
     expect(mergeStyleValues(undefined, { local: { '': { color: 'red' } } })?.local[''].color).toBe('red')
 
     const appSource = 'const GenAppStyles = [_uM([["app", _pS(_uM([["color", "red"]]))], ["unused", _pS(_uM([["color", "blue"]]))]])]'

--- a/packages/weapp-tailwindcss/test/watch-hmr-coverage-matrix.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/watch-hmr-coverage-matrix.unit.test.ts
@@ -49,6 +49,7 @@ const localOnlyDemoProjects = new Set([
   'demo/subpackage-taro-webpack-react-tailwindcss-v4',
   'demo/subpackage-uni-app-vite-tailwindcss-v4',
   'demo/uni-app-vite-vue3-hbuilderx-tailwindcss-v4',
+  'demo/uni-app-x-harmony-vapor-tailwindcss-v4',
   'demo/uni-app-x-hbuilderx-tailwindcss-v4',
 ])
 function isIssueRegressionDemoProject(project: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3421,6 +3421,61 @@ importers:
         specifier: workspace:*
         version: link:../../packages/weapp-tailwindcss
 
+  demo/uni-app-x-harmony-vapor-tailwindcss-v4:
+    dependencies:
+      '@dcloudio/uni-app':
+        specifier: 3.0.0-alpha-5020220260725001
+        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.147.0)(rolldown@1.2.3)(unplugin@3.3.0(@rspack/core@2.2.0(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.63.0)(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.41(typescript@6.0.3)))(postcss@8.5.26)(rollup@4.63.0)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.3.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.41(typescript@6.0.3))
+      '@dcloudio/uni-components':
+        specifier: 3.0.0-alpha-5020220260725001
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.147.0)(rolldown@1.2.3)(unplugin@3.3.0(@rspack/core@2.2.0(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.63.0)(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.41(typescript@6.0.3)))(postcss@8.5.26)(rollup@4.63.0)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.3.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.41(typescript@6.0.3))
+      '@dcloudio/uni-h5':
+        specifier: 3.0.0-alpha-5020220260725001
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.147.0)(rolldown@1.2.3)(unplugin@3.3.0(@rspack/core@2.2.0(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.63.0)(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.41(typescript@6.0.3)))(postcss@8.5.26)(rollup@4.63.0)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.3.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.41(typescript@6.0.3))
+      vue:
+        specifier: ^3.5.41
+        version: 3.5.41(typescript@6.0.3)
+    devDependencies:
+      '@dcloudio/hbuilderx-cli':
+        specifier: ^1.2.0
+        version: 1.2.0
+      '@dcloudio/uni-uts-v1':
+        specifier: 3.0.0-alpha-5020220260725001
+        version: 3.0.0-alpha-5020220260725001(rollup@4.63.0)(supports-color@10.2.2)
+      '@dcloudio/vite-plugin-uni':
+        specifier: 3.0.0-alpha-5020220260725001
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.147.0)(rolldown@1.2.3)(unplugin@3.3.0(@rspack/core@2.2.0(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.63.0)(vite@7.3.6(@types/node@26.3.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.41(typescript@6.0.3)))(postcss@8.5.26)(rollup@4.63.0)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.3.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.41(typescript@6.0.3))
+      '@iconify-json/mdi':
+        specifier: catalog:iconifyJson
+        version: 1.2.3
+      '@iconify-json/svg-spinners':
+        specifier: catalog:iconifyJson
+        version: 1.2.4
+      '@iconify/tailwind4':
+        specifier: ^1.2.3
+        version: 1.2.3(tailwindcss@4.3.3)
+      '@tailwindcss/postcss':
+        specifier: catalog:tailwindcss4
+        version: 4.3.3
+      '@weapp-tailwindcss/debug-uni-app-x':
+        specifier: workspace:*
+        version: link:../../packages/debug-uni-app-x
+      cross-env:
+        specifier: catalog:crossEnv
+        version: 10.1.0
+      tailwindcss:
+        specifier: catalog:tailwindcss4
+        version: 4.3.3
+      typescript:
+        specifier: catalog:typescript59
+        version: 6.0.3
+      vite:
+        specifier: ^5.4.21
+        version: 5.4.21(@types/node@26.3.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)
+      weapp-tailwindcss:
+        specifier: workspace:*
+        version: link:../../packages/weapp-tailwindcss
+
   demo/uni-app-x-hbuilderx-tailwindcss-v4:
     dependencies:
       '@dcloudio/uni-app':
@@ -21089,9 +21144,6 @@ packages:
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
-
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
@@ -34652,7 +34704,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
@@ -34903,7 +34955,7 @@ snapshots:
   '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -35072,7 +35124,7 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/helpers@8.0.0':
     dependencies:
@@ -35092,7 +35144,7 @@ snapshots:
 
   '@babel/parser@7.25.6':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.8':
     dependencies:
@@ -36314,7 +36366,7 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -36325,7 +36377,7 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@8.0.1)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -36736,7 +36788,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       esutils: 2.0.3
 
   '@babel/preset-modules@0.2.0(@babel/core@8.0.1)':
@@ -36821,7 +36873,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.8
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/template@8.0.0':
     dependencies:
@@ -41616,7 +41668,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.8
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       '@expo/config': 8.5.6(supports-color@10.2.2)
       '@expo/env': 0.2.3(supports-color@10.2.2)
       '@expo/json-file': 8.3.3
@@ -45253,7 +45305,7 @@ snapshots:
   '@parcel/watcher-wasm@2.6.0':
     dependencies:
       is-glob: 4.0.3
-      picomatch: 4.0.5
+      picomatch: 4.0.7
 
   '@parcel/watcher-win32-arm64@2.6.0':
     optional: true
@@ -47878,10 +47930,10 @@ snapshots:
       '@rollup/pluginutils': 5.4.0(rollup@4.63.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.5)
+      fdir: 6.5.0(picomatch@4.0.7)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.5
+      picomatch: 4.0.7
     optionalDependencies:
       rollup: 4.63.0
 
@@ -50133,7 +50185,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       lodash: 4.18.1
       mime-types: 2.1.35
@@ -51995,7 +52047,7 @@ snapshots:
       glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.5
+      picomatch: 4.0.7
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -58080,8 +58132,6 @@ snapshots:
 
   es-module-lexer@2.3.0: {}
 
-  es-module-lexer@2.3.1: {}
-
   es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
@@ -61747,7 +61797,7 @@ snapshots:
   impound@1.1.6(@rspack/core@2.2.0(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.63.0)(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       pathe: 2.0.3
       unplugin: 3.3.0(@rspack/core@2.2.0(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.63.0)(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.105.4)
       unplugin-utils: 0.3.2
@@ -62774,7 +62824,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.5
+      picomatch: 4.0.7
 
   jest-validate@27.5.1:
     dependencies:
@@ -64602,7 +64652,7 @@ snapshots:
   metro-source-map@0.80.12(supports-color@10.2.2):
     dependencies:
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.80.12(supports-color@10.2.2)
@@ -64777,7 +64827,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -73759,7 +73809,7 @@ snapshots:
   vite-node@6.0.0(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       cac: 7.0.0
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       obug: 2.1.4
       pathe: 2.0.3
       vite: 8.2.2(@types/node@26.3.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.103.1)(sass@1.103.1)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)


### PR DESCRIPTION
## 变更说明

Refs #1119

新增独立的 uni-app x Harmony Vapor 回归 demo，显式启用 Vapor 字节码目标，覆盖 `leading-[26px]` 的 CSS 生成、UTS style map 转换、Harmony 样式注入，以及 Vapor 产物断言。

当前 `weapp-tailwindcss` 5.3.6 的核心链路已通过真实 Harmony 设备验证，因此本 PR 主要补齐可重复的复现 demo、回归测试和本地 HBuilderX case，防止后续回归。

## 验证

- `packages/weapp-tailwindcss`: 8 个测试文件、142 个测试通过
- `e2e/e2e-matrix.test.ts`: 33 个测试通过
- HBuilderX 5.24 Vapor/字节码模式编译、安装、启动成功
- Harmony 设备 `127.0.0.1:5557` 运行成功，产物包含 `line-height: 26px` / `lineHeight: 26`，不包含原始 `leading-[26px]`

定向 HBuilderX runner 因本地会话管理未返回最终 Vitest 汇总，但同一 case 已通过直接 HBuilderX 编译和真实设备运行验证。
