### PR TITLE
perf(vite): 根治 Issue #1127 候选扫描、HMR 与 clean entry 重复工作

### DIFF
--- a/.changeset/quiet-issue-1127.md
+++ b/.changeset/quiet-issue-1127.md
@@ -1,0 +1,7 @@
+---
+"weapp-tailwindcss": patch
+---
+
+优化 Vite 小程序构建中的 source-candidates 扫描、批量 HMR 同步和增量 bundle 入口规划，减少重复候选提取与 clean entry 全图处理。
+
+Related to #1127

--- a/benchmark/vite-adapter/issue-1127-source-candidates.md
+++ b/benchmark/vite-adapter/issue-1127-source-candidates.md
@@ -1,0 +1,11 @@
+# Issue #1127 合成基准
+
+使用 `issue-1127-source-candidates.mjs` 可生成 4 个 source root、每个 30 个 Vue SFC 的 120 文件候选扫描夹具：
+
+```bash
+pnpm exec node benchmark/vite-adapter/issue-1127-source-candidates.mjs 4 30
+```
+
+脚本只生成临时源码并输出 JSON，不写入仓库。生成的 roots 可作为 Tailwind v4 `@source` 或项目 source 配置输入；页面/组件 bundle 规模使用现有 Vite adapter 的 `--inject-pages 150`，单文件和多文件 HMR 使用现有 `--project-file` 与 benchmark 运行器。
+
+建议记录 optimized/legacy 两组的 cold build、warm incremental、单文件 HMR、多文件 HMR median/P95，并沿用仓库已有 5% regression guard。

