### PR TITLE
fix(vite): 修复 uni-app x Web 样式入口与热更新

### DIFF
--- a/.changeset/calm-web-variables.md
+++ b/.changeset/calm-web-variables.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x Web 中 Tailwind CSS 主题变量、scoped 页面样式与并发 HMR 更新丢失的问题，并在配置入口未进入 Web 样式构建链路时给出明确告警。

--- a/e2e/hbuilderx-local-helpers.test.ts
+++ b/e2e/hbuilderx-local-helpers.test.ts
@@ -47,6 +47,15 @@ describe('HBuilderX local helpers', () => {
       expect(await fs.readFile(file, 'utf8')).toBe('@import "tailwindcss";\n@theme { --color-issue-1021: #123456; }\n')
       await restore()
       expect(await fs.readFile(file, 'utf8')).toBe('@import "tailwindcss";\n')
+
+      await appendHmrSourceMutation(root, {
+        file: 'theme.css',
+        replace: {
+          from: '@import "tailwindcss";',
+          to: '@import "./main.css";',
+        },
+      })
+      expect(await fs.readFile(file, 'utf8')).toBe('@import "./main.css";\n')
     }
     finally {
       await fs.rm(root, { force: true, recursive: true })

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -32,6 +32,10 @@ export interface HmrSourceMutation {
   cssContains?: Array<string | RegExp>
   expectOutputRefresh?: boolean
   file: string
+  replace?: {
+    from: string
+    to: string
+  }
   touch?: boolean
 }
 
@@ -1198,8 +1202,11 @@ export const webCases: WebCase[] = [
           styles: { backgroundColor: 'rgb(16, 41, 56)', color: 'rgb(247, 251, 255)', marginTop: '800px', width: '173px' },
         }],
         sourceMutation: {
-          file: 'main.css',
-          touch: true,
+          file: 'pages/index/index.uvue',
+          replace: {
+            from: '@reference "../../main.css";',
+            to: '@import "../../main.css";',
+          },
         },
       },
       {

--- a/e2e/hbuilderx-local/source-mutations.ts
+++ b/e2e/hbuilderx-local/source-mutations.ts
@@ -18,13 +18,21 @@ export async function appendHmrSourceMutation(projectRoot: string, mutation: Hmr
   const file = path.resolve(projectRoot, mutation.file)
   const source = await readUtf8(file)
   const separator = source.endsWith('\n') ? '' : '\n'
-  const nextSource = typeof mutation.append === 'string'
-    ? `${source}${separator}${mutation.append.trimEnd()}\n`
-    : mutation.touch
-      ? `${source}${separator}\n`
-      : undefined
+  let nextSource: string | undefined
+  if (mutation.replace) {
+    if (!source.includes(mutation.replace.from)) {
+      throw new Error(`HMR 源码变更找不到替换目标：${mutation.file}`)
+    }
+    nextSource = source.replace(mutation.replace.from, mutation.replace.to)
+  }
+  else if (typeof mutation.append === 'string') {
+    nextSource = `${source}${separator}${mutation.append.trimEnd()}\n`
+  }
+  else if (mutation.touch) {
+    nextSource = `${source}${separator}\n`
+  }
   if (nextSource === undefined) {
-    throw new Error(`HMR 源码变更缺少 append 或 touch：${mutation.file}`)
+    throw new Error(`HMR 源码变更缺少 append、replace 或 touch：${mutation.file}`)
   }
   await fs.writeFile(file, nextSource, 'utf8')
   return file

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-files.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-files.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { postcss } from '@weapp-tailwindcss/postcss'
 import {
+  hasTailwindRootDirectives,
   hasTailwindSourceDirectives,
   parseImportRequest,
   resolveCssEntrySource,
@@ -314,7 +315,7 @@ function extractStyleDirectiveSourcesDeep(
   seen: Set<string>,
 ): Array<{ source: string, file: string }> {
   const ownSources = extractStyleDirectiveSources(source)
-  if (ownSources.length > 0) {
+  if (ownSources.some(styleSource => hasTailwindRootDirectives(styleSource, { importFallback: true }))) {
     return ownSources.map(styleSource => ({ source: styleSource, file: sourceFile }))
   }
 
@@ -333,7 +334,9 @@ function extractStyleDirectiveSourcesDeep(
     catch {
     }
   }
-  return sources
+  return sources.length > 0
+    ? sources
+    : ownSources.map(styleSource => ({ source: styleSource, file: sourceFile }))
 }
 
 export interface SourceSideCssEntrySource {

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-resolver/resolve-source.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-resolver/resolve-source.ts
@@ -5,6 +5,7 @@ import type { NormalizedWeappTailwindcssGeneratorOptions } from '@/generator'
 import path from 'node:path'
 import { resolveTailwindV4Source, resolveTailwindV4SourceFromRuntime } from '@/generator'
 import { omitUndefined } from '@/utils/object'
+import { isSfcStyleSourceRequest } from '../../style-requests'
 import { normalizeConfigDirective, prependConfigDirective } from '../config-directive'
 import { hasTailwindApplyDirective, hasTailwindRootDirectives, resolveCssEntrySource } from '../directives'
 import { hasTailwindGeneratedCss, hasTailwindGeneratedCssMarkers } from '../markers'
@@ -80,8 +81,17 @@ export async function resolveGeneratorSource(
     ? resolveSourceSideCssEntrySource(file, normalizedSourceOptions as SourceStyleMatchOptions, { removeConfig: false })
     : undefined
   const shouldPreferMatchedSourceSideCssSource = sourceSideEntrySource?.file
-    && normalizedSourceOptions.cssEntries?.some(cssEntry =>
-      path.resolve(cssEntry.replace(/[?#].*$/, '')) === path.resolve(sourceSideEntrySource.file!),
+    && (
+      sourceOptions?.cssEntries?.some(cssEntry =>
+        path.resolve(cssEntry.replace(/[?#].*$/, '')) === path.resolve(sourceSideEntrySource.file!),
+      )
+      || (
+        isSfcStyleSourceRequest(file)
+        && sourceOptions?.cssSources?.some(cssSource =>
+          typeof cssSource.file === 'string'
+          && path.resolve(cssSource.file.replace(/[?#].*$/, '')) === path.resolve(sourceSideEntrySource.file!),
+        )
+      )
     )
   const sourceSideCssSource = shouldPreferMatchedSourceSideCssSource
     ? await resolveTailwindV4SourceSideEntrySource(
@@ -89,6 +99,7 @@ export async function resolveGeneratorSource(
         normalizedSourceOptions,
         generatorOptions,
         file,
+        rawSource,
       )
     : undefined
   if (sourceSideCssSource) {

--- a/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-resolver/single-source.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/generator-css/source-resolver/single-source.ts
@@ -236,6 +236,7 @@ export async function resolveTailwindV4SourceSideEntrySource(
   sourceOptions: ReturnType<typeof resolveTailwindV4SourceOptionsFromRuntime>,
   generatorOptions: NormalizedWeappTailwindcssGeneratorOptions | undefined,
   file: string,
+  currentCss?: string,
 ) {
   if (!resolvedEntrySource) {
     return undefined
@@ -252,13 +253,13 @@ export async function resolveTailwindV4SourceSideEntrySource(
   )
   const css = createTailwindV4SourceReferenceSource(
     normalizeConfigDirective(
-      prependConfigDirective(resolvedEntrySource.css, generatorOptions?.config),
+      prependConfigDirective(currentCss ?? resolvedEntrySource.css, generatorOptions?.config),
       config,
     ),
     resolvedSourceOptions,
   )
   const source = await resolveTailwindV4Source(createSingleTailwindV4SourceOptions(resolvedSourceOptions, {
-    base: resolvedEntrySource.base,
+    base: currentCss && config ? path.dirname(config) : resolvedEntrySource.base,
     css,
     cssEntries: [resolvedEntrySource.file],
   }))

--- a/packages/weapp-tailwindcss/src/bundlers/shared/style-requests.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/style-requests.ts
@@ -1,5 +1,6 @@
 const SOURCE_STYLE_EXT_RE = /\.(?:css|scss|sass|less|styl|stylus|pcss|postcss)$/i
 const SOURCE_PREPROCESSOR_EXT_RE = /\.(?:scss|sass|less|styl|stylus)$/i
+const SFC_SOURCE_EXT_RE = /\.(?:vue|uvue|nvue|svelte|mpx)$/i
 const INLINE_PREPROCESSOR_LANG_RE = /(?:^|[.?&])lang\.(?:scss|sass|less|styl|stylus)(?:[.&]|$)/i
 const STYLE_QUERY_RE = /(?:^|&)type=styles?(?:&|$)/
 const VUE_STYLE_QUERY_RE = /(?:^|&)type=style(?:&|$)/
@@ -35,6 +36,19 @@ export function isSourceStyleRequest(request: string | undefined) {
   }
   const query = normalized.slice(queryIndex + 1)
   return STYLE_QUERY_RE.test(query) || STYLE_LANG_QUERY_RE.test(query)
+}
+
+export function isSfcStyleSourceRequest(request: string | undefined) {
+  if (typeof request !== 'string' || request.length === 0) {
+    return false
+  }
+  const normalized = stripHash(request)
+  const queryIndex = normalized.indexOf('?')
+  const pathname = queryIndex === -1 ? normalized : normalized.slice(0, queryIndex)
+  if (SFC_SOURCE_EXT_RE.test(pathname)) {
+    return true
+  }
+  return queryIndex !== -1 && VUE_STYLE_QUERY_RE.test(normalized.slice(queryIndex + 1))
 }
 
 export function isSourcePreprocessorRequest(request: string | undefined, lang?: string) {

--- a/packages/weapp-tailwindcss/src/bundlers/shared/style-requests.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/style-requests.ts
@@ -42,13 +42,7 @@ export function isSfcStyleSourceRequest(request: string | undefined) {
   if (typeof request !== 'string' || request.length === 0) {
     return false
   }
-  const normalized = stripHash(request)
-  const queryIndex = normalized.indexOf('?')
-  const pathname = queryIndex === -1 ? normalized : normalized.slice(0, queryIndex)
-  if (SFC_SOURCE_EXT_RE.test(pathname)) {
-    return true
-  }
-  return queryIndex !== -1 && VUE_STYLE_QUERY_RE.test(normalized.slice(queryIndex + 1))
+  return SFC_SOURCE_EXT_RE.test(stripRequestQuery(request))
 }
 
 export function isSourcePreprocessorRequest(request: string | undefined, lang?: string) {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/frameworks/uni-app-x/index.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/frameworks/uni-app-x/index.ts
@@ -90,6 +90,7 @@ export function createUniAppXVitePlugins(options: UserDefinedOptions | InternalU
       ensureRuntimeClassSet: context.ensureRuntimeClassSet,
       generateCss: context.generateCss,
       getResolvedConfig: context.getResolvedConfig,
+      hmrCssModuleVersions: context.hmrCssModuleVersions,
       isEnabled: context.isEnabled,
       isIosPlatform: context.isIosPlatform,
       isNativeAppStyleTarget: context.isNativeAppStyleTarget,
@@ -103,6 +104,7 @@ export function createUniAppXVitePlugins(options: UserDefinedOptions | InternalU
       tailwindRootCssModuleIds: context.tailwindRootCssModuleIds,
       uniAppX: context.uniAppX,
       viteProcessedCssSourceFiles: context.viteProcessedCssSourceFiles,
+      webCssEntryDiagnostics: context.webCssEntryDiagnostics,
     }),
   })
 }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/hot-css-modules.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/hot-css-modules.ts
@@ -53,6 +53,7 @@ async function resolveHotModulesByIds(
 export async function resolveHotTailwindCssModules(
   ctx: HmrContext,
   tailwindRootCssModuleIds: Iterable<string | null | undefined>,
+  selectModules?: (modules: ModuleNode[]) => ModuleNode[],
 ) {
   const root = ctx.server.config?.root ?? process.cwd()
   const outDir = ctx.server.config?.build?.outDir
@@ -88,10 +89,11 @@ export async function resolveHotTailwindCssModules(
       }
     }
   }
-  for (const mod of modules) {
+  const selectedModules = selectModules?.(modules) ?? modules
+  for (const mod of selectedModules) {
     ctx.server.moduleGraph.invalidateModule(mod)
   }
-  return modules
+  return selectedModules
 }
 
 export async function resolveHotSourceModulesByIds(
@@ -231,6 +233,12 @@ function includesHotModule(modules: ModuleNode[], target: ModuleNode, root: stri
   })
 }
 
+function includesHotId(modules: ModuleNode[], targetId: string, root: string) {
+  return modules.some(mod => [mod.id, mod.url, mod.file].some(moduleId => (
+    hasSameViteModuleIdentity(targetId, moduleId, root)
+  )))
+}
+
 function createSupplementalHotUpdate(hotUrl: string, timestamp: number) {
   return {
     type: 'js-update' as const,
@@ -254,11 +262,15 @@ export function sendSupplementalCssHotUpdates(
   cssModules: ModuleNode[],
   fallbackCssIds: Iterable<string> = [],
   fallbackSourceIds: Iterable<string> = [],
+  handledModules: ModuleNode[] = ctx.modules,
 ) {
   const seenUrls = new Set<string>()
   const root = ctx.server.config?.root ?? process.cwd()
   const updates: Array<ReturnType<typeof createSupplementalHotUpdate>> = []
   for (const id of fallbackSourceIds) {
+    if (includesHotId(handledModules, id, root)) {
+      continue
+    }
     const hotUrl = resolveCssHotUrl(id, root)
     if (!hotUrl || seenUrls.has(hotUrl)) {
       continue
@@ -267,7 +279,7 @@ export function sendSupplementalCssHotUpdates(
     updates.push(createSupplementalHotUpdate(hotUrl, ctx.timestamp))
   }
   for (const id of fallbackCssIds) {
-    if (!isSourceStyleRequest(id)) {
+    if (!isSourceStyleRequest(id) || includesHotId(handledModules, id, root)) {
       continue
     }
     const hotUrl = resolveCssHotUrl(id, root)
@@ -278,7 +290,7 @@ export function sendSupplementalCssHotUpdates(
     updates.push(createSupplementalHotUpdate(hotUrl, ctx.timestamp))
   }
   for (const mod of cssModules) {
-    if (includesHotModule(ctx.modules, mod, root)) {
+    if (includesHotModule(handledModules, mod, root)) {
       continue
     }
     const moduleHotUrl = resolveModuleHotUrl(mod)

--- a/packages/weapp-tailwindcss/src/bundlers/vite/rewrite-css-imports.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/rewrite-css-imports.ts
@@ -6,6 +6,7 @@ import { vitePluginName } from '@/constants'
 import { resolveTailwindcssImport, rewriteTailwindcssImportsInCode } from '../shared/css-imports'
 import { hasTailwindApplyDirective, hasTailwindRootDirectives, normalizeTailwindConfigDirectives } from '../shared/generator-css/directives'
 import { isSourceStyleRequest } from '../shared/style-requests'
+import { isSfcStyleSourceFile } from './generate-bundle/sfc-style-source'
 import { cleanUrl, isCSSRequest } from './utils'
 
 function joinPosixPath(base: string, subpath: string) {
@@ -77,7 +78,7 @@ export function createRewriteCssImportsPlugins(options: RewriteCssImportsOptions
           return null
         }
         const file = cleanUrl(id)
-        const normalizedCode = hasTailwindRootDirectives(code) || code.includes('@config')
+        const normalizedCode = !isSfcStyleSourceFile(file) && (hasTailwindRootDirectives(code) || code.includes('@config'))
           ? normalizeTailwindConfigDirectives(code, path.dirname(file))
           : code
         await options.onCssSourceTransform?.(id, normalizedCode)

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/configured-css-entry-observer.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/configured-css-entry-observer.ts
@@ -1,0 +1,115 @@
+import type { Plugin } from 'vite'
+import path from 'node:path'
+import { logger } from '@weapp-tailwindcss/logger'
+import { parseTailwindCssDirectiveRequest, postcss } from '@weapp-tailwindcss/postcss'
+import { isSourceStyleRequest } from '../../shared/style-requests'
+import { resolveViteModuleIdentity } from '../module-identity'
+
+const WINDOWS_ABSOLUTE_PATH_RE = /^[a-z]:[\\/]/i
+
+interface ConfiguredCssEntryObserverOptions {
+  delayMs?: number
+  getEntries: () => string[] | undefined
+  getRoot: () => string | undefined
+  onMissing: (entries: string[]) => void
+}
+
+export function createConfiguredCssEntryObserver(options: ConfiguredCssEntryObserverOptions) {
+  const observedEntries = new Set<string>()
+  let checkRequested = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let warned = false
+
+  const resolveEntry = (entry: string) => resolveViteModuleIdentity(entry, options.getRoot()).key
+  const observeImport = (request: string, sourceId: string) => {
+    if (!request.startsWith('.') && !path.isAbsolute(request) && !WINDOWS_ABSOLUTE_PATH_RE.test(request)) {
+      return
+    }
+    const sourceFile = resolveViteModuleIdentity(sourceId, options.getRoot()).file
+    if (!sourceFile) {
+      return
+    }
+    const pathApi = WINDOWS_ABSOLUTE_PATH_RE.test(sourceFile) ? path.win32 : path
+    observedEntries.add(resolveEntry(pathApi.resolve(pathApi.dirname(sourceFile), request)))
+  }
+  const clearTimer = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+  }
+  const missingEntries = () => options.getEntries()?.filter(entry => !observedEntries.has(resolveEntry(entry))) ?? []
+  const check = () => {
+    clearTimer()
+    if (!checkRequested || warned) {
+      return
+    }
+    const missing = missingEntries()
+    if (missing.length === 0) {
+      return
+    }
+    warned = true
+    options.onMissing(missing)
+  }
+
+  return {
+    dispose() {
+      clearTimer()
+    },
+    flush: check,
+    observe(id: string) {
+      observedEntries.add(resolveEntry(id))
+      if (checkRequested && missingEntries().length === 0) {
+        clearTimer()
+      }
+    },
+    observeSourceImports(source: string, sourceId: string) {
+      if (!source.includes('@import')) {
+        return
+      }
+      try {
+        postcss.parse(source).walkAtRules('import', (rule) => {
+          const request = parseTailwindCssDirectiveRequest(rule.params)
+          if (request) {
+            observeImport(request, sourceId)
+          }
+        })
+      }
+      catch {}
+    },
+    requestCheck() {
+      if (warned) {
+        return
+      }
+      checkRequested = true
+      clearTimer()
+      timer = setTimeout(check, options.delayMs ?? 1000)
+    },
+  }
+}
+
+export function createConfiguredCssEntryDiagnostics(options: {
+  getEntries: () => string[] | undefined
+  getRoot: () => string | undefined
+  isWeb: () => boolean
+}) {
+  const observer = createConfiguredCssEntryObserver({
+    getEntries: options.getEntries,
+    getRoot: options.getRoot,
+    onMissing(entries) {
+      logger.warn(
+        '[uni-app-x Web] cssEntries 中的 Tailwind CSS 入口未进入 Web 样式构建链路：%s。componentLocalStyles 已生成 wtu-* 局部类，但入口中的 @theme/CSS 变量不会投递到浏览器。请在 App.uvue 或应用入口中显式 import 这些 CSS 文件。',
+        entries.join(', '),
+      )
+    },
+  })
+  const plugin: Plugin = {
+    name: 'weapp-tailwindcss:configured-css-entry-observer',
+    transform(_code, id) {
+      if (options.isWeb() && isSourceStyleRequest(id)) {
+        observer.observe(id)
+      }
+    },
+  }
+  return { observer, plugin }
+}

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins-runtime.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins-runtime.ts
@@ -50,7 +50,10 @@ import { cleanUrl, isCSSRequest, isHTMLRequest, resolveViteCssPipelineRequestFil
 import { shouldAdaptFrameworkWatchCssBeforeCache, wrapViteCssPostTransform } from '../watch-css-post'
 import { resolveWeappViteSourceRoot } from '../weapp-vite-config'
 import { resolveViteWebCssCompatOptions, shouldApplyViteWebCssCompat } from '../web-css-compat'
+import { createConfiguredCssEntryDiagnostics } from './configured-css-entry-observer'
+import { createFrameworkCssGenerationQueue } from './framework-css-generation-queue'
 import { createViteHmrCandidateState } from './framework-hmr-candidate-state'
+import { createViteHmrCssModuleVersionFilterPlugin, createViteHmrCssModuleVersionTracker } from './framework-hmr-module-version'
 import { createFrameworkModuleCandidateRegistrar } from './framework-module-candidates'
 import { orderFrameworkSourceCandidatePlugins } from './framework-plugin-order'
 import { createFrameworkPostPlugin } from './framework-post-plugin'
@@ -106,6 +109,7 @@ function createViteFrameworkPlugins(options = {}, frameworkBranch): any {
   }
   const shouldRewriteCssImports = opts.rewriteCssImports === true
   let resolvedConfig
+  const { observer: webCssEntryDiagnostics, plugin: webCssEntryObserverPlugin } = createConfiguredCssEntryDiagnostics({ getEntries: () => opts.cssEntries, getRoot: () => resolvedConfig?.root, isWeb: () => resolveCurrentGeneratorBranch().isWeb }); const hmrCssModuleVersions = createViteHmrCssModuleVersionTracker()
   const resolveViteStylePlatform = () => {
     const explicit = normalizeFrameworkStylePlatform(opts.cssOptions?.platform ?? opts.platform, opts.appType); if (explicit) {
       return explicit
@@ -297,7 +301,7 @@ function createViteFrameworkPlugins(options = {}, frameworkBranch): any {
   const transformCssHandlerOptions = createCssHandlerOptionsCache({ getAppType: () => opts.appType, mainCssChunkMatcher, getMajorVersion: () => runtimeState.tailwindRuntime.majorVersion, getOutputRoot: () => resolvedConfig?.build?.outDir ? path.resolve(resolvedConfig.root, resolvedConfig.build.outDir) : resolvedConfig?.root, getExtraOptions: file => ({ ...resolveViteCssHandlerExtraOptions(file), ...frameworkCssPipelineStrategy?.getCssHandlerExtraOptions?.({ ...createCssPipelineContext(), file }) ?? {} }), getDynamicCssOptions: () => ({ cssPreflight: opts.cssPreflight }) })
   const serveJsHandlerOptions = createJsHandlerOptionsFactory({ getExperimentalJsFastPath: () => opts.experimentalJsFastPath ?? 'oxc', getMajorVersion: () => runtimeState.tailwindRuntime.majorVersion, moduleGraph: void 0 })
   const shouldAdaptFrameworkWatchCss = () => { const platform = resolveViteStylePlatform(); return shouldAdaptFrameworkWatchCssBeforeCache({ enabled: frameworkBranch.adaptWatchCssBeforeFrameworkCache === true, ownsTailwindGeneration: shouldOwnTailwindGeneration, isWatchBuild: isWatchBuild(), isWebGeneratorBranch: resolveCurrentGeneratorBranch().isWeb, platform }) }
-  const generateTailwindCssForVitePipeline = async (id, code, hookContext) => {
+  const generateTailwindCssForVitePipelineNow = async (id, code, hookContext) => {
     if (!shouldOwnTailwindGeneration) {
       return void 0
     }
@@ -411,6 +415,7 @@ ${previousTracedCss}`
     return `${createBundlerGeneratedCssMarker('vite', normalizeViteProcessedCssFile(file))}
 ${tracedCss}`
   }
+  const generateTailwindCssForVitePipeline = createFrameworkCssGenerationQueue(normalizeGeneratedCssCacheFile, generateTailwindCssForVitePipelineNow)
   const shouldDeferFrameworkPreTransformGeneration = (id: string, code: string) => frameworkCssPipelineStrategy?.shouldDeferPreTransformTailwindGeneration?.({ ...createCssPipelineContext(), code, id }) === true
   const rewritePlugins = createRewriteCssImportsPlugins({ getAppType: () => opts.appType, generateTailwindCss: generateTailwindCssForVitePipeline, rootImport: shouldOwnTailwindGeneration ? `${weappTailwindcssDirPosix}/generator-placeholder.css` : void 0, onTailwindRootCss: registerTailwindRootCss, onCssSourceTransform: (id, code) => cssMemory.refreshRememberedCssSourceBySourceFile(id, code), shouldGenerateCss: (_id, code) => hasVitePipelineTailwindGenerationDirective(code), shouldDeferGeneration: (id, code) => !shouldRewriteCssImports && hasTailwindRootDirectives(code, { importFallback: resolveCurrentGeneratorOptions().importFallback }) || shouldDeferFrameworkPreTransformGeneration(id, code), shouldOwnTailwindGeneration, shouldRewrite: shouldRewriteCssImports, weappTailwindcssDirPosix })
   if (disabledOptions.plugin) {
@@ -426,7 +431,7 @@ ${tracedCss}`
       await discoverAndRegisterAutoCssSources()
     } await sourceScanSession.sync()
   }
-  const extraPlugins = capability.frameworkExtras ? frameworkBranch.createExtraPlugins?.({ customAttributesEntities, disabledDefaultTemplateHandler, ensureRuntimeClassSet, generateCss: generateTailwindCssForVitePipeline, getResolvedConfig, isEnabled: shouldEnableFrameworkExtraPlugins, isIosPlatform: extraPluginPlatform.isIosPlatform === true, isNativeAppStyleTarget: () => frameworkCssPipelineStrategy?.isNativeAppStyleTarget?.(createCssPipelineContext()) === true, isWebGeneratorTarget: () => resolveCurrentGeneratorBranch().isWeb, jsHandler, mainCssChunkMatcher, registerModuleGraphCandidates, runtimeState, styleHandler, syncSourceCandidatesForHotUpdate, tailwindRootCssModuleIds, uniAppX, viteProcessedCssSourceFiles: processedCssRegistry.sourceFiles }) ?? [] : []
+  const extraPlugins = capability.frameworkExtras ? frameworkBranch.createExtraPlugins?.({ customAttributesEntities, disabledDefaultTemplateHandler, ensureRuntimeClassSet, generateCss: generateTailwindCssForVitePipeline, getResolvedConfig, hmrCssModuleVersions, isEnabled: shouldEnableFrameworkExtraPlugins, isIosPlatform: extraPluginPlatform.isIosPlatform === true, isNativeAppStyleTarget: () => frameworkCssPipelineStrategy?.isNativeAppStyleTarget?.(createCssPipelineContext()) === true, isWebGeneratorTarget: () => resolveCurrentGeneratorBranch().isWeb, jsHandler, mainCssChunkMatcher, registerModuleGraphCandidates, runtimeState, styleHandler, syncSourceCandidatesForHotUpdate, tailwindRootCssModuleIds, uniAppX, viteProcessedCssSourceFiles: processedCssRegistry.sourceFiles, webCssEntryDiagnostics }) ?? [] : []
   const installFrameworkWatchCssCacheAdapter = async (config) => {
     if (!shouldAdaptFrameworkWatchCss()) {
       return
@@ -443,7 +448,7 @@ ${tracedCss}`
   }
   /* eslint-disable antfu/consistent-list-newline */
   const sourceCandidatesPlugin = createFrameworkSourceCandidatesPlugin({
-    cssMemory, hasUserCssLayerBlocks, hmrCandidateState, hmrTimingRecorder, invalidateRecordedGeneratorCandidates,
+    cssMemory, hasUserCssLayerBlocks, hmrCandidateState, hmrCssModuleVersions, hmrTimingRecorder, invalidateRecordedGeneratorCandidates,
     isCurrentWebLikeStylePlatform, isNuxtPageHotModule, isUniViteProject, isWebOrNativeAppPlatform,
     prepareTailwindGeneration, preGenerateBundleHook, refreshRuntimeStateForAutoCssSources, refreshTailwindRootCssSource,
     rememberOriginalCssLayerSource, rememberTailwindRootCssModule, resolveCurrentGeneratorBranch, resolveCurrentGeneratorOptions,
@@ -484,8 +489,9 @@ ${tracedCss}`
   })
   const sourceAndRewritePlugins = orderFrameworkSourceCandidatePlugins(extraPlugins, rewritePlugins, sourceCandidatesPlugin, frameworkBranch.sourceCandidatesBeforeExtraPlugin)
   const serveJsPlugin = capability.serveJsTransform ? createViteServeJsTransformPlugin({ createHandlerOptions: file => serveJsHandlerOptions(file, frameworkCssPipelineStrategy?.getServeJsHandlerOptions?.({ ...createCssPipelineContext(), file })), getCommand: () => resolvedConfig?.command, jsHandler, shouldTransform: () => shouldOwnTailwindGeneration && (frameworkCssPipelineStrategy?.shouldTransformServeJs?.(createCssPipelineContext()) ?? !resolveCurrentGeneratorBranch().isWeb), transformRuntime: ensureRuntimeClassSet }) : undefined
-  const plugins = [...sourceAndRewritePlugins, ...createViteCssGenerationPlugins({ generateCss: generateTailwindCssForVitePipeline, getCommand: () => resolvedConfig?.command, onTailwindRootCss: registerTailwindRootCss, shouldDeferGeneration: shouldDeferFrameworkPreTransformGeneration, shouldGenerate: () => shouldOwnTailwindGeneration, shouldGenerateBuild: () => resolveCurrentGeneratorBranch().isWeb }), ...(serveJsPlugin ? [serveJsPlugin] : []), { name: `${vitePluginName}:watch-css-cache`, configResolved: { order: 'post', handler: installFrameworkWatchCssCacheAdapter } }, postPlugin]
+  const plugins = [...sourceAndRewritePlugins, webCssEntryObserverPlugin, ...createViteCssGenerationPlugins({ generateCss: generateTailwindCssForVitePipeline, getCommand: () => resolvedConfig?.command, onTailwindRootCss: registerTailwindRootCss, shouldDeferGeneration: shouldDeferFrameworkPreTransformGeneration, shouldGenerate: () => shouldOwnTailwindGeneration, shouldGenerateBuild: () => resolveCurrentGeneratorBranch().isWeb }), ...(serveJsPlugin ? [serveJsPlugin] : []), { name: `${vitePluginName}:watch-css-cache`, configResolved: { order: 'post', handler: installFrameworkWatchCssCacheAdapter } }, postPlugin]
   plugins.push(cssFinalizerOutputPlugin)
+  plugins.push(createViteHmrCssModuleVersionFilterPlugin(hmrCssModuleVersions))
   if (capability.styleInjector) {
     plugins.push(...createBuiltinViteStyleInjectorPlugins(styleInjector, () => frameworkBranch.styleInjectorDelegate))
   }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/create-framework-plugins.ts
@@ -1,6 +1,7 @@
 import type { HmrContext, Plugin, ResolvedConfig } from 'vite'
 import type { ViteFrameworkName } from '../../framework-selector'
 import type { createViteRuntimeClassSet } from '../runtime-class-set'
+import type { ViteHmrCssModuleVersionTracker } from './framework-hmr-module-version'
 import type { ViteFrameworkCssPipelineStrategy, ViteFrameworkExtraPluginPlatform, ViteFrameworkRuntimeFeatureContext } from './framework-strategy'
 import type { getCompilerContext } from '@/context'
 import type { toCustomAttributesEntities } from '@/context/custom-attributes'
@@ -34,6 +35,7 @@ export interface ViteFrameworkExtraPluginContext {
   ensureRuntimeClassSet: (...args: any[]) => Promise<Set<string>>
   generateCss: (...args: any[]) => Promise<string | undefined>
   getResolvedConfig: () => ResolvedConfig | undefined
+  hmrCssModuleVersions: ViteHmrCssModuleVersionTracker
   isEnabled: () => boolean
   isIosPlatform: boolean
   isNativeAppStyleTarget: () => boolean
@@ -47,6 +49,12 @@ export interface ViteFrameworkExtraPluginContext {
   tailwindRootCssModuleIds: Set<string>
   uniAppX: ReturnType<typeof getCompilerContext>['uniAppX']
   viteProcessedCssSourceFiles: Iterable<string>
+  webCssEntryDiagnostics: {
+    dispose: () => void
+    flush: () => void
+    observeSourceImports: (source: string, sourceId: string) => void
+    requestCheck: () => void
+  }
 }
 
 function wrapPluginHook(

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-css-generation-queue.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-css-generation-queue.ts
@@ -1,0 +1,19 @@
+export function createFrameworkCssGenerationQueue<Args extends unknown[], Result>(
+  normalizeId: (id: string) => string,
+  generate: (id: string, ...args: Args) => Promise<Result>,
+) {
+  const pendingByFile = new Map<string, Promise<void>>()
+  return (id: string, ...args: Args) => {
+    const fileKey = normalizeId(id)
+    const previous = pendingByFile.get(fileKey) ?? Promise.resolve()
+    const task = previous.then(() => generate(id, ...args))
+    const tail = task.then(() => undefined, () => undefined)
+    pendingByFile.set(fileKey, tail)
+    void tail.then(() => {
+      if (pendingByFile.get(fileKey) === tail) {
+        pendingByFile.delete(fileKey)
+      }
+    })
+    return task
+  }
+}

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-hmr-module-version.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-hmr-module-version.ts
@@ -1,0 +1,103 @@
+import type { ModuleNode, Plugin } from 'vite'
+import process from 'node:process'
+import { isSourceStyleRequest } from '../../shared/style-requests'
+import { sendSupplementalCssHotUpdates } from '../hot-css-modules'
+import { resolveViteModuleIdentity } from '../module-identity'
+
+export interface ViteHmrCssModuleVersionTracker {
+  clear: () => void
+  filterIds: (ids: Iterable<string>, timestamp: number, root: string) => string[]
+  filterModules: (modules: ModuleNode[], timestamp: number, root: string) => ModuleNode[]
+  reserveRefreshTimestamp: (modules: ModuleNode[], timestamp: number, root: string) => number
+}
+
+function acceptVersion(versions: Map<string, number>, keys: string[], timestamp: number) {
+  if (keys.some(key => (versions.get(key) ?? 0) > timestamp)) {
+    return false
+  }
+  for (const key of keys) {
+    versions.set(key, Math.max(versions.get(key) ?? 0, timestamp))
+  }
+  return true
+}
+
+export function createViteHmrCssModuleVersionTracker(): ViteHmrCssModuleVersionTracker {
+  const versions = new Map<string, number>()
+  const keysForId = (id: string, root: string) => [resolveViteModuleIdentity(id, root).key]
+  const keysForModule = (mod: ModuleNode, root: string) => [...new Set(
+    [mod.id, mod.url, mod.file]
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      .flatMap(id => keysForId(id, root)),
+  )]
+
+  return {
+    clear() {
+      versions.clear()
+    },
+    filterIds(ids, timestamp, root) {
+      return [...ids].filter(id => acceptVersion(versions, keysForId(id, root), timestamp))
+    },
+    filterModules(modules, timestamp, root) {
+      return modules.filter((mod) => {
+        const keys = keysForModule(mod, root)
+        return keys.length === 0 || acceptVersion(versions, keys, timestamp)
+      })
+    },
+    reserveRefreshTimestamp(modules, timestamp, root) {
+      const moduleKeys = modules.flatMap(mod => keysForModule(mod, root))
+      const latestTimestamp = moduleKeys.reduce(
+        (latest, key) => Math.max(latest, versions.get(key) ?? 0),
+        0,
+      )
+      const refreshTimestamp = Math.max(Date.now(), timestamp + 1, latestTimestamp + 1)
+      for (const key of moduleKeys) {
+        versions.set(key, refreshTimestamp)
+      }
+      return refreshTimestamp
+    },
+  }
+}
+
+export function createViteHmrCssModuleVersionFilterPlugin(
+  tracker: ViteHmrCssModuleVersionTracker,
+): Plugin {
+  return {
+    name: 'weapp-tailwindcss:hmr-css-module-version',
+    enforce: 'post',
+    handleHotUpdate: {
+      order: 'post',
+      handler(ctx) {
+        const styleModules = ctx.modules.filter((mod) => {
+          const request = mod.id ?? mod.url
+          return isSourceStyleRequest(request)
+        })
+        if (styleModules.length === 0) {
+          return
+        }
+        const root = ctx.server.config?.root ?? process.cwd()
+        const currentStyleModules = tracker.filterModules(styleModules, ctx.timestamp, root)
+        if (currentStyleModules.length === styleModules.length) {
+          return
+        }
+        const droppedStyleModules = styleModules.filter(mod => !currentStyleModules.includes(mod))
+        for (const mod of droppedStyleModules) {
+          ctx.server.moduleGraph.invalidateModule(mod)
+        }
+        const refreshTimestamp = tracker.reserveRefreshTimestamp(
+          droppedStyleModules,
+          ctx.timestamp,
+          root,
+        )
+        sendSupplementalCssHotUpdates(
+          { ...ctx, timestamp: refreshTimestamp },
+          droppedStyleModules,
+          [],
+          [],
+          [],
+        )
+        const sourceModules = ctx.modules.filter(mod => !styleModules.includes(mod))
+        return [...sourceModules, ...currentStyleModules]
+      },
+    },
+  }
+}

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-candidates-plugin.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-candidates-plugin.ts
@@ -191,8 +191,14 @@ export function createFrameworkSourceCandidatesPlugin(options: any, apply?: Plug
           const hotTailwindCssModuleIds = isSourceStyleRequest(ctx.file)
             ? [ctx.file]
             : options.tailwindRootCssModuleIds
-          const cssModules = await resolveHotTailwindCssModules(ctx, hotTailwindCssModuleIds)
           const hotRoot = ctx.server.config?.root ?? process.cwd()
+          const cssModules = await resolveHotTailwindCssModules(
+            ctx,
+            hotTailwindCssModuleIds,
+            options.hmrCssModuleVersions
+              ? modules => options.hmrCssModuleVersions.filterModules(modules, ctx.timestamp, hotRoot)
+              : undefined,
+          )
           const sourceModules = isSourceCandidateHotUpdate && !isSourceStyleRequest(ctx.file)
             ? await resolveHotSourceModules(ctx)
             : ctx.modules
@@ -260,11 +266,16 @@ export function createFrameworkSourceCandidatesPlugin(options: any, apply?: Plug
             ...options.tailwindRootCssModuleIds,
             ...options.viteProcessedCssSourceFiles,
           ])
+          const currentSupplementalCssFallbackIds = options.hmrCssModuleVersions?.filterIds(
+            supplementalCssFallbackIds,
+            ctx.timestamp,
+            hotRoot,
+          ) ?? supplementalCssFallbackIds
           if (options.hmrCandidateState.hasPendingChange()) {
-            options.hmrCandidateState.armTargets(cssModules, supplementalCssFallbackIds)
+            options.hmrCandidateState.armTargets(cssModules, currentSupplementalCssFallbackIds)
           }
-          if (shouldSendSupplementalCssHotUpdates) {
-            sendSupplementalCssHotUpdates(ctx, cssModules, supplementalCssFallbackIds)
+          if (shouldSendSupplementalCssHotUpdates && cssModules.length === 0) {
+            sendSupplementalCssHotUpdates(ctx, [], currentSupplementalCssFallbackIds)
           }
           if (isWebLikeHotUpdate && isSourceCandidateHotUpdate && !isSourceStyleRequest(ctx.file)) {
             return cssModules.length > 0
@@ -277,6 +288,9 @@ export function createFrameworkSourceCandidatesPlugin(options: any, apply?: Plug
           return cssModules.length > 0 ? mergeHotModulesByIdentity(hotRoot, ctx.modules, cssModules) : undefined
         }, { emit: false })
       },
+    },
+    closeBundle() {
+      options.hmrCssModuleVersions?.clear()
     },
     async buildStart() {
       await options.hmrTimingRecorder.measure('sourceCandidates.buildStart', options.prepareTailwindGeneration, { emit: false })

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
@@ -258,9 +258,10 @@ function normalizeTailwindV4CssEntrySources(
   const remainingCssEntries: string[] = []
   const cssSources: NonNullable<TailwindV4SourceOptions['cssSources']> = []
   for (const cssEntry of cssEntries) {
-    const file = path.resolve(cssEntry)
+    const normalizedCssEntry = cssEntry.replace(/[?#].*$/, '')
+    const file = path.resolve(normalizedCssEntry)
     if (!existsSync(file)) {
-      remainingCssEntries.push(cssEntry)
+      remainingCssEntries.push(normalizedCssEntry)
       continue
     }
     const base = path.dirname(file)

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
@@ -61,6 +61,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     syncSourceCandidatesForHotUpdate,
     tailwindRootCssModuleIds = [],
     generateCss,
+    hmrCssModuleVersions,
     jsHandler,
     ensureRuntimeClassSet,
     getResolvedConfig,
@@ -69,6 +70,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     isWebGeneratorTarget = () => resolveUniUtsPlatform().isWeb,
     uniAppX,
     viteProcessedCssSourceFiles = [],
+    webCssEntryDiagnostics,
   } = options
   const resolvedUniAppXOptions = resolveUniAppXOptions(uniAppX)
   const utsPlatform = resolveUniUtsPlatform()
@@ -91,7 +93,8 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
   }>()
   const nativeLocalStyleModuleIds = new Set<string>()
   const knownSfcSources = new Map<string, string>()
-  const webLocalStyle = createUniAppXWebLocalStyleBridge(isWebGeneratorTarget)
+  const pendingSfcTransforms = new Map<string, Promise<TransformResult | undefined>>()
+  const webLocalStyle = createUniAppXWebLocalStyleBridge(isWebGeneratorTarget, hmrCssModuleVersions)
   let componentLocalStyleEnabled: boolean | undefined
   const isNativeAppBuildTarget = createUniAppXNativeBuildTargetResolver(getResolvedConfig)
   const nativeHmrReloader = createUniAppXNativeHmrReloader({
@@ -253,7 +256,10 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
         return
       }
       await runtimeState.readyPromise
-      const { query } = parseVueRequest(id)
+      const { filename, query } = parseVueRequest(id)
+      if (query.vue && query.type === 'style') {
+        await pendingSfcTransforms.get(cleanUrl(filename))
+      }
       const styleCode = query.vue && query.type === 'style' ? webLocalStyle.appendToStyle(code, id) : code
       // Vite 热更新会绕过 SFC 主模块，直接把原始样式交给预处理器；先移除
       // Sass 无法解析的 important utility 后，再由后续 CSS 阶段还原。
@@ -285,6 +291,11 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
 
   async function transformSfc(code: string, id: string, context: { addWatchFile?: (id: string) => void }) {
     knownSfcSources.set(cleanUrl(id), code)
+    if (isWebGeneratorTarget()) {
+      for (const style of extractSfcStyleBlocks(code)) {
+        webCssEntryDiagnostics?.observeSourceImports(style.source, id)
+      }
+    }
     if (isNativeAppBuildTarget(id)) {
       nativeLocalStyleModuleIds.add(id)
       nativeLocalStyleModuleIds.add(cleanUrl(id))
@@ -312,7 +323,14 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       native: true,
       pageMatcher: resolvedUniAppXOptions.componentLocalStyles.pageMatcher,
       ...(isWebGeneratorTarget() && customAttributesEntities.length > 0 ? { webCustomAttributeDeep: true } : {}),
-      ...(isWebGeneratorTarget() ? { onWebLocalStyleRules: (rules: string) => webLocalStyle.remember(id, rules) } : {}),
+      ...(isWebGeneratorTarget()
+        ? {
+            onWebLocalStyleRules: (rules: string) => {
+              webLocalStyle.remember(id, rules)
+              webCssEntryDiagnostics?.requestCheck()
+            },
+          }
+        : {}),
     })
     const result = Object.keys(transformOptions).length > 0
       ? transformUVue(code, id, jsHandler, currentRuntimeSet, transformOptions)
@@ -323,6 +341,18 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
     harmonyApply.rememberSource(result.code, id)
     const expandedCode = await harmonyApply.expandStyles(result.code, id, context)
     return expandedCode === result.code ? result : { code: expandedCode, map: null }
+  }
+
+  function runTransformSfc(code: string, id: string, context: { addWatchFile?: (id: string) => void }) {
+    const file = cleanUrl(id)
+    const pending = transformSfc(code, id, context)
+    pendingSfcTransforms.set(file, pending)
+    void pending.finally(() => {
+      if (pendingSfcTransforms.get(file) === pending) {
+        pendingSfcTransforms.delete(file)
+      }
+    })
+    return pending
   }
 
   const nvuePlugin: Plugin = {
@@ -343,11 +373,11 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
         if (!UVUE_NVUE_QUERY_RE.test(id)) {
           return
         }
-        return transformSfc(code, id, this)
+        return runTransformSfc(code, id, this)
       },
     },
     handleHotUpdate: {
-      order: 'pre',
+      order: 'post',
       async handler(ctx) {
         if (!isEnabled() || getResolvedConfig()?.command !== 'serve') {
           return
@@ -361,7 +391,7 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
             ctx.server.ws.send({ type: 'full-reload', path: ctx.file })
             return []
           }
-          await transformSfc(source, ctx.file, this)
+          await runTransformSfc(source, ctx.file, this)
         }
         return webLocalStyle.handleHotUpdate(ctx) ?? nativeHmrReloader.handleHotUpdate(ctx)
       },
@@ -379,6 +409,14 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
       }
       // 针对 `vite build --watch` 的增量构建刷新运行时类集
       await ensureRuntimeClassSet(true)
+    },
+    buildEnd() {
+      if (isWebGeneratorTarget()) {
+        webCssEntryDiagnostics?.flush()
+      }
+    },
+    closeBundle() {
+      webCssEntryDiagnostics?.dispose()
     },
   }
 

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite/plugin-options.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite/plugin-options.ts
@@ -1,4 +1,5 @@
 import type { HmrContext, ResolvedConfig } from 'vite'
+import type { ViteHmrCssModuleVersionTracker } from '@/bundlers/vite/shared/framework-hmr-module-version'
 import type {
   AppType,
   ICustomAttributesEntities,
@@ -25,10 +26,17 @@ export interface CreateUniAppXPluginsOptions {
   jsHandler: JsHandler
   ensureRuntimeClassSet: (force?: boolean) => Promise<Set<string>>
   getResolvedConfig: () => ResolvedConfig | undefined
+  hmrCssModuleVersions?: ViteHmrCssModuleVersionTracker | undefined
   isIosPlatform?: boolean
   isNativeAppStyleTarget?: (() => boolean) | undefined
   isWebGeneratorTarget?: (() => boolean) | undefined
   isEnabled?: (() => boolean) | undefined
   uniAppX?: InternalUserDefinedOptions['uniAppX']
   viteProcessedCssSourceFiles?: Iterable<string> | undefined
+  webCssEntryDiagnostics?: {
+    dispose: () => void
+    flush: () => void
+    observeSourceImports: (source: string, sourceId: string) => void
+    requestCheck: () => void
+  } | undefined
 }

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite/web-local-style.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite/web-local-style.ts
@@ -1,4 +1,6 @@
 import type { HmrContext, ModuleNode } from 'vite'
+import type { ViteHmrCssModuleVersionTracker } from '@/bundlers/vite/shared/framework-hmr-module-version'
+import process from 'node:process'
 import { cleanUrl } from '@/bundlers/vite/utils'
 
 function isStyleModule(mod: ModuleNode) {
@@ -6,7 +8,10 @@ function isStyleModule(mod: ModuleNode) {
   return typeof request === 'string' && /[?&](?:vue&)?type=style(?:&|$)/.test(request)
 }
 
-export function createUniAppXWebLocalStyleBridge(isEnabled: () => boolean) {
+export function createUniAppXWebLocalStyleBridge(
+  isEnabled: () => boolean,
+  hmrCssModuleVersions?: ViteHmrCssModuleVersionTracker,
+) {
   const rulesByFile = new Map<string, string>()
 
   return {
@@ -21,15 +26,23 @@ export function createUniAppXWebLocalStyleBridge(isEnabled: () => boolean) {
       if (!isEnabled() || !/\.(?:uvue|nvue)$/i.test(cleanUrl(ctx.file))) {
         return
       }
-      const styleModules = [...ctx.server.moduleGraph.getModulesByFile?.(ctx.file) ?? []]
+      const root = ctx.server.config?.root ?? process.cwd()
+      const sourceModules = ctx.modules.filter(mod => !isStyleModule(mod))
+      const contextStyleModules = ctx.modules.filter(isStyleModule)
+      const currentContextStyleModules = hmrCssModuleVersions?.filterModules(contextStyleModules, ctx.timestamp, root)
+        ?? contextStyleModules
+      const resolvedStyleModules = [...ctx.server.moduleGraph.getModulesByFile?.(ctx.file) ?? []]
         .filter(isStyleModule)
-      if (styleModules.length === 0) {
+      const currentResolvedStyleModules = hmrCssModuleVersions?.filterModules(resolvedStyleModules, ctx.timestamp, root)
+        ?? resolvedStyleModules
+      const styleModules = [...new Set([...currentContextStyleModules, ...currentResolvedStyleModules])]
+      if (styleModules.length === 0 && sourceModules.length === ctx.modules.length) {
         return
       }
       for (const mod of styleModules) {
         ctx.server.moduleGraph.invalidateModule(mod)
       }
-      return [...new Set([...ctx.modules, ...styleModules])]
+      return [...new Set([...sourceModules, ...styleModules])]
     },
     remember(id: string, rules: string) {
       rulesByFile.set(cleanUrl(id), rules)

--- a/packages/weapp-tailwindcss/test/bundlers/generator-css.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/generator-css.unit.test.ts
@@ -11438,4 +11438,68 @@ describe('bundlers/shared generator css', () => {
       css: expect.stringContaining(`@config "${configFile}";`),
     }))
   })
+
+  it('resolves imported SFC @config from its configured cssSource file', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-sfc-import-config-'))
+    const mainCssFile = path.join(root, 'main.css')
+    const configFile = path.join(root, 'tailwind.config.js')
+    const pageFile = path.join(root, 'pages/index/index.uvue')
+    const mainCss = '@import "tailwindcss" source(none);\n@config "./tailwind.config.js";'
+    const flattenedCss = `${mainCss}\n.probe { @apply flex; }`
+    await mkdir(path.dirname(pageFile), { recursive: true })
+    await writeFile(mainCssFile, mainCss)
+    await writeFile(configFile, 'export default {}')
+    await writeFile(pageFile, '<style scoped>\n@import "../../main.css";\n.probe { @apply flex; }\n</style>')
+    const resolveTailwindV4Source = vi.fn(async (options: any = {}) => ({
+      projectRoot: root,
+      base: options.base ?? root,
+      baseFallbacks: [],
+      css: options.css ?? '@import "tailwindcss";',
+      dependencies: [],
+      version: 4,
+    }))
+    vi.doMock('@/generator', () => createDefaultGeneratorMock({
+      resolveTailwindV4Source,
+      resolveTailwindV4SourceOptionsFromRuntime: vi.fn(() => ({
+        projectRoot: root,
+        cwd: root,
+        base: root,
+        baseFallbacks: [root],
+        cssSources: [{
+          file: mainCssFile,
+          base: root,
+          css: mainCss,
+        }],
+      })),
+    }))
+    const { resolveGeneratorSource } = await import('@/bundlers/shared/generator-css/source-resolver')
+
+    const source = await resolveGeneratorSource(
+      4,
+      { tailwindRuntime: { majorVersion: 4 } as any },
+      flattenedCss,
+      `${pageFile}?vue&type=style&index=0&scoped=abc&lang.css`,
+      {
+        isMainChunk: false,
+        majorVersion: 4,
+        postcssOptions: { options: { from: pageFile } },
+      } as any,
+      normalizeGeneratorOptions(),
+      {
+        cssSources: [{
+          file: pageFile,
+          base: path.dirname(pageFile),
+          css: flattenedCss,
+        }],
+      },
+    )
+
+    expect(source?.css).toContain(`@config "${configFile}";`)
+    expect(source?.css).toContain('.probe { @apply flex; }')
+    expect(source?.css).not.toContain(path.join(path.dirname(pageFile), 'tailwind.config.js'))
+    expect(resolveTailwindV4Source).toHaveBeenCalledWith(expect.objectContaining({
+      base: root,
+      css: expect.stringContaining(`@config "${configFile}";`),
+    }))
+  })
 })

--- a/packages/weapp-tailwindcss/test/bundlers/style-requests.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/style-requests.unit.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { isSfcStyleSourceRequest } from '@/bundlers/shared/style-requests'
+
+describe('style requests', () => {
+  it('distinguishes SFC source files from external Vue style requests', () => {
+    expect(isSfcStyleSourceRequest('/project/src/pages/index.uvue')).toBe(true)
+    expect(isSfcStyleSourceRequest('/project/src/pages/index.vue?vue&type=style&index=0')).toBe(true)
+    expect(isSfcStyleSourceRequest('/project/src/pages/index.css?vue&type=style&index=0&src=true&lang.css')).toBe(false)
+    expect(isSfcStyleSourceRequest('/project/src/pages/index.scss?vue&type=style&index=0&src=true&lang.scss')).toBe(false)
+  })
+})

--- a/packages/weapp-tailwindcss/test/bundlers/vite-configured-css-entry-observer.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-configured-css-entry-observer.unit.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createConfiguredCssEntryObserver } from '@/bundlers/vite/shared/configured-css-entry-observer'
+
+describe('vite configured css entry observer', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not report configured entries that entered the module graph', () => {
+    vi.useFakeTimers()
+    const onMissing = vi.fn()
+    const observer = createConfiguredCssEntryObserver({
+      delayMs: 10,
+      getEntries: () => ['/project/main.css'],
+      getRoot: () => '/project',
+      onMissing,
+    })
+
+    observer.requestCheck()
+    observer.observe('/@fs/project/main.css?direct')
+    vi.advanceTimersByTime(10)
+
+    expect(onMissing).not.toHaveBeenCalled()
+  })
+
+  it('reports unobserved entries once after local style generation settles', () => {
+    vi.useFakeTimers()
+    const onMissing = vi.fn()
+    const observer = createConfiguredCssEntryObserver({
+      delayMs: 10,
+      getEntries: () => ['/project/main.css', '/project/theme.css'],
+      getRoot: () => '/project',
+      onMissing,
+    })
+
+    observer.observe('/project/main.css')
+    observer.requestCheck()
+    vi.advanceTimersByTime(10)
+    observer.requestCheck()
+    observer.flush()
+
+    expect(onMissing).toHaveBeenCalledTimes(1)
+    expect(onMissing).toHaveBeenCalledWith(['/project/theme.css'])
+  })
+
+  it('accepts configured entries inlined by an SFC style preprocessor', () => {
+    vi.useFakeTimers()
+    const onMissing = vi.fn()
+    const observer = createConfiguredCssEntryObserver({
+      delayMs: 10,
+      getEntries: () => ['/project/main.css', '/project/main.iconify.css'],
+      getRoot: () => '/project',
+      onMissing,
+    })
+
+    observer.observeSourceImports([
+      '@import "../main.css";',
+      '@import url(\'../main.iconify.css\');',
+    ].join('\n'), '/project/src/App.uvue')
+    observer.requestCheck()
+    vi.advanceTimersByTime(10)
+
+    expect(onMissing).not.toHaveBeenCalled()
+  })
+
+  it('resolves Windows SFC imports without treating module ids as POSIX paths', () => {
+    vi.useFakeTimers()
+    const onMissing = vi.fn()
+    const observer = createConfiguredCssEntryObserver({
+      delayMs: 10,
+      getEntries: () => ['C:\\project\\main.css'],
+      getRoot: () => 'C:\\project',
+      onMissing,
+    })
+
+    observer.observeSourceImports('@import "..\\\\main.css";', 'C:\\project\\src\\App.uvue')
+    observer.requestCheck()
+    vi.advanceTimersByTime(10)
+
+    expect(onMissing).not.toHaveBeenCalled()
+  })
+})

--- a/packages/weapp-tailwindcss/test/bundlers/vite-hmr-module-version.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-hmr-module-version.unit.test.ts
@@ -1,0 +1,141 @@
+import type { HmrContext, ModuleNode } from 'vite'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { createViteHmrCssModuleVersionFilterPlugin, createViteHmrCssModuleVersionTracker } from '@/bundlers/vite/shared/framework-hmr-module-version'
+import { createUniAppXWebLocalStyleBridge } from '@/uni-app-x/vite/web-local-style'
+
+describe('Vite CSS HMR module versions', () => {
+  it('rejects an older transaction for the same normalized style module', () => {
+    const root = path.resolve('/project')
+    const pageFile = path.join(root, 'pages/index.uvue')
+    const tracker = createViteHmrCssModuleVersionTracker()
+    const currentModule = {
+      file: pageFile,
+      id: `${pageFile}?vue&type=style&index=0&scoped=abc&lang.scss`,
+      url: '/pages/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
+    } as ModuleNode
+    const staleModule = { ...currentModule } as ModuleNode
+
+    expect(tracker.filterModules([currentModule], 200, root)).toEqual([currentModule])
+    expect(tracker.filterModules([staleModule], 100, root)).toEqual([])
+    expect(tracker.filterIds([currentModule.id!], 100, root)).toEqual([])
+
+    tracker.clear()
+    expect(tracker.filterModules([staleModule], 100, root)).toEqual([staleModule])
+  })
+
+  it('keeps a stale uni-app x page transaction from re-adding its style module', () => {
+    const root = path.resolve('/project')
+    const pageFile = path.join(root, 'pages/index.uvue')
+    const tracker = createViteHmrCssModuleVersionTracker()
+    const pageModule = { id: pageFile, url: '/pages/index.uvue' } as ModuleNode
+    const styleModule = {
+      file: pageFile,
+      id: `${pageFile}?vue&type=style&index=0&scoped=abc&lang.scss`,
+      url: '/pages/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
+    } as ModuleNode
+    const invalidateModule = vi.fn()
+    const bridge = createUniAppXWebLocalStyleBridge(() => true, tracker)
+    const createContext = (timestamp: number) => ({
+      file: pageFile,
+      modules: [pageModule],
+      timestamp,
+      server: {
+        config: { root },
+        moduleGraph: {
+          getModulesByFile: () => new Set([pageModule, styleModule]),
+          invalidateModule,
+        },
+      },
+    }) as unknown as HmrContext
+
+    tracker.filterModules([styleModule], 200, root)
+    expect(bridge.handleHotUpdate(createContext(100))).toBeUndefined()
+    expect(invalidateModule).not.toHaveBeenCalled()
+
+    expect(bridge.handleHotUpdate(createContext(201))).toEqual([pageModule, styleModule])
+    expect(invalidateModule).toHaveBeenCalledWith(styleModule)
+  })
+
+  it('removes stale style modules already returned by an earlier HMR hook', () => {
+    const root = path.resolve('/project')
+    const pageFile = path.join(root, 'pages/index.uvue')
+    const tracker = createViteHmrCssModuleVersionTracker()
+    const pageModule = { id: pageFile, url: '/pages/index.uvue' } as ModuleNode
+    const styleModule = {
+      file: pageFile,
+      id: `${pageFile}?vue&type=style&index=0&scoped=abc&lang.scss`,
+      url: '/pages/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
+    } as ModuleNode
+    const bridge = createUniAppXWebLocalStyleBridge(() => true, tracker)
+
+    tracker.filterModules([styleModule], 200, root)
+    const result = bridge.handleHotUpdate({
+      file: pageFile,
+      modules: [pageModule, styleModule],
+      timestamp: 100,
+      server: {
+        config: { root },
+        moduleGraph: {
+          getModulesByFile: () => new Set([pageModule, styleModule]),
+          invalidateModule: vi.fn(),
+        },
+      },
+    } as unknown as HmrContext)
+
+    expect(result).toEqual([pageModule])
+  })
+
+  it('refreshes stale CSS with a timestamp newer than the superseding transaction', async () => {
+    const root = path.resolve('/project')
+    const pageFile = path.join(root, 'pages/index.uvue')
+    const tracker = createViteHmrCssModuleVersionTracker()
+    const plugin = createViteHmrCssModuleVersionFilterPlugin(tracker)
+    const pageModule = { id: pageFile, url: '/pages/index.uvue' } as ModuleNode
+    const styleModule = {
+      file: pageFile,
+      id: `${pageFile}?vue&type=style&index=0&scoped=abc&lang.scss`,
+      url: '/pages/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
+    } as ModuleNode
+    const invalidateModule = vi.fn()
+    const send = vi.fn()
+    const hook = plugin.handleHotUpdate as { handler: (ctx: HmrContext) => ModuleNode[] | undefined }
+
+    tracker.filterModules([styleModule], 200, root)
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(150)
+    let result: ModuleNode[] | undefined
+    try {
+      result = hook.handler({
+        file: pageFile,
+        modules: [pageModule, styleModule],
+        timestamp: 100,
+        server: {
+          config: { root },
+          moduleGraph: { invalidateModule },
+          ws: { send },
+        },
+      } as unknown as HmrContext)
+      await Promise.resolve()
+    }
+    finally {
+      dateNow.mockRestore()
+    }
+
+    expect(plugin.handleHotUpdate).toMatchObject({ order: 'post' })
+    expect(result).toEqual([pageModule])
+    expect(invalidateModule).toHaveBeenCalledWith(styleModule)
+    expect(send).toHaveBeenCalledWith({
+      type: 'update',
+      updates: [{
+        type: 'js-update',
+        timestamp: 201,
+        path: styleModule.url,
+        acceptedPath: styleModule.url,
+        explicitImportRequired: false,
+        isWithinCircularImport: false,
+      }],
+    })
+    expect(tracker.filterModules([styleModule], 200, root)).toEqual([])
+    expect(tracker.filterModules([styleModule], 201, root)).toEqual([styleModule])
+  })
+})

--- a/packages/weapp-tailwindcss/test/bundlers/vite-hot-css-modules.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-hot-css-modules.unit.test.ts
@@ -221,4 +221,21 @@ describe('bundlers/vite hot css modules', () => {
       ],
     })
   })
+
+  it('does not resend css modules handled by the normal Vite HMR transaction', async () => {
+    const root = path.resolve('/project')
+    const ctx = createHmrContext(root)
+    const cssModule = {
+      file: path.join(root, 'main.css'),
+      id: path.join(root, 'main.css'),
+      url: '/main.css',
+    } as any
+
+    sendSupplementalCssHotUpdates(ctx, [cssModule], [
+      `${path.join(root, 'main.css')}?direct`,
+    ], [], [cssModule])
+    await Promise.resolve()
+
+    expect(ctx.server.ws.send).not.toHaveBeenCalled()
+  })
 })

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin-hooks.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin-hooks.unit.test.ts
@@ -49,6 +49,7 @@ describe('bundlers/vite WeappTailwindcss hook coverage', () => {
 
   beforeEach(() => {
     vi.resetModules()
+    vi.doUnmock('@/bundlers/vite/shared/configured-css-entry-observer')
     resetVitePluginTestContext()
     mocks.generateTailwindV4Css.mockReset()
     mocks.generateTailwindV4Css.mockResolvedValue({
@@ -57,6 +58,51 @@ describe('bundlers/vite WeappTailwindcss hook coverage', () => {
       classSet: new Set(['generated']),
       target: 'weapp',
     })
+  })
+
+  it('observes configured web css entries only when Vite transforms their style modules', async () => {
+    const cssFile = '/project/main.css'
+    const observer = {
+      dispose: vi.fn(),
+      flush: vi.fn(),
+      observe: vi.fn(),
+      observeSourceImports: vi.fn(),
+      requestCheck: vi.fn(),
+    }
+    vi.doMock('@/bundlers/vite/shared/configured-css-entry-observer', () => ({
+      createConfiguredCssEntryDiagnostics: vi.fn(() => ({
+        observer,
+        plugin: {
+          name: `${vitePluginName}:configured-css-entry-observer`,
+          transform(_code: string, id: string) {
+            observer.observe(id)
+          },
+        },
+      })),
+    }))
+    const context = createContext({
+      appType: 'uni-app-x',
+      cssEntries: [cssFile],
+      generator: { target: 'web' },
+      tailwindcssBasedir: '/project',
+    })
+    setCurrentContext(context)
+    const WeappTailwindcss = await loadWeappTailwindcssPlugin()
+    const plugins = WeappTailwindcss()!
+    const css = '@import "tailwindcss";'
+    const serveCssPlugin = getPlugin(plugins, 'generate:serve')
+
+    await getTransformHandler(serveCssPlugin)?.call(
+      { addWatchFile: vi.fn() },
+      css,
+      cssFile,
+    )
+    expect(observer.observe).not.toHaveBeenCalled()
+
+    const entryObserverPlugin = getPlugin(plugins, 'configured-css-entry-observer')
+    await getTransformHandler(entryObserverPlugin)?.call(entryObserverPlugin, css, `${cssFile}?direct`)
+    expect(observer.observe).toHaveBeenCalledOnce()
+    expect(observer.observe).toHaveBeenCalledWith(`${cssFile}?direct`)
   })
 
   it('drives source candidate transform, watch change, hot update, build start, and post config hooks', async () => {
@@ -650,6 +696,74 @@ describe('bundlers/vite WeappTailwindcss hook coverage', () => {
     )
     expect(jsResult).toBeUndefined()
     expect(context.jsHandler).not.toHaveBeenCalled()
+  })
+
+  it('serializes concurrent generation for the same Vite style module', async () => {
+    const context = createContext({
+      appType: 'uni-app-x',
+      generator: { target: 'web' },
+      tailwindcssBasedir: '/project',
+    })
+    setCurrentContext(context)
+    let releaseFirst!: () => void
+    let markFirstStarted!: () => void
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    let activeGenerations = 0
+    let maxActiveGenerations = 0
+    mocks.generateTailwindV4Css.mockImplementation(async () => {
+      activeGenerations += 1
+      maxActiveGenerations = Math.max(maxActiveGenerations, activeGenerations)
+      if (mocks.generateTailwindV4Css.mock.calls.length === 1) {
+        markFirstStarted()
+        await firstPending
+      }
+      activeGenerations -= 1
+      return {
+        css: '.generated{color:red}',
+        dependencies: [],
+        classSet: new Set(['generated']),
+        target: 'web',
+      }
+    })
+
+    const WeappTailwindcss = await loadWeappTailwindcssPlugin()
+    const plugins = WeappTailwindcss()!
+    const postPlugin = getPlugin(plugins, 'post')
+    await (postPlugin.configResolved as any)?.call(postPlugin, {
+      command: 'serve',
+      root: '/project',
+      plugins: [{ name: 'vite:css' }],
+      css: { postcss: { plugins: [] } },
+      build: { outDir: 'dist/web' },
+    } as ResolvedConfig)
+    const serveCssPlugin = getPlugin(plugins, 'generate:serve')
+    const serveCssHmrPlugin = getPlugin(plugins, 'generate:serve-hmr')
+    const transform = getTransformHandler(serveCssPlugin)!
+    const transformHmr = getTransformHandler(serveCssHmrPlugin)!
+    const source = '@import "tailwindcss";'
+    const id = '/project/pages/index/index.uvue?vue&type=style&index=0&scoped=abc&lang.css'
+    const hmrCode = `const __vite__css = ${JSON.stringify(source)};\n__vite__updateStyle(__vite__id, __vite__css)`
+
+    const first = transform.call(serveCssPlugin, source, id)
+    await firstStarted
+    const second = transformHmr.call(serveCssHmrPlugin, hmrCode, `${id}&t=2`)
+    await Promise.resolve()
+
+    expect(mocks.generateTailwindV4Css).toHaveBeenCalledTimes(1)
+    releaseFirst()
+    const results = await Promise.all([first, second])
+
+    expect(mocks.generateTailwindV4Css).toHaveBeenCalledTimes(2)
+    expect(maxActiveGenerations).toBe(1)
+    expect(results).toEqual([
+      expect.objectContaining({ code: expect.stringContaining('.generated{color:red}') }),
+      expect.objectContaining({ code: expect.stringContaining('.generated{color:red}') }),
+    ])
   })
 
   it('generates build css in a pre transform before Vite PostCSS and asset finalization', async () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.bundle.unit.test.ts
@@ -1333,7 +1333,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
     expect(createdSources[0]?.css).not.toContain('../../../tailwind.config.js')
   }, TEST_TIMEOUT_MS)
 
-  it('preserves Vite vue hmr result while supplementing Tailwind root css updates for web target', async () => {
+  it('keeps the Tailwind root CSS in the normal Vite Web HMR transaction', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'weapp-tw-vite-hmr-root-css-'))
     createdDirs.push(root)
     const pageFile = path.join(root, 'src/pages/index/index.vue')
@@ -1442,14 +1442,15 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
     expect(result).toEqual([vueModule, cssModule])
     expect(invalidateModule).toHaveBeenCalledWith(cssModule)
     await Promise.resolve()
+    expect(wsSend).toHaveBeenCalledTimes(1)
     expect(wsSend).toHaveBeenCalledWith({
       type: 'update',
       updates: [
         {
-          acceptedPath: styleId,
+          acceptedPath: '/src/pages/index/index.vue',
           explicitImportRequired: false,
           isWithinCircularImport: false,
-          path: styleId,
+          path: '/src/pages/index/index.vue',
           timestamp: 123456,
           type: 'js-update',
         },
@@ -2266,19 +2267,18 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
       sourceModule,
       expect.objectContaining({ id: cssFile, url: '/app.css' }),
     ])
+    expect(wsSend).toHaveBeenCalledTimes(1)
     expect(wsSend).toHaveBeenCalledWith({
       type: 'update',
-      updates: expect.arrayContaining([
-        expect.objectContaining({
-          acceptedPath: '/app.css',
-          path: '/app.css',
-          type: expect.stringMatching(/^(?:css|js)-update$/),
-        }),
-      ]),
+      updates: [expect.objectContaining({
+        acceptedPath: '/src/pages/index/index.tsx',
+        path: '/src/pages/index/index.tsx',
+        type: 'js-update',
+      })],
     })
   }, TEST_TIMEOUT_MS)
 
-  it('lets uni-app H5 vue source hot updates continue while sending supplemental Tailwind css updates', async () => {
+  it('keeps uni-app H5 source and Tailwind CSS in one normal Vite HMR transaction', async () => {
     const previousUniPlatform = process.env.UNI_PLATFORM
     process.env.UNI_PLATFORM = 'h5'
     try {
@@ -2397,14 +2397,15 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
       })
       expect(invalidateModule).toHaveBeenCalledWith(cssModule)
       await Promise.resolve()
+      expect(wsSend).toHaveBeenCalledTimes(1)
       expect(wsSend).toHaveBeenCalledWith({
         type: 'update',
         updates: [
           {
-            acceptedPath: styleId,
+            acceptedPath: '/src/pages/index/index.vue',
             explicitImportRequired: false,
             isWithinCircularImport: false,
-            path: styleId,
+            path: '/src/pages/index/index.vue',
             timestamp: 123456,
             type: 'js-update',
           },
@@ -2737,19 +2738,7 @@ describe('bundlers/vite WeappTailwindcss bundle', () => {
     expect(result).toEqual([vueModule, cssModule])
     expect(invalidateModule).toHaveBeenCalledWith(cssModule)
     await Promise.resolve()
-    expect(wsSend).toHaveBeenCalledWith({
-      type: 'update',
-      updates: [
-        {
-          acceptedPath: styleId,
-          explicitImportRequired: false,
-          isWithinCircularImport: false,
-          path: styleId,
-          timestamp: 123456,
-          type: 'js-update',
-        },
-      ],
-    })
+    expect(wsSend).not.toHaveBeenCalled()
   }, TEST_TIMEOUT_MS)
 
   it('regenerates serve css hmr from updated wxml expression candidates', async () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-plugin.rewrite.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-plugin.rewrite.unit.test.ts
@@ -474,6 +474,26 @@ describe('bundlers/vite WeappTailwindcss rewrite', () => {
     expect(result?.code).not.toContain('@config')
   })
 
+  it('preserves relative @config directives that came from an imported SFC style source', async () => {
+    const generateTailwindCss = vi.fn(async () => undefined)
+    const onTailwindRootCss = vi.fn()
+    const [rewritePlugin] = createRewriteCssImportsPlugins({
+      generateTailwindCss,
+      onTailwindRootCss,
+      shouldOwnTailwindGeneration: true,
+      shouldRewrite: false,
+      weappTailwindcssDirPosix: '/virtual/weapp-tailwindcss',
+    })
+    const transform = getTransformHandler(rewritePlugin!)
+    const source = '@import "tailwindcss";\n@config "./tailwind.config.js";'
+    const id = '/project/pages/index/index.uvue?vue&type=style&index=0&scoped=abc&lang.css'
+
+    await transform?.(source, id)
+
+    expect(onTailwindRootCss).toHaveBeenCalledWith(id, source)
+    expect(generateTailwindCss).toHaveBeenCalledWith(id, source, expect.anything())
+  })
+
   it('normalizes relative @config directives from scss source files before generation', async () => {
     const generateTailwindCss = vi.fn(async () => undefined)
     const onTailwindRootCss = vi.fn()

--- a/packages/weapp-tailwindcss/test/bundlers/vite-source-candidates-hmr.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-source-candidates-hmr.unit.test.ts
@@ -158,16 +158,7 @@ describe('Vite source candidate HMR transactions', () => {
         expect.objectContaining({ path: '/pages/index.uvue' }),
       ]),
     })
-    expect(wsSend).toHaveBeenCalledWith({
-      type: 'update',
-      updates: expect.arrayContaining([
-        expect.objectContaining({
-          acceptedPath: '/main.css?direct',
-          path: '/main.css?direct',
-          type: 'js-update',
-        }),
-      ]),
-    })
+    expect(wsSend).not.toHaveBeenCalled()
   })
 
   it('keeps a regular candidate update in the same Web source and CSS transaction', async () => {
@@ -228,16 +219,7 @@ describe('Vite source candidate HMR transactions', () => {
 
     expect(result).toEqual([pageModule, cssModule])
     await Promise.resolve()
-    expect(wsSend).toHaveBeenCalledWith({
-      type: 'update',
-      updates: expect.arrayContaining([
-        expect.objectContaining({
-          acceptedPath: '/main.css?direct',
-          path: '/main.css?direct',
-          type: 'js-update',
-        }),
-      ]),
-    })
+    expect(wsSend).not.toHaveBeenCalled()
   })
 
   it('falls back to a full reload for a Nuxt route transaction without the page module', async () => {

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4-source-options.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4-source-options.test.ts
@@ -39,6 +39,29 @@ describe('tailwind v4 source options', () => {
     expect(packageJsonOptions?.cssSources?.[0]?.css).toContain('#tw')
   })
 
+  it('removes Vite request queries before treating css entries as file paths', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-query-entry-'))
+    const cssEntry = path.join(root, 'src/app.css')
+    const missingEntry = path.join(root, 'src/missing.css')
+    await mkdir(path.dirname(cssEntry), { recursive: true })
+    await writeFile(cssEntry, '@import "tailwindcss";')
+
+    const options = normalizeTailwindV4SourceOptions({
+      projectRoot: root,
+      cssEntries: [
+        `${cssEntry}?vue&type=style&index=0&src=true&lang.css`,
+        `${missingEntry}?direct`,
+      ],
+    })
+
+    expect(options?.cssSources?.[0]).toMatchObject({
+      file: cssEntry,
+      base: path.dirname(cssEntry),
+      dependencies: [cssEntry],
+    })
+    expect(options?.cssEntries).toEqual([missingEntry])
+  })
+
   it('normalizes configured source files, bases, and runtime fallbacks', () => {
     const root = path.resolve('/virtual/project')
     const options = normalizeTailwindV4SourceOptions({

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
@@ -1025,6 +1025,12 @@ describe('uni-app-x vite plugins', () => {
     const ensureRuntimeClassSet = vi.fn(async () => new Set(['text-red-500']))
     const invalidateModule = vi.fn()
     const send = vi.fn()
+    const webCssEntryDiagnostics = {
+      dispose: vi.fn(),
+      flush: vi.fn(),
+      observeSourceImports: vi.fn(),
+      requestCheck: vi.fn(),
+    }
     const plugins = createUniAppXPlugins({
       appType: 'uni-app-x',
       customAttributesEntities: [['a-navbar', ['leftClass']]],
@@ -1038,6 +1044,7 @@ describe('uni-app-x vite plugins', () => {
       isWebGeneratorTarget: () => true,
       tailwindRootCssModuleIds: new Set(['/project/main.css']),
       viteProcessedCssSourceFiles: new Set(['/project/main.css']),
+      webCssEntryDiagnostics,
     })
     const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
     const cssPrePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
@@ -1061,6 +1068,8 @@ describe('uni-app-x vite plugins', () => {
       },
     } as unknown as HmrContext
 
+    expect(nvuePlugin?.handleHotUpdate).toMatchObject({ order: 'post' })
+
     await nvuePlugin!.buildStart?.()
     ensureRuntimeClassSet.mockClear()
     transformUVueMock.mockImplementation((_code, _id, _jsHandler, _runtimeSet, options) => {
@@ -1074,6 +1083,7 @@ describe('uni-app-x vite plugins', () => {
     expect(ensureRuntimeClassSet).toHaveBeenCalledWith(true)
     expect(invalidateModule).toHaveBeenCalledWith(styleModule)
     expect(send).not.toHaveBeenCalled()
+    expect(webCssEntryDiagnostics.requestCheck).toHaveBeenCalledTimes(1)
     const styleResult = await getTransformHandler(cssPrePlugin)?.call(
       cssPrePlugin,
       '.author { color: red; }',
@@ -1081,6 +1091,73 @@ describe('uni-app-x vite plugins', () => {
     ) as TransformResult
     expect(styleResult).toEqual({
       code: '.author { color: red; }\n.wtu-hmr { @apply text-red-500; }\n',
+      map: null,
+    })
+
+    await nvuePlugin!.buildEnd?.()
+    await nvuePlugin!.closeBundle?.()
+    expect(webCssEntryDiagnostics.flush).toHaveBeenCalledTimes(1)
+    expect(webCssEntryDiagnostics.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for concurrent SFC local style collection before transforming its style module', async () => {
+    let releaseCandidates!: () => void
+    const candidatesReady = new Promise<void>((resolve) => {
+      releaseCandidates = resolve
+    })
+    const registerModuleGraphCandidates = vi.fn(async () => {
+      await candidatesReady
+      return new Set(['bg-primary'])
+    })
+    const plugins = createUniAppXPlugins({
+      appType: 'uni-app-x',
+      customAttributesEntities: [],
+      disabledDefaultTemplateHandler: false,
+      mainCssChunkMatcher: vi.fn(() => true),
+      registerModuleGraphCandidates,
+      runtimeState: { readyPromise: Promise.resolve() },
+      styleHandler: vi.fn(),
+      jsHandler: vi.fn(),
+      ensureRuntimeClassSet: vi.fn(async () => new Set(['bg-primary'])),
+      getResolvedConfig: () => ({ command: 'serve', root: '/project' } as ResolvedConfig),
+      isWebGeneratorTarget: () => true,
+      uniAppX: {
+        enabled: true,
+        componentLocalStyles: {
+          enabled: true,
+          onlyWhenStyleIsolationVersion2: false,
+        },
+      },
+    })
+    const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
+    const cssPrePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
+    transformUVueMock.mockImplementation((_code, _id, _jsHandler, _runtimeSet, options) => {
+      const bridge = (options as { onWebLocalStyleRules?: (rules: string) => void }).onWebLocalStyleRules
+      bridge?.('.wtu-concurrent { @apply bg-primary; }\n')
+      return { code: 'transformed', map: null } as TransformResult
+    })
+
+    const sfcTransform = getTransformHandler(nvuePlugin)?.call(
+      nvuePlugin,
+      '<template><view class="bg-primary" /></template><style scoped>.author { color: red; }</style>',
+      '/project/pages/index/index.uvue',
+    )
+    await vi.waitFor(() => expect(registerModuleGraphCandidates).toHaveBeenCalled())
+    let styleTransformSettled = false
+    const styleTransform = getTransformHandler(cssPrePlugin)?.call(
+      cssPrePlugin,
+      '.author { color: red; }',
+      '/project/pages/index/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
+    ).finally(() => {
+      styleTransformSettled = true
+    })
+    await Promise.resolve()
+    expect(styleTransformSettled).toBe(false)
+
+    releaseCandidates()
+    await sfcTransform
+    await expect(styleTransform).resolves.toEqual({
+      code: '.author { color: red; }\n.wtu-concurrent { @apply bg-primary; }\n',
       map: null,
     })
   })


### PR DESCRIPTION
## 变更

- 在 uni-app x Web 已生成 `wtu-*`、但配置的 `cssEntries` 没有进入真实 Vite 样式构建链路时输出一次可操作告警
- 修复 scoped SFC 导入 Tailwind 根样式时 `@config` 相对路径按页面目录解析的问题，并保留页面局部 `@apply` 规则
- 串行化同一物理样式文件的生成任务，按模块身份过滤乱序 HMR，并对被丢弃的陈旧样式发送严格递增时间戳的纠正更新
- 扩展 HBuilderX Web E2E，覆盖 `@reference` 切换为 `@import` 后紧邻页面与主题更新的竞态

## 根因

`cssEntries` 只负责生成器入口识别，不等同于 Vite import；因此局部类可以生成，但承载 `@theme` 变量的 CSS 不一定进入浏览器。scoped SFC 的预处理结果又丢失了根入口的配置基准，且 uni-app x 会为相邻源码写入产生重叠、乱序的 style HMR 事务，旧事务可能覆盖新规则。

## 验证

- `pnpm --filter weapp-tailwindcss test`
- `pnpm --filter weapp-tailwindcss lint`
- `pnpm typecheck`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm repo:check`
- `E2E_HBUILDERX_LOCAL=1 E2E_HBUILDERX_CASE_GROUP=web E2E_HBUILDERX_CASE=uni-app-x-hbuilderx-tailwindcss-v4 pnpm exec vitest run --bail=1 -c ./e2e/vitest.e2e.config.ts e2e/hbuilderx-local.test.ts`

Refs #1123