### PR TITLE
test(e2e): stabilize HBuilderX HMR regressions

### DIFF
--- a/e2e/hbuilderx-local-helpers.test.ts
+++ b/e2e/hbuilderx-local-helpers.test.ts
@@ -56,6 +56,15 @@ describe('HBuilderX local helpers', () => {
         },
       })
       expect(await fs.readFile(file, 'utf8')).toBe('@import "./main.css";\n')
+
+      await appendHmrSourceMutation(root, {
+        file: 'theme.css',
+        replace: {
+          from: '@import "tailwindcss";',
+          to: '@import "./main.css";',
+        },
+      })
+      expect(await fs.readFile(file, 'utf8')).toBe('@import "./main.css";\n')
     }
     finally {
       await fs.rm(root, { force: true, recursive: true })

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -1258,7 +1258,7 @@ export const webCases: WebCase[] = [
       {
         markerClass: 'hbuilderx-web-hmr-probe mt-200 bg-[#102938] text-[#f7fbff] w-[173px]',
         markerText: 'hbuilderx-web-hmr-v4-mt-200',
-        cssContains: [/\.mt-200\s*\{/, /background-color:\s*#102938/, /width:\s*173px/],
+        cssContains: [/margin-top:\s*(?:calc\(0\.25rem\s*\*\s*200\)|800px)/, /background-color:\s*#102938/, /width:\s*173px/],
         runtimeStyles: [{
           selector: '.hbuilderx-web-hmr-probe',
           styles: { backgroundColor: 'rgb(16, 41, 56)', color: 'rgb(247, 251, 255)', marginTop: '800px', width: '173px' },

--- a/e2e/hbuilderx-local/source-mutations.ts
+++ b/e2e/hbuilderx-local/source-mutations.ts
@@ -20,10 +20,16 @@ export async function appendHmrSourceMutation(projectRoot: string, mutation: Hmr
   const separator = source.endsWith('\n') ? '' : '\n'
   let nextSource: string | undefined
   if (mutation.replace) {
-    if (!source.includes(mutation.replace.from)) {
+    if (source.includes(mutation.replace.from)) {
+      nextSource = source.replace(mutation.replace.from, mutation.replace.to)
+    }
+    else if (source.includes(mutation.replace.to)) {
+      // HMR 测试可能在上次中断后留下目标状态，重复执行时保持幂等。
+      return file
+    }
+    else {
       throw new Error(`HMR 源码变更找不到替换目标：${mutation.file}`)
     }
-    nextSource = source.replace(mutation.replace.from, mutation.replace.to)
   }
   else if (typeof mutation.append === 'string') {
     nextSource = `${source}${separator}${mutation.append.trimEnd()}\n`

--- a/e2e/hbuilderx-local/web.ts
+++ b/e2e/hbuilderx-local/web.ts
@@ -286,6 +286,12 @@ async function rewriteHmrMarker(file: string, anchors: string[], steps: WebHmrSt
   await fs.writeFile(file, next, 'utf8')
 }
 
+async function waitForHmrMarker(page: Page, markerText: string) {
+  await page.waitForFunction(text => document.body?.textContent?.includes(text), markerText, {
+    timeout: serverTimeoutMs,
+  })
+}
+
 export async function runWebHmr(
   projectRoot: string,
   sourceFile: string,
@@ -350,6 +356,7 @@ export async function runWebHmr(
     const hmrCss: string[] = []
     for (const [index, step] of hmrSteps.entries()) {
       await rewriteHmrMarker(sourceFile, markerAnchors, hmrSteps, index)
+      await waitForHmrMarker(page, step.markerText)
       if (step.sourceMutation) {
         await appendHmrSourceMutation(projectRoot, step.sourceMutation)
         if (step.sourceMutation.cssContains?.length) {


### PR DESCRIPTION
## 变更说明

- 让 HMR 源码 replace mutation 幂等，避免测试中断后重复执行误报找不到替换目标。
- 连续源码变更之间等待页面 marker 完成 HMR 更新，避免页面更新与样式更新竞态。
- 使用安全类转换后的稳定 CSS 语义断言 `mt-200`，覆盖 uni-app x Web HMR。
- 补充重复执行 replace mutation 的回归测试。

## 验证结果

- HBuilderX helper：6/6
- uni-app x Web HMR：通过
- Harmony VDOM：通过
- Harmony Vapor：通过
- Android App HMR：通过
- #1113 `.uvue` fixture：1/1
- PostCSS important/Sass：30/30
- static generator 对比：10/10

关联 Issue：
- https://github.com/sonofmagic/weapp-tailwindcss/issues/1125
- https://github.com/sonofmagic/weapp-tailwindcss/issues/1123
- https://github.com/sonofmagic/weapp-tailwindcss/issues/1113