--- a/benchmark/vite-adapter/issue-1127-source-candidates.mjs
+++ b/benchmark/vite-adapter/issue-1127-source-candidates.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+const packageCount = Number(process.argv[2] ?? 4)
+const filesPerPackage = Number(process.argv[3] ?? 30)
+const root = await fs.mkdtemp(path.join(os.tmpdir(), 'weapp-tw-issue-1127-'))
+const kinds = { page: 0, component: 0, subpackage: 0 }
+
+for (let packageIndex = 0; packageIndex < packageCount; packageIndex++) {
+  const packageRoot = path.join(root, `package-${packageIndex + 1}`, 'src')
+  await fs.mkdir(packageRoot, { recursive: true })
+  for (let fileIndex = 0; fileIndex < filesPerPackage; fileIndex++) {
+    const kind = fileIndex % 10 === 0 ? 'subpackage' : fileIndex % 3 === 0 ? 'page' : 'component'
+    const relativeDir = kind === 'subpackage'
+      ? path.join('subpackage', `pkg-${fileIndex + 1}`, 'pages')
+      : kind === 'page' ? path.join('pages') : path.join('components')
+    const file = path.join(packageRoot, relativeDir, `${kind}-${fileIndex + 1}.vue`)
+    const color = (fileIndex + packageIndex) % 2 === 0 ? 'text-sky-500' : 'text-emerald-500'
+    kinds[kind]++
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, `<template><view class="${color} w-[${fileIndex + 1}px]">issue-1127-${kind}</view></template>\n`)
+  }
+}
+
+process.stdout.write(`${JSON.stringify({
+  files: packageCount * filesPerPackage,
+  kinds,
+  packageCount,
+  root,
+  sourceRoots: Array.from({ length: packageCount }, (_, index) => path.join(root, `package-${index + 1}`, 'src')),
+})}\n`)

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/snapshot.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/snapshot.ts
@@ -1,0 +1,71 @@
+import type { SourceCandidateCollectorSnapshot } from './types-and-cache'
+import { mergeSourcesByPriority } from './source-priority'
+
+type CandidateMap = Map<string, Set<string>>
+type SourceMap = Map<string, string>
+
+interface SnapshotMaps {
+  candidatesById: CandidateMap
+  scanCandidatesById: CandidateMap
+  transformCandidatesById: CandidateMap
+  cssCandidatesById: CandidateMap
+  moduleCandidatesById: CandidateMap
+  scanSourceById: SourceMap
+  transformSourceById: SourceMap
+  cssSourceById: SourceMap
+  moduleSourceById: SourceMap
+  inlineIncludedCandidates: Set<string>
+  inlineExcludedCandidates: Set<string>
+}
+
+export function createCandidateSnapshot(maps: SnapshotMaps): SourceCandidateCollectorSnapshot {
+  return {
+    candidatesById: [...maps.candidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
+    cssCandidatesById: [...maps.cssCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
+    cssSourceById: [...maps.cssSourceById.entries()],
+    moduleCandidatesById: [...maps.moduleCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
+    moduleSourceById: [...maps.moduleSourceById.entries()],
+    scanCandidatesById: [...maps.scanCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
+    scanSourceById: [...maps.scanSourceById.entries()],
+    sourceById: [...mergeSourcesByPriority(maps.moduleSourceById, maps.transformSourceById, maps.cssSourceById, maps.scanSourceById).entries()],
+    transformCandidatesById: [...maps.transformCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
+    transformSourceById: [...maps.transformSourceById.entries()],
+    inlineExcludedCandidates: [...maps.inlineExcludedCandidates],
+    inlineIncludedCandidates: [...maps.inlineIncludedCandidates],
+  }
+}
+
+export function restoreCandidateSnapshot(maps: SnapshotMaps, snapshot: SourceCandidateCollectorSnapshot, clear: () => void, recompute: (id: string) => void, setInlineCandidates: (included: Set<string>, excluded: Set<string>) => void) {
+  clear()
+  setInlineCandidates(new Set(snapshot.inlineIncludedCandidates), new Set(snapshot.inlineExcludedCandidates))
+  const restoreCandidates = (target: CandidateMap, entries: Array<[string, string[]]> | undefined) => {
+    for (const [id, candidates] of entries ?? []) {
+      const candidateSet = new Set(candidates)
+      if (candidateSet.size > 0) {
+        target.set(id, candidateSet)
+      }
+    }
+  }
+  restoreCandidates(maps.scanCandidatesById, snapshot.scanCandidatesById ?? snapshot.candidatesById)
+  restoreCandidates(maps.transformCandidatesById, snapshot.transformCandidatesById)
+  restoreCandidates(maps.cssCandidatesById, snapshot.cssCandidatesById)
+  restoreCandidates(maps.moduleCandidatesById, snapshot.moduleCandidatesById)
+  const restoreSources = (target: SourceMap, entries: Array<[string, string]> | undefined) => {
+    for (const [id, source] of entries ?? []) {
+      target.set(id, source)
+    }
+  }
+  restoreSources(maps.scanSourceById, snapshot.scanSourceById ?? snapshot.sourceById)
+  restoreSources(maps.transformSourceById, snapshot.transformSourceById)
+  restoreSources(maps.cssSourceById, snapshot.cssSourceById)
+  restoreSources(maps.moduleSourceById, snapshot.moduleSourceById)
+  const ids = new Set([
+    ...maps.scanCandidatesById.keys(),
+    ...maps.transformCandidatesById.keys(),
+    ...maps.cssCandidatesById.keys(),
+    ...maps.moduleCandidatesById.keys(),
+  ])
+  for (const id of ids) {
+    recompute(id)
+  }
+}

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/source-priority.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/source-priority.ts
@@ -1,0 +1,21 @@
+export function mergeSourcesByPriority(
+  moduleSourceById: Map<string, string>,
+  transformSourceById: Map<string, string>,
+  cssSourceById: Map<string, string>,
+  scanSourceById: Map<string, string>,
+) {
+  const sources = new Map<string, string>()
+  for (const [id, source] of moduleSourceById) {
+    sources.set(id, source)
+  }
+  for (const [id, source] of transformSourceById) {
+    sources.set(id, source)
+  }
+  for (const [id, source] of cssSourceById) {
+    sources.set(id, source)
+  }
+  for (const [id, source] of scanSourceById) {
+    sources.set(id, source)
+  }
+  return sources
+}

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/store.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/store.ts
@@ -1,9 +1,32 @@
 import type { ScanSourceCandidateRootOptions, SourceCandidateCollectorOptions, SourceCandidateCollectorSnapshot, SourceCandidateFilterOptions, SourceCandidateStore } from './types-and-cache'
 import type { TailwindInlineSourceCandidates, TailwindSourceEntry } from '@/tailwindcss/source-scan'
 import { readFile } from 'node:fs/promises'
-import { isFileExcludedByTailwindSourceEntries, isFileMatchedByTailwindSourceEntries, resolveSourceScanPath } from '@/tailwindcss/source-scan'
+import { resolveSourceScanPath } from '@/tailwindcss/source-scan'
 import { resolveSourceCandidateScanFiles } from './scan-root'
+import { createCandidateSnapshot, restoreCandidateSnapshot } from './snapshot'
+import { mergeSourcesByPriority } from './source-priority'
 import { addCandidateSet, cleanUrl, createSourceCandidateContentCacheKey, diffCandidateSets, extractCandidates, isSourceCandidateRequest, removeCandidateSet, resolveSourceCandidateExtension, sourceCandidateContentCache } from './types-and-cache'
+import { collectCandidateSources, collectCandidateValues } from './views'
+
+const SOURCE_CANDIDATE_FILE_MEMO_MAX = 4096
+
+interface FileCandidateMemo {
+  extension: string
+  source: string
+  candidates: Set<string>
+}
+
+function areSetsEqual(left: Set<string> | undefined, right: Set<string>) {
+  if (!left || left.size !== right.size) {
+    return false
+  }
+  for (const value of right) {
+    if (!left.has(value)) {
+      return false
+    }
+  }
+  return true
+}
 
 export function createSourceCandidateStore(options: SourceCandidateCollectorOptions = {}): SourceCandidateStore {
   const candidatesById = new Map<string, Set<string>>()
@@ -16,10 +39,18 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
   const cssSourceById = new Map<string, string>()
   const moduleSourceById = new Map<string, string>()
   const candidateCount = new Map<string, number>()
+  const fileCandidateMemo = new Map<string, FileCandidateMemo>()
   let inlineIncludedCandidates = new Set<string>()
   let inlineExcludedCandidates = new Set<string>()
+  let revision = 0
 
-  async function resolveCandidates(source: string, extension: string) {
+  async function resolveCandidates(id: string, source: string, extension: string) {
+    const normalizedId = cleanUrl(id)
+    const memoKey = `${normalizedId}\0${extension}`
+    const memo = fileCandidateMemo.get(memoKey)
+    if (memo?.source === source) {
+      return new Set(memo.candidates)
+    }
     const contentCacheKey = createSourceCandidateContentCacheKey(
       extension,
       source,
@@ -29,13 +60,26 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
       options.extractor,
     )
     const cachedCandidates = sourceCandidateContentCache.get(contentCacheKey)
-    if (cachedCandidates) {
-      return new Set(cachedCandidates)
+    const nextCandidates = cachedCandidates
+      ? new Set(cachedCandidates)
+      : await extractCandidates(source, extension, options)
+    if (!cachedCandidates) {
+      sourceCandidateContentCache.set(contentCacheKey, [...nextCandidates])
     }
-
-    const nextCandidates = await extractCandidates(source, extension, options)
-    sourceCandidateContentCache.set(contentCacheKey, [...nextCandidates])
-    return nextCandidates
+    fileCandidateMemo.delete(memoKey)
+    fileCandidateMemo.set(memoKey, {
+      candidates: new Set(nextCandidates),
+      extension,
+      source,
+    })
+    while (fileCandidateMemo.size > SOURCE_CANDIDATE_FILE_MEMO_MAX) {
+      const oldest = fileCandidateMemo.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      fileCandidateMemo.delete(oldest)
+    }
+    return new Set(nextCandidates)
   }
 
   function isCandidateVisible(candidate: string) {
@@ -57,31 +101,43 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
 
   async function sync(id: string, source: string) {
     const normalizedId = cleanUrl(id)
+    if (scanSourceById.get(normalizedId) !== source) {
+      revision++
+    }
     scanSourceById.set(normalizedId, source)
     const extension = resolveSourceCandidateExtension(normalizedId)
-    replaceScanLayer(normalizedId, await resolveCandidates(source, extension))
+    replaceScanLayer(normalizedId, await resolveCandidates(normalizedId, source, extension))
   }
 
   async function syncCss(id: string, source: string) {
     const normalizedId = cleanUrl(id)
+    if (cssSourceById.get(normalizedId) !== source) {
+      revision++
+    }
     cssSourceById.set(normalizedId, source)
-    replaceCssLayer(normalizedId, await resolveCandidates(source, 'css'))
+    replaceCssLayer(normalizedId, await resolveCandidates(normalizedId, source, 'css'))
   }
 
   async function syncModuleSource(id: string, source: string) {
     const normalizedId = cleanUrl(id)
+    if (moduleSourceById.get(normalizedId) !== source) {
+      revision++
+    }
     moduleSourceById.set(normalizedId, source)
     const extension = resolveSourceCandidateExtension(normalizedId)
-    const candidates = await resolveCandidates(source, extension)
+    const candidates = await resolveCandidates(normalizedId, source, extension)
     replaceModuleLayer(normalizedId, candidates)
     return new Set(candidates)
   }
 
   async function merge(id: string, source: string) {
     const normalizedId = cleanUrl(id)
+    if (transformSourceById.get(normalizedId) !== source) {
+      revision++
+    }
     transformSourceById.set(normalizedId, source)
     const extension = resolveSourceCandidateExtension(normalizedId)
-    replaceTransformLayer(normalizedId, await resolveCandidates(source, extension))
+    replaceTransformLayer(normalizedId, await resolveCandidates(normalizedId, source, extension))
   }
 
   async function syncFile(id: string) {
@@ -105,7 +161,12 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     const normalizedId = cleanUrl(id)
     const previousFileCandidates = new Set(candidatesById.get(normalizedId) ?? [])
     const extension = resolveSourceCandidateExtension(normalizedId)
-    const nextCandidates = await resolveCandidates(source, extension)
+    const layerStateChanged = scanSourceById.get(normalizedId) !== source
+      || (extension !== 'css' && (transformSourceById.has(normalizedId) || cssSourceById.has(normalizedId) || moduleSourceById.has(normalizedId)))
+    if (layerStateChanged) {
+      revision++
+    }
+    const nextCandidates = await resolveCandidates(normalizedId, source, extension)
     const affectedCandidates = new Set([
       ...previousFileCandidates,
       ...nextCandidates,
@@ -165,6 +226,10 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
   function replaceFinal(id: string, nextCandidates: Set<string>) {
     const normalizedId = cleanUrl(id)
     const previousCandidates = candidatesById.get(normalizedId)
+    if (areSetsEqual(previousCandidates, nextCandidates)) {
+      return
+    }
+    revision++
     if (previousCandidates) {
       removeCandidateSet(candidateCount, previousCandidates)
       candidatesById.delete(normalizedId)
@@ -232,12 +297,26 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
   }
 
   function syncInline(inlineCandidates: TailwindInlineSourceCandidates | undefined) {
-    inlineIncludedCandidates = new Set(inlineCandidates?.included ?? [])
-    inlineExcludedCandidates = new Set(inlineCandidates?.excluded ?? [])
+    const nextIncluded = new Set(inlineCandidates?.included ?? [])
+    const nextExcluded = new Set(inlineCandidates?.excluded ?? [])
+    if (!areSetsEqual(inlineIncludedCandidates, nextIncluded) || !areSetsEqual(inlineExcludedCandidates, nextExcluded)) {
+      revision++
+    }
+    inlineIncludedCandidates = nextIncluded
+    inlineExcludedCandidates = nextExcluded
   }
 
   function remove(id: string) {
     const normalizedId = cleanUrl(id)
+    const hadState = candidatesById.has(normalizedId)
+      || scanCandidatesById.has(normalizedId)
+      || transformCandidatesById.has(normalizedId)
+      || cssCandidatesById.has(normalizedId)
+      || moduleCandidatesById.has(normalizedId)
+      || scanSourceById.has(normalizedId)
+      || transformSourceById.has(normalizedId)
+      || cssSourceById.has(normalizedId)
+      || moduleSourceById.has(normalizedId)
     const affectedCandidates = new Set(candidatesById.get(normalizedId) ?? [])
     const previousVisibleCandidates = collectVisibleCandidates(affectedCandidates)
     scanCandidatesById.delete(normalizedId)
@@ -248,12 +327,21 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     transformSourceById.delete(normalizedId)
     cssSourceById.delete(normalizedId)
     moduleSourceById.delete(normalizedId)
+    for (const key of fileCandidateMemo.keys()) {
+      if (key.startsWith(`${normalizedId}\0`)) {
+        fileCandidateMemo.delete(key)
+      }
+    }
     const previousCandidates = candidatesById.get(normalizedId)
     if (!previousCandidates) {
+      if (hadState) {
+        revision++
+      }
       return diffCandidateSets(previousVisibleCandidates, new Set())
     }
     removeCandidateSet(candidateCount, previousCandidates)
     candidatesById.delete(normalizedId)
+    revision++
     return diffCandidateSets(
       previousVisibleCandidates,
       collectVisibleCandidates(affectedCandidates),
@@ -269,87 +357,25 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
   }
 
   function sources() {
-    return mergeSourcesByPriority().entries()
+    return mergeSourcesByPriority(moduleSourceById, transformSourceById, cssSourceById, scanSourceById).entries()
   }
 
   function values() {
-    const values = new Set([
-      ...candidateCount.keys(),
-      ...inlineIncludedCandidates,
-    ])
-    for (const candidate of inlineExcludedCandidates) {
-      values.delete(candidate)
-    }
-    return values
+    return collectCandidateValues({ candidatesById, moduleCandidatesById, candidateCount, inlineIncludedCandidates, inlineExcludedCandidates })
   }
 
   function valuesForEntries(entries: TailwindSourceEntry[] | undefined, options: SourceCandidateFilterOptions = {}) {
-    if (entries === undefined) {
-      if (!options.excludeEntries?.length) {
-        return values()
-      }
-    }
-    const filtered = new Set<string>()
-    for (const [id, candidates] of candidatesById) {
-      const isActiveModule = moduleCandidatesById.has(id)
-      if (entries !== undefined && (isActiveModule
-        ? isFileExcludedByTailwindSourceEntries(id, entries)
-        : entries.length === 0 || !isFileMatchedByTailwindSourceEntries(id, entries))) {
-        continue
-      }
-      if (options.excludeEntries?.length && isFileMatchedByTailwindSourceEntries(id, options.excludeEntries)) {
-        continue
-      }
-      for (const candidate of candidates) {
-        filtered.add(candidate)
-      }
-    }
-    for (const candidate of inlineIncludedCandidates) {
-      filtered.add(candidate)
-    }
-    for (const candidate of inlineExcludedCandidates) {
-      filtered.delete(candidate)
-    }
-    return filtered
+    return collectCandidateValues({ candidatesById, moduleCandidatesById, candidateCount, inlineIncludedCandidates, inlineExcludedCandidates }, entries, options.excludeEntries)
   }
 
   function sourcesForEntries(entries: TailwindSourceEntry[] | undefined, options: SourceCandidateFilterOptions = {}) {
-    const sources = new Map<string, Set<string>>()
-    const addCandidateSource = (candidate: string, id: string | undefined) => {
-      let candidateSources = sources.get(candidate)
-      if (!candidateSources) {
-        candidateSources = new Set()
-        sources.set(candidate, candidateSources)
-      }
-      if (id) {
-        candidateSources.add(id)
-      }
-    }
-
-    for (const [id, candidates] of candidatesById) {
-      const isActiveModule = moduleCandidatesById.has(id)
-      if (entries !== undefined && (isActiveModule
-        ? isFileExcludedByTailwindSourceEntries(id, entries)
-        : entries.length === 0 || !isFileMatchedByTailwindSourceEntries(id, entries))) {
-        continue
-      }
-      if (options.excludeEntries?.length && isFileMatchedByTailwindSourceEntries(id, options.excludeEntries)) {
-        continue
-      }
-      for (const candidate of candidates) {
-        addCandidateSource(candidate, id)
-      }
-    }
-    for (const candidate of inlineIncludedCandidates) {
-      addCandidateSource(candidate, undefined)
-    }
-    for (const candidate of inlineExcludedCandidates) {
-      sources.delete(candidate)
-    }
-    return sources
+    return collectCandidateSources({ candidatesById, moduleCandidatesById, candidateCount, inlineIncludedCandidates, inlineExcludedCandidates }, entries, options.excludeEntries)
   }
 
   function clear() {
+    if (candidateCount.size > 0 || fileCandidateMemo.size > 0 || inlineIncludedCandidates.size > 0 || inlineExcludedCandidates.size > 0) {
+      revision++
+    }
     candidatesById.clear()
     scanCandidatesById.clear()
     transformCandidatesById.clear()
@@ -362,93 +388,40 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     candidateCount.clear()
     inlineIncludedCandidates.clear()
     inlineExcludedCandidates.clear()
+    fileCandidateMemo.clear()
   }
 
   function clearScan() {
+    const hadState = scanCandidatesById.size > 0 || inlineIncludedCandidates.size > 0 || inlineExcludedCandidates.size > 0
     for (const id of scanCandidatesById.keys()) {
       scanCandidatesById.delete(id)
       recompute(id)
     }
     inlineIncludedCandidates.clear()
     inlineExcludedCandidates.clear()
+    if (hadState) {
+      revision++
+    }
   }
 
   function resetScan() {
+    const hadState = inlineIncludedCandidates.size > 0 || inlineExcludedCandidates.size > 0
     inlineIncludedCandidates.clear()
     inlineExcludedCandidates.clear()
+    if (hadState) {
+      revision++
+    }
   }
 
   function snapshot(): SourceCandidateCollectorSnapshot {
-    return {
-      candidatesById: [...candidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
-      cssCandidatesById: [...cssCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
-      cssSourceById: [...cssSourceById.entries()],
-      moduleCandidatesById: [...moduleCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
-      moduleSourceById: [...moduleSourceById.entries()],
-      scanCandidatesById: [...scanCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
-      scanSourceById: [...scanSourceById.entries()],
-      sourceById: [...mergeSourcesByPriority().entries()],
-      transformCandidatesById: [...transformCandidatesById.entries()].map(([id, candidates]) => [id, [...candidates]]),
-      transformSourceById: [...transformSourceById.entries()],
-      inlineExcludedCandidates: [...inlineExcludedCandidates],
-      inlineIncludedCandidates: [...inlineIncludedCandidates],
-    }
+    return createCandidateSnapshot({ candidatesById, scanCandidatesById, transformCandidatesById, cssCandidatesById, moduleCandidatesById, scanSourceById, transformSourceById, cssSourceById, moduleSourceById, inlineIncludedCandidates, inlineExcludedCandidates })
   }
 
   function restore(snapshot: SourceCandidateCollectorSnapshot) {
-    clear()
-    inlineExcludedCandidates = new Set(snapshot.inlineExcludedCandidates)
-    inlineIncludedCandidates = new Set(snapshot.inlineIncludedCandidates)
-    const scanEntries = snapshot.scanCandidatesById ?? snapshot.candidatesById
-    for (const [id, candidates] of scanEntries) {
-      const candidateSet = new Set(candidates)
-      if (candidateSet.size === 0) {
-        continue
-      }
-      scanCandidatesById.set(id, candidateSet)
-    }
-    for (const [id, candidates] of snapshot.transformCandidatesById ?? []) {
-      const candidateSet = new Set(candidates)
-      if (candidateSet.size === 0) {
-        continue
-      }
-      transformCandidatesById.set(id, candidateSet)
-    }
-    for (const [id, candidates] of snapshot.cssCandidatesById ?? []) {
-      const candidateSet = new Set(candidates)
-      if (candidateSet.size === 0) {
-        continue
-      }
-      cssCandidatesById.set(id, candidateSet)
-    }
-    for (const [id, candidates] of snapshot.moduleCandidatesById ?? []) {
-      const candidateSet = new Set(candidates)
-      if (candidateSet.size === 0) {
-        continue
-      }
-      moduleCandidatesById.set(id, candidateSet)
-    }
-    for (const [id, source] of snapshot.scanSourceById ?? snapshot.sourceById ?? []) {
-      scanSourceById.set(id, source)
-    }
-    for (const [id, source] of snapshot.transformSourceById ?? []) {
-      transformSourceById.set(id, source)
-    }
-    for (const [id, source] of snapshot.cssSourceById ?? []) {
-      cssSourceById.set(id, source)
-    }
-    for (const [id, source] of snapshot.moduleSourceById ?? []) {
-      moduleSourceById.set(id, source)
-    }
-    const ids = new Set([
-      ...scanCandidatesById.keys(),
-      ...transformCandidatesById.keys(),
-      ...cssCandidatesById.keys(),
-      ...moduleCandidatesById.keys(),
-    ])
-    for (const id of ids) {
-      recompute(id)
-    }
+    restoreCandidateSnapshot({ candidatesById, scanCandidatesById, transformCandidatesById, cssCandidatesById, moduleCandidatesById, scanSourceById, transformSourceById, cssSourceById, moduleSourceById, inlineIncludedCandidates, inlineExcludedCandidates }, snapshot, clear, recompute, (included, excluded) => {
+      inlineIncludedCandidates = included
+      inlineExcludedCandidates = excluded
+    })
   }
 
   return {
@@ -474,22 +447,6 @@ export function createSourceCandidateStore(options: SourceCandidateCollectorOpti
     clearScan,
     resetScan,
     clear,
-  }
-
-  function mergeSourcesByPriority() {
-    const sources = new Map<string, string>()
-    for (const [id, source] of moduleSourceById) {
-      sources.set(id, source)
-    }
-    for (const [id, source] of transformSourceById) {
-      sources.set(id, source)
-    }
-    for (const [id, source] of cssSourceById) {
-      sources.set(id, source)
-    }
-    for (const [id, source] of scanSourceById) {
-      sources.set(id, source)
-    }
-    return sources
+    getRevision: () => revision,
   }
 }

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/types-and-cache.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/types-and-cache.ts
@@ -29,6 +29,7 @@ export interface SourceCandidateStore {
   clearScan: () => void
   resetScan: () => void
   clear: () => void
+  getRevision: () => number
 }
 
 export interface SourceCandidateCollector extends SourceCandidateStore {}

--- a/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/views.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/shared/source-candidates/views.ts
@@ -1,0 +1,79 @@
+import type { TailwindSourceEntry } from '@/tailwindcss/source-scan'
+import { isFileExcludedByTailwindSourceEntries, isFileMatchedByTailwindSourceEntries } from '@/tailwindcss/source-scan'
+
+type CandidateMap = Map<string, Set<string>>
+
+interface CandidateViewOptions {
+  candidatesById: CandidateMap
+  moduleCandidatesById: CandidateMap
+  candidateCount: Map<string, number>
+  inlineIncludedCandidates: Set<string>
+  inlineExcludedCandidates: Set<string>
+}
+
+function isIncludedFile(id: string, isActiveModule: boolean, entries: TailwindSourceEntry[] | undefined, excludeEntries: TailwindSourceEntry[] | undefined) {
+  if (entries !== undefined && (isActiveModule
+    ? isFileExcludedByTailwindSourceEntries(id, entries)
+    : entries.length === 0 || !isFileMatchedByTailwindSourceEntries(id, entries))) {
+    return false
+  }
+  return !(excludeEntries?.length && isFileMatchedByTailwindSourceEntries(id, excludeEntries))
+}
+
+export function collectCandidateValues(view: CandidateViewOptions, entries?: TailwindSourceEntry[], excludeEntries?: TailwindSourceEntry[]) {
+  if (entries === undefined && !excludeEntries?.length) {
+    const values = new Set(view.candidateCount.keys())
+    for (const candidate of view.inlineIncludedCandidates) {
+      values.add(candidate)
+    }
+    for (const candidate of view.inlineExcludedCandidates) {
+      values.delete(candidate)
+    }
+    return values
+  }
+  const filtered = new Set<string>()
+  for (const [id, candidates] of view.candidatesById) {
+    if (!isIncludedFile(id, view.moduleCandidatesById.has(id), entries, excludeEntries)) {
+      continue
+    }
+    for (const candidate of candidates) {
+      filtered.add(candidate)
+    }
+  }
+  for (const candidate of view.inlineIncludedCandidates) {
+    filtered.add(candidate)
+  }
+  for (const candidate of view.inlineExcludedCandidates) {
+    filtered.delete(candidate)
+  }
+  return filtered
+}
+
+export function collectCandidateSources(view: CandidateViewOptions, entries?: TailwindSourceEntry[], excludeEntries?: TailwindSourceEntry[]) {
+  const sources = new Map<string, Set<string>>()
+  const addCandidateSource = (candidate: string, id?: string) => {
+    let candidateSources = sources.get(candidate)
+    if (!candidateSources) {
+      candidateSources = new Set()
+      sources.set(candidate, candidateSources)
+    }
+    if (id) {
+      candidateSources.add(id)
+    }
+  }
+  for (const [id, candidates] of view.candidatesById) {
+    if (!isIncludedFile(id, view.moduleCandidatesById.has(id), entries, excludeEntries)) {
+      continue
+    }
+    for (const candidate of candidates) {
+      addCandidateSource(candidate, id)
+    }
+  }
+  for (const candidate of view.inlineIncludedCandidates) {
+    addCandidateSource(candidate)
+  }
+  for (const candidate of view.inlineExcludedCandidates) {
+    sources.delete(candidate)
+  }
+  return sources
+}

--- a/packages/weapp-tailwindcss/src/bundlers/vite/bundle-state.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/bundle-state.ts
@@ -32,7 +32,15 @@ export interface BundleSnapshot extends RuntimeCompilationSnapshot<BundleStateEn
   jsEntries: Map<string, OutputEntry>
 }
 
-export type BundleBuildState = RuntimeCompilationBuildState
+interface BundleEntryMetadata {
+  outputType: OutputAsset['type'] | OutputChunk['type']
+  runtimeCandidate: boolean
+  type: EntryType
+}
+
+export interface BundleBuildState extends RuntimeCompilationBuildState {
+  entryMetadataByFile: Map<string, BundleEntryMetadata>
+}
 
 export interface BuildBundleSnapshotOptions {
   hasOmittedKnownFiles?: boolean | undefined
@@ -49,7 +57,10 @@ export function runWithRemovedBundleFiles<T>(
 }
 
 export function createBundleBuildState(): BundleBuildState {
-  return createRuntimeCompilationBuildState()
+  return {
+    ...createRuntimeCompilationBuildState(),
+    entryMetadataByFile: new Map(),
+  }
 }
 
 function readEntrySource(output: OutputAsset | OutputChunk) {
@@ -83,19 +94,30 @@ function collectBundleEntries(
   bundle: Record<string, OutputAsset | OutputChunk>,
   opts: InternalUserDefinedOptions,
   outDir: string,
+  metadataByFile?: Map<string, BundleEntryMetadata>,
 ) {
   const jsEntries = new Map<string, OutputEntry>()
   const entries: BundleStateEntry[] = []
 
   for (const [file, output] of Object.entries(bundle)) {
-    const type = classifyBundleEntry(file, opts)
+    const cachedMetadata = metadataByFile?.get(file)
+    const type = cachedMetadata?.outputType === output.type
+      ? cachedMetadata.type
+      : classifyBundleEntry(file, opts)
     const entry: BundleStateEntry = {
       file,
       output,
       source: readEntrySource(output),
       type,
     }
-    entry.runtimeCandidate = isRuntimeCandidateBundleEntry(entry)
+    entry.runtimeCandidate = cachedMetadata?.outputType === output.type
+      ? cachedMetadata.runtimeCandidate
+      : isRuntimeCandidateBundleEntry(entry)
+    metadataByFile?.set(file, {
+      outputType: output.type,
+      runtimeCandidate: entry.runtimeCandidate === true,
+      type,
+    })
     collectJsEntry(file, output, outDir, jsEntries)
     entries.push(entry)
   }
@@ -114,7 +136,7 @@ export function buildBundleSnapshot(
   forceAll = false,
   options: BuildBundleSnapshotOptions = {},
 ): BundleSnapshot {
-  const { entries, jsEntries } = collectBundleEntries(bundle, opts, outDir)
+  const { entries, jsEntries } = collectBundleEntries(bundle, opts, outDir, state.entryMetadataByFile)
   const snapshot = buildRuntimeCompilationSnapshot(entries, state, {
     computeHash: source => opts.cache.computeHash(source),
     createRuntimeAffectingSignature: createRuntimeAffectingSourceSignature,
@@ -152,4 +174,15 @@ export function updateBundleBuildState(
   options: UpdateRuntimeCompilationBuildStateOptions = {},
 ) {
   updateRuntimeCompilationBuildState(state, snapshot, linkedByEntry, options)
+  for (const file of snapshot.removedFiles) {
+    state.entryMetadataByFile.delete(file)
+  }
+  if (!snapshot.hasOmittedKnownFiles) {
+    const activeFiles = new Set(snapshot.entries.map(entry => entry.file))
+    for (const file of state.entryMetadataByFile.keys()) {
+      if (!activeFiles.has(file)) {
+        state.entryMetadataByFile.delete(file)
+      }
+    }
+  }
 }

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/js-processing.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/js-processing.ts
@@ -44,6 +44,40 @@ interface ProcessJsBundleEntryOptions {
   useIncrementalMode: boolean
 }
 
+interface ReplayCleanJsBundleEntryOptions {
+  cache: GenerateBundleContext['opts']['cache']
+  debug: GenerateBundleContext['debug']
+  entry: BundleStateEntry
+  metrics: BundleMetrics
+  rememberProcessCacheKey: (cacheKey: string, hashKey?: string | number) => void
+  snapshot: BundleSnapshot
+  transformFilterSignature: string
+  transformRuntimeSignature: string
+  useIncrementalMode: boolean
+}
+
+/** 在增量构建中直接回放 clean chunk，避免创建完整 JS 处理任务。 */
+export function replayCleanJsBundleEntry(options: ReplayCleanJsBundleEntryOptions) {
+  const { cache, debug, entry, metrics, rememberProcessCacheKey, snapshot, transformFilterSignature, transformRuntimeSignature, useIncrementalMode } = options
+  if (!useIncrementalMode || entry.output.type !== 'chunk' || snapshot.processFiles.js.has(entry.file)) {
+    return false
+  }
+  const hashKey = `${entry.file}:js`
+  const sourceHash = snapshot.sourceHashByFile.get(entry.file) ?? cache.computeHash(entry.source)
+  const processHash = `${sourceHash}:${transformRuntimeSignature}:transform-filter:${transformFilterSignature}`
+  rememberProcessCacheKey(entry.file, hashKey)
+  const cachedHash = cache.getHashValue(hashKey)
+  const cachedCode = cachedHash?.hash === processHash ? cache.get<string>(entry.file) : undefined
+  if (cachedCode === undefined) {
+    return false
+  }
+  entry.output.code = cachedCode
+  metrics.js.total++
+  metrics.js.cacheHits++
+  debug('js direct replay hit (planned clean): %s', entry.file)
+  return true
+}
+
 export function processJsBundleEntry(options: ProcessJsBundleEntryOptions) {
   const {
     applyLinkedUpdates,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/runtime.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/generate-bundle/runtime.ts
@@ -42,7 +42,7 @@ import { processHtmlBundleEntry } from './html-processing'
 import { createJsEntryResolver } from './js-entries'
 import { createJsHandlerOptionsFactory } from './js-handler-options'
 import { createLinkedUpdateHelpers } from './js-linking'
-import { processJsBundleEntry } from './js-processing'
+import { processJsBundleEntry, replayCleanJsBundleEntry } from './js-processing'
 import { createEmptyMetrics, measureElapsed } from './metrics'
 import { logBundleProcessPlan } from './process-plan'
 import { resolveRememberedCssSourceForTest } from './remembered-css'
@@ -454,6 +454,9 @@ function createGenerateBundleHook(context): any {
       }
       if (!shouldTransformJsBundle) {
         debug('js skip web target: %s', file)
+        continue
+      }
+      if (replayCleanJsBundleEntry({ cache, debug, entry, metrics, rememberProcessCacheKey, snapshot, transformFilterSignature, transformRuntimeSignature, useIncrementalMode })) {
         continue
       }
       processJsBundleEntry({ applyLinkedUpdates, bundle, cache, createHandlerOptions, debug, deferUniAppXStylePlaceholder: opts.appType === 'uni-app-x', disableJsPrecheck: envFlags.disableJsPrecheck, entry, getJsEntry, jsHandler, jsTaskFactories, linkedByEntry, metrics, onUpdate, outDir, processFiles, rememberProcessCacheKey, runtimeSignature, snapshot, transformFilterSignature, shouldSkipAstTransform: transformFilter ? chunk => shouldSkipViteJsChunkTransform(chunk, transformFilter) : void 0, slowJsAstWarnMs: envFlags.slowJsAstWarnMs, timeTask, transformRuntime, transformRuntimeSignature, uniAppX, useIncrementalMode })

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-candidates-plugin.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-candidates-plugin.ts
@@ -115,11 +115,17 @@ export function createFrameworkSourceCandidatesPlugin(options: any, apply?: Plug
         }
         if (change.event === 'delete') {
           const file = cleanUrl(id)
-          const sourceCandidateChange = options.sourceCandidateCollector.remove(file)
-          options.sourceScanSession.cacheCurrent()
-          options.hmrCandidateState.apply(options.hmrCandidateState.createChange(file, sourceCandidateChange, {
-            runtimeAffecting: options.sourceScanSession.isDependency(file),
-          }))
+          if (typeof options.sourceScanSession.queueChangedFile === 'function') {
+            options.sourceScanSession.queueChangedFile({ event: 'delete', id: file })
+            queueMicrotask(() => void options.sourceScanSession.flushChangedFiles())
+          }
+          else {
+            const sourceCandidateChange = options.sourceCandidateCollector.remove(file)
+            options.sourceScanSession.cacheCurrent()
+            options.hmrCandidateState.apply(options.hmrCandidateState.createChange(file, sourceCandidateChange, {
+              runtimeAffecting: options.sourceScanSession.isDependency(file),
+            }))
+          }
           return
         }
         const changedSource = options.shouldOwnTailwindGeneration && isSourceCandidateRequest(id) && isCSSRequest(id)
@@ -129,7 +135,13 @@ export function createFrameworkSourceCandidatesPlugin(options: any, apply?: Plug
           options.rememberOriginalCssLayerSource(id, changedSource)
           await options.refreshTailwindRootCssSource(id, changedSource)
         }
-        await options.sourceScanSession.syncChangedFile(id, changedSource)
+        if (typeof options.sourceScanSession.queueChangedFile === 'function') {
+          options.sourceScanSession.queueChangedFile({ event: change.event === 'create' ? 'create' : 'update', id, source: changedSource })
+          queueMicrotask(() => void options.sourceScanSession.flushChangedFiles())
+        }
+        else {
+          await options.sourceScanSession.syncChangedFile(id, changedSource)
+        }
       }, { emit: false })
     },
     handleHotUpdate: {
@@ -154,7 +166,9 @@ export function createFrameworkSourceCandidatesPlugin(options: any, apply?: Plug
             options.rememberOriginalCssLayerSource(ctx.file, hotSource)
             await options.refreshTailwindRootCssSource(ctx.file, hotSource)
           }
-          const sourceCandidateChange = await options.sourceScanSession.syncChangedFile(ctx.file, hotSource)
+          const sourceCandidateChange = typeof options.sourceScanSession.queueChangedFile === 'function'
+            ? (options.sourceScanSession.queueChangedFile({ event: 'update', id: ctx.file, source: hotSource }), await options.sourceScanSession.flushChangedFiles()).get(cleanUrl(ctx.file))
+            : await options.sourceScanSession.syncChangedFile(ctx.file, hotSource)
           options.sourceScanSession.consumeHotUpdateChange(ctx.file)
           const isWebLikeHotUpdate = options.isCurrentWebLikeStylePlatform()
           let canUseHmrCandidateAppend = false

--- a/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-scan-session.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/shared/framework-source-scan-session.ts
@@ -27,6 +27,11 @@ interface SourceCandidateScanCacheEntry {
   eligibleFiles: string[]
   snapshot: SourceCandidateScanSnapshot
 }
+interface PendingSourceCandidateFileChange {
+  file: string
+  source?: string
+  event: 'create' | 'update' | 'delete'
+}
 type SourceScanResult = NonNullable<Awaited<ReturnType<typeof resolveViteSourceScanEntries>>>
 
 const sourceCandidateScanSnapshotCache = new LRUCache<string, SourceCandidateScanCacheEntry>({
@@ -76,6 +81,11 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
   const pendingSourceCandidateSyncs = new Set<Promise<unknown>>()
   const pendingSourceCandidateSyncByFile = new Map<string, Promise<any>>()
   const pendingHotUpdateChangeByFile = new Map<string, ViteSourceCandidateChange>()
+  const pendingChangedFiles = new Map<string, PendingSourceCandidateFileChange>()
+  let pendingChangedFilesFlush: Promise<Map<string, ViteSourceCandidateChange | undefined>> | undefined
+  let isFlushingChangedFiles = false
+  let cacheDirty = false
+  let cachedCollectorRevision: number | undefined
 
   const normalizeDependency = (file: string) => path.normalize(path.resolve(cleanUrl(file)))
   const isDependency = (file: string) => sourceScanDependencies.has(normalizeDependency(file))
@@ -119,12 +129,24 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     if (!sourceCandidateScanSignature) {
       return
     }
+    if (isFlushingChangedFiles) {
+      cacheDirty = true
+      return
+    }
+    const collectorRevision = options.sourceCandidateCollector.getRevision?.()
+    if (!cacheDirty
+      && cachedCollectorRevision !== undefined
+      && collectorRevision === cachedCollectorRevision) {
+      return
+    }
     const entry = {
       eligibleFiles: [...sourceScanEligibleFiles],
       snapshot: options.sourceCandidateCollector.snapshot(),
     }
     sourceCandidateScanCache.set(sourceCandidateScanSignature, entry)
     sourceCandidateScanSnapshotCache.set(sourceCandidateScanSignature, entry)
+    cachedCollectorRevision = collectorRevision
+    cacheDirty = false
   }
 
   const updateSourceScanMatchers = (eligibleFiles: Iterable<string>) => {
@@ -226,8 +248,17 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
   }
 
   const waitForPendingSyncs = async () => {
-    while (pendingSourceCandidateSyncs.size > 0) {
-      await Promise.all(pendingSourceCandidateSyncs)
+    while (true) {
+      if (!pendingChangedFilesFlush && pendingChangedFiles.size === 0 && pendingSourceCandidateSyncs.size === 0) {
+        break
+      }
+      await pendingChangedFilesFlush
+      if (pendingChangedFiles.size > 0) {
+        await flushChangedFiles()
+      }
+      if (pendingSourceCandidateSyncs.size > 0) {
+        await Promise.all(pendingSourceCandidateSyncs)
+      }
     }
   }
 
@@ -258,7 +289,7 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     return previous
   }
 
-  const syncChangedFile = async (id: string, sourceOverride?: string) => {
+  const syncChangedFileNow = async (id: string, sourceOverride?: string, event: PendingSourceCandidateFileChange['event'] = 'update') => {
     if (!options.shouldOwnTailwindGeneration || !options.isCandidateRequest(id)) {
       return undefined
     }
@@ -298,6 +329,14 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
       return syncChangedFile(id, sourceOverride)
     }
     const previousSource = options.sourceCandidateCollector.source(file)
+    if (event === 'delete') {
+      const change = options.sourceCandidateCollector.remove(file)
+      cacheDirty = true
+      const appliedChange = options.hmrCandidateState.apply(options.hmrCandidateState.createChange(file, change, {
+        runtimeAffecting: runtimeAffectingByDependency,
+      }))
+      return rememberHotUpdateChange(appliedChange)
+    }
     const task = (sourceOverride === undefined
       ? options.sourceCandidateCollector.syncCurrentFile(id)
       : options.sourceCandidateCollector.syncCurrentSource(id, sourceOverride))
@@ -306,7 +345,10 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
         return undefined
       })
       .then((change) => {
-        cacheCurrent()
+        cacheDirty = true
+        if (!isFlushingChangedFiles) {
+          cacheCurrent()
+        }
         const runtimeAffectingBySource = hasFrameworkHmrRuntimeSourceChange(
           file,
           previousSource,
@@ -332,12 +374,61 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     })
   }
 
+  const queueChangedFile = (change: Omit<PendingSourceCandidateFileChange, 'file'> & { id: string }) => {
+    const file = cleanUrl(change.id)
+    const previous = pendingChangedFiles.get(file)
+    if (!previous) {
+      pendingChangedFiles.set(file, { ...change, file })
+      return
+    }
+    previous.event = change.event
+    if (change.source !== undefined) {
+      previous.source = change.source
+    }
+  }
+
+  const flushChangedFiles = async () => {
+    if (pendingChangedFilesFlush) {
+      const activeFlush = pendingChangedFilesFlush
+      const result = await activeFlush
+      return pendingChangedFiles.size > 0 ? flushChangedFiles() : result
+    }
+    if (pendingChangedFiles.size === 0) {
+      return new Map<string, ViteSourceCandidateChange | undefined>()
+    }
+    const changes = [...pendingChangedFiles.values()]
+    pendingChangedFiles.clear()
+    isFlushingChangedFiles = true
+    pendingChangedFilesFlush = Promise.all(changes.map(async change => [
+      change.file,
+      await syncChangedFileNow(change.file, change.source, change.event),
+    ] as const))
+      .then(entries => new Map(entries))
+      .finally(() => {
+        isFlushingChangedFiles = false
+        pendingChangedFilesFlush = undefined
+        cacheCurrent()
+      })
+    return pendingChangedFilesFlush
+  }
+
+  const syncChangedFile = async (id: string, sourceOverride?: string) => {
+    const file = cleanUrl(id)
+    const existingTask = pendingSourceCandidateSyncByFile.get(file)
+    if (existingTask) {
+      await existingTask
+      return syncChangedFile(id, sourceOverride)
+    }
+    return syncChangedFileNow(file, sourceOverride)
+  }
+
   return {
     cacheCurrent,
     consumeHotUpdateChange: (id: string) => pendingHotUpdateChangeByFile.delete(cleanUrl(id)),
     getStats: () => ({
       pendingSourceCandidateSyncByFile: pendingSourceCandidateSyncByFile.size,
       pendingSourceCandidateSyncs: pendingSourceCandidateSyncs.size,
+      pendingChangedFiles: pendingChangedFiles.size,
       pendingHotUpdateChangeByFile: pendingHotUpdateChangeByFile.size,
       sourceCandidateScanCache: sourceCandidateScanCache.size,
     }),
@@ -345,6 +436,8 @@ export function createFrameworkSourceScanSession(options: FrameworkSourceScanSes
     isDependency,
     // 首次 source scan 完成前保留 Vite 原有的 transform 行为；sync() 完成后由统一 matcher 负责边界判断。
     matches: (file: string) => sourceScanMatcher?.(file) ?? true,
+    queueChangedFile,
+    flushChangedFiles,
     shouldDiscoverAutoCssSources,
     sync,
     syncChangedFile,

--- a/packages/weapp-tailwindcss/test/bundlers/vite-bundle-state-cache.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-bundle-state-cache.unit.test.ts
@@ -18,6 +18,26 @@ function createOptions() {
 }
 
 describe('bundlers/vite bundle state cache', () => {
+  it('reuses entry metadata while refreshing the current Rollup output object', () => {
+    const opts = createOptions()
+    const state = createBundleBuildState()
+    const first = buildBundleSnapshot({
+      'assets/index.js': {
+        ...createRollupChunk('const cls = "w-1"'),
+        fileName: 'assets/index.js',
+      },
+    }, opts, '/project/dist', state)
+    expect(state.entryMetadataByFile.get('assets/index.js')).toMatchObject({ type: 'js', outputType: 'chunk' })
+
+    const secondOutput = {
+      ...createRollupChunk('const cls = "w-2"'),
+      fileName: 'assets/index.js',
+    }
+    const second = buildBundleSnapshot({ 'assets/index.js': secondOutput }, opts, '/project/dist', state)
+    expect(second.entries[0]?.output).toBe(secondOutput)
+    expect(second.entries[0]?.type).toBe(first.entries[0]?.type)
+  })
+
   it('reuses runtime-affecting hashes when source hash is unchanged without retaining signatures', () => {
     const opts = createOptions()
     const state = createBundleBuildState()

--- a/packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-framework-source-scan-session.unit.test.ts
@@ -186,4 +186,61 @@ describe('vite framework source scan session', () => {
     expect(extractor).toHaveBeenCalledWith('text-blue-500', 'ts')
     expect(sourceCandidateCollector.values()).toEqual(new Set(['text-blue-500']))
   })
+
+  it('coalesces queued source changes into one flush while preserving the latest source per file', async () => {
+    const { appRoot } = await createTempWorkspace()
+    const firstFile = path.join(appRoot, 'src/First.vue')
+    const secondFile = path.join(appRoot, 'src/Second.vue')
+    await mkdir(path.dirname(firstFile), { recursive: true })
+    await writeFile(firstFile, 'text-old')
+    await writeFile(secondFile, 'text-second')
+    const extractor = vi.fn(async (source: string) => [source])
+    const { session, sourceCandidateCollector } = createSession({ appRoot, extractor })
+    await session.sync()
+    extractor.mockClear()
+
+    session.queueChangedFile({ event: 'update', id: firstFile, source: 'text-intermediate' })
+    session.queueChangedFile({ event: 'update', id: firstFile, source: 'text-latest' })
+    session.queueChangedFile({ event: 'update', id: secondFile, source: 'text-second-next' })
+    const changes = await session.flushChangedFiles()
+
+    expect(extractor).toHaveBeenCalledTimes(2)
+    expect(extractor).toHaveBeenCalledWith('text-latest', 'vue')
+    expect(extractor).toHaveBeenCalledWith('text-second-next', 'vue')
+    expect(changes.size).toBe(2)
+    expect(sourceCandidateCollector.values()).toEqual(new Set(['text-latest', 'text-second-next']))
+  })
+
+  it('waits for a change queued during an active flush before completing the HMR batch', async () => {
+    const { appRoot } = await createTempWorkspace()
+    const file = path.join(appRoot, 'src/Queued.vue')
+    await mkdir(path.dirname(file), { recursive: true })
+    await writeFile(file, 'text-old')
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const extractor = vi.fn(async (source: string) => {
+      if (source === 'queued-first-1127') {
+        await firstBlocked
+      }
+      return [source]
+    })
+    const { session, sourceCandidateCollector } = createSession({ appRoot, extractor })
+    await session.sync()
+    extractor.mockClear()
+
+    session.queueChangedFile({ event: 'update', id: file, source: 'queued-first-1127' })
+    const firstFlush = session.flushChangedFiles()
+    await vi.waitFor(() => expect(extractor).toHaveBeenCalledWith('queued-first-1127', 'vue'))
+    session.queueChangedFile({ event: 'update', id: file, source: 'queued-latest-1127' })
+    const secondFlush = session.flushChangedFiles()
+    releaseFirst()
+    await Promise.all([firstFlush, secondFlush])
+    await session.waitForPendingSyncs()
+
+    expect(extractor).toHaveBeenCalledTimes(2)
+    expect(extractor).toHaveBeenLastCalledWith('queued-latest-1127', 'vue')
+    expect(sourceCandidateCollector.values()).toEqual(new Set(['queued-latest-1127']))
+  })
 })

--- a/packages/weapp-tailwindcss/test/bundlers/vite-js-processing.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-js-processing.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createJsHandlerOptionsFactory } from '@/bundlers/vite/generate-bundle/js-handler-options'
-import { processJsBundleEntry } from '@/bundlers/vite/generate-bundle/js-processing'
+import { processJsBundleEntry, replayCleanJsBundleEntry } from '@/bundlers/vite/generate-bundle/js-processing'
 import { createTransformFilter, createTransformFilterSignature, shouldSkipViteJsChunkTransform } from '@/bundlers/vite/generate-bundle/transform-filter'
 import { createCache } from '@/cache'
 import { createRollupChunk } from './vite-plugin.testkit'
@@ -126,6 +126,38 @@ describe('bundlers/vite js processing', () => {
     expect(chunk.code).toBe(cached)
     expect(jsTaskFactories).toHaveLength(0)
     expect(linkedByEntry.get(file)).toEqual(new Set())
+  })
+
+  it('plans a cached clean chunk without creating a js handler task or replacing linked state', () => {
+    const cache = createCache()
+    const file = 'assets/clean.js'
+    const source = 'const cls = "text-red-500"'
+    const sourceHash = cache.computeHash(source)
+    const runtimeSignature = 'runtime:stable'
+    const processHash = `${sourceHash}:${runtimeSignature}:transform-filter:include:none;exclude:none`
+    const cached = 'const cls = "tw-text-red-500"'
+    cache.set(file, cached)
+    cache.setHashValue(`${file}:js`, { changed: false, hash: processHash })
+    const chunk = { ...createRollupChunk(source), fileName: file }
+    const metrics = createMetrics()
+    const rememberProcessCacheKey = vi.fn()
+
+    const replayed = replayCleanJsBundleEntry({
+      cache,
+      debug: vi.fn(),
+      entry: { file, output: chunk, source, type: 'js' },
+      metrics,
+      rememberProcessCacheKey,
+      snapshot: createSnapshot(file, sourceHash) as any,
+      transformFilterSignature: 'include:none;exclude:none',
+      transformRuntimeSignature: runtimeSignature,
+      useIncrementalMode: true,
+    })
+
+    expect(replayed).toBe(true)
+    expect(chunk.code).toBe(cached)
+    expect(metrics.js.cacheHits).toBe(1)
+    expect(rememberProcessCacheKey).toHaveBeenCalledWith(file, `${file}:js`)
   })
 
   it('skips js ast work when all chunk modules match transform.exclude', async () => {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-source-candidates.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-source-candidates.unit.test.ts
@@ -39,6 +39,21 @@ describe('bundlers/vite source candidates', () => {
     expect(collector.values()).toEqual(new Set(['text-[23px]', 'bg-[#123456]']))
   })
 
+  it('reuses extraction across scan and transform layers for the same file source', async () => {
+    const { createSourceCandidateCollector } = await import('@/bundlers/vite/source-candidates')
+    const extractor = vi.fn((source: string) => source.split(/\s+/).filter(Boolean))
+    const collector = createSourceCandidateCollector({ extractor })
+    const file = '/project/pages/index.vue'
+    const source = '<view class="text-red-500" />'
+
+    await collector.sync(file, source)
+    await collector.merge(file, source)
+    await collector.syncCurrentSource(file, source)
+
+    expect(extractor).toHaveBeenCalledTimes(1)
+    expect(collector.getRevision()).toBeGreaterThan(0)
+  })
+
   it('exposes a shared source candidate store API for bundlers', async () => {
     const { createSourceCandidateStore } = await import('@/bundlers/vite/source-candidates')
     const store = createSourceCandidateStore()

--- a/reports/weapp-vite-source-candidates-root-cause.md
+++ b/reports/weapp-vite-source-candidates-root-cause.md
@@ -1,0 +1,26 @@
+# Issue #1127：weapp-vite source-candidates 性能根因
+
+## 结论
+
+Issue #1127 报告的主要耗时来自候选源扫描、候选提取重复执行和 `generateBundle` 入口规划的全图遍历。`realpath` 只是次级热点，单独优化它不能解决 3 至 5 秒的构建耗时，也不能消除单文件 HMR 的级联更新。
+
+问题复现环境为 `weapp-tailwindcss 5.3.6`、Tailwind CSS 4.3.3、`weapp-vite 6.23.0`、`wevu 6.23.0`、Vite 8.2.2，项目约 51 个页面、105 个 Vue SFC、116 个组件和 815 个生产文件。固定 repro 的构建观测约为 11 至 13 秒，其中插件约 10.9 至 13.0 秒，`post generateBundle` 约 3.7 秒，`source-candidates buildStart/transform` 合计约 2 秒。单文件 HMR 可观察到数百次 `watchChange/handleHotUpdate` 调用。
+
+## 根因数据流
+
+1. source scan 通过 source entries 解析所有 eligible 文件，并读取、提取每个文件。watch 只复用扫描定义和部分快照，不能保证 scan 与 transform 对同一文件共享提取结果；全局内容 LRU 容量有限，在百级 SFC 项目中会频繁淘汰。
+2. Vite 先调用 `watchChange`，随后可能为同一文件调用 `handleHotUpdate`。原实现按文件保存 pending promise，但两个生命周期各自读取和同步，无法把一次文件系统变化合并为一个事务；非候选文件也会触发匹配、删除和快照路径。
+3. `generateBundle` 已有 dirty 集合，但入口循环仍为 clean JS/CSS 构造完整处理计划。clean JS 只需要回放处理缓存时，仍会创建 handler、链接集合和任务工厂；CSS 入口也会重复执行归属和 source plan 判断。
+
+## 修复边界
+
+- shared source-candidate store 增加按规范化文件和源码版本的有界 memo，scan、transform、CSS、module layer 统一命中；返回集合始终 clone。
+- Vite source scan session 增加 queued change 与 batch flush。`watchChange` 登记事件，`handleHotUpdate` 复用登记源码并等待同一批次；同文件只保留最新事件，批次完成后按 collector revision 至多生成一次快照。
+- bundle state 缓存 entry metadata；增量 clean JS 优先直接回放已缓存代码，只有缓存未命中才进入完整 transform。CSS 入口继续使用保守的 dirty/remembered replay 判定，避免把“曾处理过”误当成“当前源码可复用”；root CSS、分包、linked impact 和删除场景保留完整回退。
+- 缓存仅存在当前进程和当前构建图，不写磁盘，不改变生产构建之间的状态隔离。
+
+## 验证口径
+
+候选集合、特殊 class/任意值、删除和重新创建行为必须与完整扫描一致。基准使用仓库自有 4 个 source root、120 个 SFC 合成夹具，并与现有 150 页面 Vite adapter 结合，报告 cold build、warm incremental、单文件 HMR 和批量 HMR 的 median/P95。性能回归继续使用仓库现有 5% 规则，不设置绝对耗时门槛。
+
+关联：[Issue #1127](https://github.com/sonofmagic/weapp-tailwindcss/issues/1127)


### PR DESCRIPTION
## 摘要

本 PR 根治 Issue #1127 的 Vite 增量构建性能问题，关联：Related to #1127。

根因是三层重复工作叠加：

- source scan、transform、CSS/module layer 对同一源码重复提取候选。
- Vite `watchChange` 与 `handleHotUpdate` 形成重复同步，无法合并为一次 HMR 事务。
- `generateBundle` 虽有 dirty 状态，但仍为大量 clean entry 构造完整规划和处理任务。

## 修复内容

- 增加按文件、源码版本、扩展名和 extractor 指纹隔离的有界 source-candidate memo，并保留跨文件内容 LRU；所有返回集合均为新 `Set`。
- 增加 Vite changed-file 批处理、最终事件合并、revision-aware snapshot 和批次级 eligible-file/依赖刷新。
- 增加 Vite entry metadata/plan 缓存，对 clean JS entry 进行安全 replay；CSS 在无法证明等价时回退完整处理。
- 保留候选精确命中、删除优先级、linked impact、root CSS、subpackage、CSS import shell、uni-app-x 占位符和输出扩展名语义。
- 增加中文根因报告、Issue #1127 合成 benchmark 和中文 changeset。

## 已完成的验证

- `pnpm --filter weapp-tailwindcss test`：318 files，3272 tests passed。
- 聚焦 source-candidate/HMR/bundle 回归：54/54 passed。
- Vite bundle 回归：209/209 passed。
- `pnpm exec tsc -p packages/weapp-tailwindcss/tsconfig.build.json --noEmit --pretty false`。
- `git diff --check`。
- 合成 benchmark corpus：120 个 Vue/SFC，覆盖 page/component/subpackage。

## 全端验收

PR required checks 将覆盖托管 runner 可执行的 build、static output、framework matrix、watch/HMR 和 benchmark guard。HBuilderX、Android、iOS、Harmony 与 uni-app-x local targets 使用本机完整报告作为必需证据；报告会记录工具链版本、设备 ID、真实产物路径、safe class、HMR 前后状态和阻塞层级。

正在执行并持续补充：

- `pnpm exec vitest run -c ./e2e/vitest.e2e.config.ts e2e/e2e-matrix.test.ts`
- `pnpm test:frameworks:matrix`
- `pnpm e2e:multiplatform-build`
- `pnpm e2e:watch:full`
- `pnpm e2e:local:full-report`
- HBuilderX Web/Android/iOS/Harmony HMR 与 uni-app-x VDOM/Vapor 验收

不提交设备截图、HBuilderX 临时目录或 `e2e/.artifacts`；本机报告路径和命令摘要会持续更新到 PR 讨论中。
