### PR TITLE
feat: 完善 Compiler/PostCSS API

### DIFF
--- a/.changeset/compiler-finalization-api.md
+++ b/.changeset/compiler-finalization-api.md
@@ -1,0 +1,6 @@
+---
+"weapp-tailwindcss": minor
+"@weapp-tailwindcss/postcss": minor
+---
+
+完善 Core Compiler 与 PostCSS 集成能力：小程序目标默认完成 CSS 最终化，支持 source glob 增量失效、内存 CSS source、root 淘汰回调、模板 filename 上下文，并公开最终化相关 API。

--- a/packages/postcss/src/compat/mini-program-css/finalize.ts
+++ b/packages/postcss/src/compat/mini-program-css/finalize.ts
@@ -30,7 +30,7 @@ export type { FinalizeMiniProgramCssOptions } from './finalize-options'
 export { insertHoistedRules } from './hoist'
 export { collectPreflightRules } from './preflight'
 
-function finalizeMiniProgramCssRoot(root: postcss.Root, options: FinalizeMiniProgramCssOptions = {}) {
+export function finalizeMiniProgramCssRoot(root: postcss.Root, options: FinalizeMiniProgramCssOptions = {}) {
   const shouldInjectTailwindcssV4Defaults = options.isTailwindcssV4 === true
   const tailwindcssV4DefaultNodes = shouldInjectTailwindcssV4Defaults
     ? createMissingCssVarsV4Nodes(root, collectUsedTailwindcssV4Variables(root))
@@ -39,6 +39,9 @@ function finalizeMiniProgramCssRoot(root: postcss.Root, options: FinalizeMiniPro
   unwrapTailwindSourceMedia(root)
   removeTailwindGenerationDirectives(root)
   root.walkAtRules('property', (atRule) => {
+    atRule.remove()
+  })
+  root.walkAtRules('supports', (atRule) => {
     atRule.remove()
   })
   removeSpecificityPlaceholders(root)

--- a/packages/postcss/src/compat/mini-program-css/index.ts
+++ b/packages/postcss/src/compat/mini-program-css/index.ts
@@ -8,6 +8,7 @@ export { consumeCascadeLayers } from './cascade-layers'
 export {
   finalizeMiniProgramCss,
   type FinalizeMiniProgramCssOptions,
+  finalizeMiniProgramCssRoot,
   hoistTailwindPreflightBase,
 } from './finalize'
 export {

--- a/packages/postcss/src/index.ts
+++ b/packages/postcss/src/index.ts
@@ -19,6 +19,8 @@ export { transformLynxCssCompat } from './compat/lynx-css'
 export {
   consumeCascadeLayers,
   finalizeMiniProgramCss,
+  type FinalizeMiniProgramCssOptions,
+  finalizeMiniProgramCssRoot,
   hasMiniProgramCssSpecificityPlaceholders,
   hoistTailwindPreflightBase,
   normalizeMiniProgramGeneratedCssForPostcss,

--- a/packages/postcss/test/mini-program-css.test.ts
+++ b/packages/postcss/test/mini-program-css.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   finalizeMiniProgramCss,
+  finalizeMiniProgramCssRoot,
   hasMiniProgramCssSpecificityPlaceholders,
   hoistTailwindPreflightBase,
   normalizeMiniProgramPrefixedDeclaration,
@@ -42,6 +43,14 @@ import {
 } from '../src/compat/mini-program-css/root-cleanups'
 
 describe('mini-program css cleanup', () => {
+  it('finalizes an existing PostCSS root in place', () => {
+    const source = '@plugin "example";\n@source "./src";\n@supports (display: grid) { .grid { display: grid; } }\n.card { display: flex; }'
+    const root = postcss.parse(source)
+    finalizeMiniProgramCssRoot(root)
+    expect(root.toString()).toBe(finalizeMiniProgramCss(source))
+    expect(root.toString()).toBe('.card { display: flex; }')
+  })
+
   it('covers mini-program predicate helper branches', () => {
     const root = postcss.parse([
       'button{appearance:button}',

--- a/packages/weapp-tailwindcss/src/core.ts
+++ b/packages/weapp-tailwindcss/src/core.ts
@@ -4,10 +4,10 @@ import { getCompilerContext } from '@/context'
 import { shouldSkipJsTransform } from '@/js/precheck'
 import { createTailwindRuntimeReadyPromise, ensureRuntimeClassSet } from '@/tailwindcss/runtime'
 
-export { createCompiler } from './core/compiler'
 export type {
   Compiler,
   CompilerCacheReuseState,
+  CompilerCssTransformOptions,
   CompilerGenerateRequest,
   CompilerGenerateResult,
   CompilerSnapshot,
@@ -18,6 +18,14 @@ export type {
   CreateCompilerOptions,
   CreateCompilerSnapshotRequest,
 } from './core/compiler'
+export { createCompiler } from './core/compiler'
+export {
+  finalizeMiniProgramCss,
+  finalizeMiniProgramCssRoot,
+  postcss,
+  removeTailwindSourceDirectivesRoot,
+} from '@weapp-tailwindcss/postcss'
+export type { FinalizeMiniProgramCssOptions } from '@weapp-tailwindcss/postcss'
 
 type RuntimeJsTransformOptions = { runtimeSet?: Set<string> } & CreateJsHandlerOptions
 

--- a/packages/weapp-tailwindcss/src/core/compiler/compiler.ts
+++ b/packages/weapp-tailwindcss/src/core/compiler/compiler.ts
@@ -7,6 +7,7 @@ import type {
   CreateCompilerOptions,
 } from './types'
 import type { UserDefinedOptions } from '@/types'
+import { finalizeMiniProgramCss, finalizeMiniProgramCssRoot } from '@weapp-tailwindcss/postcss'
 import { createWeappTailwindcssGenerator, resolveTailwindV4Source } from '@/generator'
 import { createCompilerGenerationCacheKey, isSameCompilerGenerationCacheKey, reuseCompilerGenerationResult } from './generation-cache'
 import { commitCompilerGeneration, prepareCompilerGeneration } from './generation-state'
@@ -25,7 +26,7 @@ const DEFAULT_MAX_ROOTS = 128
 export function createCompiler(options: CreateCompilerOptions = {}): Compiler {
   const { compiler: compilerOptions, ...userOptions } = options
   const maxRoots = Math.max(1, Math.floor(compilerOptions?.maxRoots ?? DEFAULT_MAX_ROOTS))
-  const rootStore = new CompilerRootStore(maxRoots)
+  const rootStore = new CompilerRootStore(maxRoots, compilerOptions?.onRootEvicted)
   const activeTasks = new Set<Promise<unknown>>()
   let lifecycle: 'active' | 'disposing' | 'disposed' = 'active'
   let disposePromise: Promise<void> | undefined
@@ -158,6 +159,7 @@ export function createCompiler(options: CreateCompilerOptions = {}): Compiler {
       entry.appliedInvalidation = invalidation
       entry.latestSnapshot = snapshot
       rootStore.attachDependencies(entry, dependencies)
+      rootStore.attachSources(entry, sources)
       if (!engineReused && previousGenerator !== generator) {
         previousGenerator?.dispose?.()
       }
@@ -211,6 +213,18 @@ export function createCompiler(options: CreateCompilerOptions = {}): Compiler {
     return createRegisteredCompilerSnapshot(request)
   }
 
+  function finalizeCss(css: string, options?: Parameters<Compiler['finalizeCss']>[1]) {
+    ensureActive()
+    return finalizeMiniProgramCss(css, options)
+  }
+
+  function finalizeCssRoot(root: Parameters<Compiler['finalizeCssRoot']>[0], options?: Parameters<Compiler['finalizeCssRoot']>[1]) {
+    ensureActive()
+    const cloned = root.clone()
+    finalizeMiniProgramCssRoot(cloned, options)
+    return cloned
+  }
+
   function mergeSnapshots(snapshots: Iterable<CompilerSnapshot>) {
     ensureActive()
     return mergeRegisteredCompilerSnapshots(snapshots)
@@ -246,6 +260,8 @@ export function createCompiler(options: CreateCompilerOptions = {}): Compiler {
   return {
     createSnapshot,
     dispose,
+    finalizeCss,
+    finalizeCssRoot,
     generate,
     invalidate,
     mergeSnapshots,

--- a/packages/weapp-tailwindcss/src/core/compiler/index.ts
+++ b/packages/weapp-tailwindcss/src/core/compiler/index.ts
@@ -2,6 +2,7 @@ export { createCompiler } from './compiler'
 export type {
   Compiler,
   CompilerCacheReuseState,
+  CompilerCssTransformOptions,
   CompilerGenerateRequest,
   CompilerGenerateResult,
   CompilerSnapshot,

--- a/packages/weapp-tailwindcss/src/core/compiler/root-store.ts
+++ b/packages/weapp-tailwindcss/src/core/compiler/root-store.ts
@@ -1,8 +1,9 @@
 import type { CompilerGenerationCacheEntry } from './generation-cache'
 import type { CompilerCompilationCacheEntry } from './generation-state'
-import type { CompilerSnapshot } from './types'
+import type { CompilerSnapshot, CompilerSourcePattern } from './types'
 import type { TailwindV4ResolvedSource, WeappTailwindcssGenerator } from '@/generator'
 import { DefaultCompilationSession } from '@/compiler/session'
+import { isFileMatchedByTailwindSourceEntries } from '@/tailwindcss/source-scan'
 
 export interface CompilerRootSession {
   accepting: boolean
@@ -22,6 +23,7 @@ export interface CompilerRootSession {
   source?: TailwindV4ResolvedSource | undefined
   sourceFingerprint?: string | undefined
   sourceInput?: object | undefined
+  sources: CompilerSourcePattern[]
 }
 
 function disposeGenerator(generator: WeappTailwindcssGenerator | undefined) {
@@ -33,7 +35,10 @@ export class CompilerRootStore {
   private readonly releasing = new Map<string, Promise<void>>()
   private readonly roots = new Map<string, CompilerRootSession>()
 
-  constructor(private readonly maxRoots: number) {}
+  constructor(
+    private readonly maxRoots: number,
+    private readonly onRootEvicted?: ((id: string) => void) | undefined,
+  ) {}
 
   get(id: string) {
     if (!id) {
@@ -54,7 +59,7 @@ export class CompilerRootStore {
     if (this.roots.size >= this.maxRoots) {
       const oldest = [...this.roots.values()].find(entry => entry.pendingCount === 0)
       if (oldest) {
-        void this.remove(oldest.id)
+        void this.remove(oldest.id, true)
       }
     }
     const entry: CompilerRootSession = {
@@ -68,6 +73,7 @@ export class CompilerRootStore {
       invalidation: 0,
       pending: Promise.resolve(),
       pendingCount: 0,
+      sources: [],
     }
     this.roots.set(id, entry)
     return entry
@@ -89,6 +95,10 @@ export class CompilerRootStore {
     }
   }
 
+  attachSources(entry: CompilerRootSession, sources: Iterable<CompilerSourcePattern>) {
+    entry.sources = [...sources]
+  }
+
   invalidate(ids: Iterable<string>) {
     const affected = new Set<string>()
     for (const id of ids) {
@@ -98,6 +108,12 @@ export class CompilerRootStore {
       }
       for (const rootId of this.dependencyRoots.get(id) ?? []) {
         affected.add(rootId)
+      }
+      const sourcePath = stripSourceQuery(id)
+      for (const sourceRoot of this.roots.values()) {
+        if (sourceRoot.accepting && sourceRoot.sources.length > 0 && isFileMatchedByTailwindSourceEntries(sourcePath, sourceRoot.sources)) {
+          affected.add(sourceRoot.id)
+        }
       }
     }
     for (const rootId of affected) {
@@ -115,11 +131,11 @@ export class CompilerRootStore {
       if (!oldest) {
         return
       }
-      void this.remove(oldest.id)
+      void this.remove(oldest.id, true)
     }
   }
 
-  remove(id: string) {
+  remove(id: string, notifyEvicted = false) {
     const pendingRelease = this.releasing.get(id)
     if (pendingRelease) {
       return pendingRelease
@@ -142,6 +158,10 @@ export class CompilerRootStore {
       entry.source = undefined
       entry.sourceInput = undefined
       entry.sourceFingerprint = undefined
+      entry.sources = []
+      if (notifyEvicted) {
+        this.onRootEvicted?.(id)
+      }
     }).finally(() => {
       this.releasing.delete(id)
     })
@@ -167,4 +187,8 @@ export class CompilerRootStore {
     }
     entry.dependencies.clear()
   }
+}
+
+function stripSourceQuery(id: string) {
+  return id.replace(/[?#].*$/, '')
 }

--- a/packages/weapp-tailwindcss/src/core/compiler/transforms.ts
+++ b/packages/weapp-tailwindcss/src/core/compiler/transforms.ts
@@ -1,6 +1,7 @@
 import type { StyleHandler } from '@weapp-tailwindcss/postcss'
-import type { Compiler, CompilerSnapshot } from './types'
+import type { Compiler, CompilerCssTransformOptions, CompilerSnapshot } from './types'
 import type { UserDefinedOptions } from '@/types'
+import { finalizeMiniProgramCssRoot } from '@weapp-tailwindcss/postcss'
 import { getCompilerContext } from '@/context'
 import { shouldSkipJsTransform } from '@/js/precheck'
 import { getInternalCompilerSnapshot } from './snapshot'
@@ -22,6 +23,24 @@ function resolveStyleOptions(options?: Parameters<StyleHandler>[1]) {
   return options?.isMainChunk === undefined
     ? { ...options, isMainChunk: true }
     : options
+}
+
+function resolveCssTransformOptions(options?: CompilerCssTransformOptions) {
+  const { finalize: _finalize, ...styleOptions } = options ?? {}
+  return {
+    finalize: _finalize,
+    styleOptions: resolveStyleOptions(styleOptions),
+  }
+}
+
+function finalizeResultRoot(result: Awaited<ReturnType<StyleHandler>>, snapshot: CompilerSnapshot, shouldFinalize: boolean) {
+  if (!shouldFinalize || result.root.type !== 'root') {
+    return
+  }
+  finalizeMiniProgramCssRoot(result.root, {
+    isTailwindcssV4: snapshot.target === 'weapp',
+  })
+  result.css = result.root.toString()
 }
 
 interface CreateCompilerTransformsOptions {
@@ -71,13 +90,24 @@ export function createCompilerTransforms({ ensureActive, track, userOptions }: C
   function transformCss(css: string, snapshot: CompilerSnapshot, options?: Parameters<Compiler['transformCss']>[2]) {
     ensureActive()
     getInternalCompilerSnapshot(snapshot)
-    return track(styleHandler(css, resolveStyleOptions(options)).then(clonePostcssResult))
+    const resolved = resolveCssTransformOptions(options)
+    const shouldFinalize = resolved.finalize ?? snapshot.target === 'weapp'
+    return track(styleHandler(css, resolved.styleOptions).then((result) => {
+      const cloned = clonePostcssResult(result)
+      finalizeResultRoot(cloned, snapshot, shouldFinalize)
+      return cloned
+    }))
   }
 
   function transformCssRoot(root: Parameters<Compiler['transformCssRoot']>[0], snapshot: CompilerSnapshot, options?: Parameters<Compiler['transformCssRoot']>[2]) {
     ensureActive()
     getInternalCompilerSnapshot(snapshot)
-    return track(styleHandler.transformRoot(root, resolveStyleOptions(options)))
+    const resolved = resolveCssTransformOptions(options)
+    const shouldFinalize = resolved.finalize ?? snapshot.target === 'weapp'
+    return track(styleHandler.transformRoot(root, resolved.styleOptions).then((result) => {
+      finalizeResultRoot(result, snapshot, shouldFinalize)
+      return result
+    }))
   }
 
   function transformJavaScript(source: string, snapshot: CompilerSnapshot, options?: Parameters<Compiler['transformJavaScript']>[2]) {

--- a/packages/weapp-tailwindcss/src/core/compiler/types.ts
+++ b/packages/weapp-tailwindcss/src/core/compiler/types.ts
@@ -1,5 +1,6 @@
 import type {
   Document,
+  FinalizeMiniProgramCssOptions,
   IStyleHandlerOptions,
   Result as PostcssResult,
   Root,
@@ -87,16 +88,25 @@ export interface CreateCompilerSnapshotRequest {
 
 export type CompilerTemplateTransformOptions = Omit<ITemplateHandlerOptions, 'classSetMode' | 'runtimeSet'>
 
+export type CompilerCssTransformOptions = Partial<IStyleHandlerOptions> & {
+  /** 是否在样式兼容转换后执行小程序 CSS 最终化。 */
+  finalize?: boolean | undefined
+}
+
 export type CreateCompilerOptions = UserDefinedOptions & {
   compiler?: {
     /** 长期未使用且没有进行中任务的 root 会话上限。 */
     maxRoots?: number | undefined
+    /** root 因超过 maxRoots 被淘汰并释放后触发。 */
+    onRootEvicted?: ((id: string) => void) | undefined
   } | undefined
 }
 
 export interface Compiler {
   createSnapshot: (request: CreateCompilerSnapshotRequest) => CompilerSnapshot
   dispose: () => Promise<void>
+  finalizeCss: (css: string, options?: FinalizeMiniProgramCssOptions) => string
+  finalizeCssRoot: (root: Root, options?: FinalizeMiniProgramCssOptions) => Root
   generate: (request: CompilerGenerateRequest) => Promise<CompilerGenerateResult>
   invalidate: (ids: Iterable<string>) => readonly string[]
   mergeSnapshots: (snapshots: Iterable<CompilerSnapshot>) => CompilerSnapshot
@@ -104,12 +114,12 @@ export interface Compiler {
   transformCss: (
     css: string,
     snapshot: CompilerSnapshot,
-    options?: Partial<IStyleHandlerOptions>,
+    options?: CompilerCssTransformOptions,
   ) => Promise<PostcssResult<Root | Document>>
   transformCssRoot: (
     root: Root,
     snapshot: CompilerSnapshot,
-    options?: Partial<IStyleHandlerOptions>,
+    options?: CompilerCssTransformOptions,
   ) => Promise<PostcssResult<Root>>
   transformJavaScript: (
     source: string,

--- a/packages/weapp-tailwindcss/src/tailwindcss/source-scan.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/source-scan.ts
@@ -104,6 +104,16 @@ export function resolveSourceScanPath(value: string) {
   }
 }
 
+function resolveSourceScanPathWithApi(value: string, pathApi: Pick<typeof path, 'resolve'>) {
+  const resolved = pathApi.resolve(value)
+  try {
+    return realpathSync.native(resolved)
+  }
+  catch {
+    return resolved
+  }
+}
+
 function normalizeEntryPattern(entry: TailwindSourceEntry) {
   const pathApi = isWindowsPath(entry.base) || isWindowsPath(entry.pattern) ? path.win32 : path
   return pathApi.isAbsolute(entry.pattern)
@@ -113,14 +123,14 @@ function normalizeEntryPattern(entry: TailwindSourceEntry) {
 
 function isFileMatchedByTailwindSourceEntry(file: string, entry: TailwindSourceEntry) {
   const pathApi = isWindowsPath(entry.base) || isWindowsPath(file) ? path.win32 : path
-  const base = pathApi === path.win32 ? pathApi.resolve(entry.base) : resolveSourceScanPath(entry.base)
-  const resolvedFile = pathApi === path.win32 ? pathApi.resolve(file) : resolveSourceScanPath(file)
+  const base = resolveSourceScanPathWithApi(entry.base, pathApi)
+  const resolvedFile = resolveSourceScanPathWithApi(file, pathApi)
   const relative = toPosixPath(pathApi.relative(base, resolvedFile))
   return relative && !relative.startsWith('../') && !pathApi.isAbsolute(relative) && micromatch.isMatch(relative, normalizeEntryPattern(entry))
 }
 
 function isWindowsPath(value: string) {
-  return path.win32.isAbsolute(value) || value.includes('\\')
+  return /^[A-Z]:[\\/]/i.test(value) || value.includes('\\')
 }
 
 export function isFileExcludedByTailwindSourceEntries(file: string, entries: TailwindSourceEntry[] | undefined) {

--- a/packages/weapp-tailwindcss/src/tailwindcss/source-scan.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/source-scan.ts
@@ -91,7 +91,7 @@ export const FULL_SOURCE_SCAN_PATTERN = createSourceScanPattern(FULL_SOURCE_SCAN
 export const FULL_SOURCE_SCAN_EXTENSION_RE = new RegExp(`\\.(?:${FULL_SOURCE_SCAN_EXTENSIONS.map(extension => extension.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`)
 
 export function toPosixPath(value: string) {
-  return value.split(path.sep).join('/')
+  return value.split(path.sep).join('/').split(path.win32.sep).join('/')
 }
 
 export function resolveSourceScanPath(value: string) {
@@ -105,22 +105,29 @@ export function resolveSourceScanPath(value: string) {
 }
 
 function normalizeEntryPattern(entry: TailwindSourceEntry) {
-  return path.isAbsolute(entry.pattern)
-    ? toPosixPath(path.relative(resolveSourceScanPath(entry.base), entry.pattern))
+  const pathApi = isWindowsPath(entry.base) || isWindowsPath(entry.pattern) ? path.win32 : path
+  return pathApi.isAbsolute(entry.pattern)
+    ? toPosixPath(pathApi.relative(pathApi.resolve(entry.base), entry.pattern))
     : entry.pattern
 }
 
 function isFileMatchedByTailwindSourceEntry(file: string, entry: TailwindSourceEntry) {
-  const relative = toPosixPath(path.relative(resolveSourceScanPath(entry.base), file))
-  return relative && !relative.startsWith('../') && !path.isAbsolute(relative) && micromatch.isMatch(relative, normalizeEntryPattern(entry))
+  const pathApi = isWindowsPath(entry.base) || isWindowsPath(file) ? path.win32 : path
+  const base = pathApi === path.win32 ? pathApi.resolve(entry.base) : resolveSourceScanPath(entry.base)
+  const resolvedFile = pathApi === path.win32 ? pathApi.resolve(file) : resolveSourceScanPath(file)
+  const relative = toPosixPath(pathApi.relative(base, resolvedFile))
+  return relative && !relative.startsWith('../') && !pathApi.isAbsolute(relative) && micromatch.isMatch(relative, normalizeEntryPattern(entry))
+}
+
+function isWindowsPath(value: string) {
+  return path.win32.isAbsolute(value) || value.includes('\\')
 }
 
 export function isFileExcludedByTailwindSourceEntries(file: string, entries: TailwindSourceEntry[] | undefined) {
   if (!entries?.length) {
     return false
   }
-  const resolvedFile = resolveSourceScanPath(file)
-  return entries.some(entry => entry.negated && isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
+  return entries.some(entry => entry.negated && isFileMatchedByTailwindSourceEntry(file, entry))
 }
 
 export function isFileMatchedByTailwindSourceEntries(file: string, entries: TailwindSourceEntry[] | undefined) {
@@ -129,15 +136,14 @@ export function isFileMatchedByTailwindSourceEntries(file: string, entries: Tail
   }
   const positiveEntries = entries.filter(entry => !entry.negated)
   const negativeEntries = entries.filter(entry => entry.negated)
-  const resolvedFile = resolveSourceScanPath(file)
   if (positiveEntries.length === 0) {
-    return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
+    return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(file, entry))
   }
-  const matchesPositive = positiveEntries.some(entry => isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
+  const matchesPositive = positiveEntries.some(entry => isFileMatchedByTailwindSourceEntry(file, entry))
   if (!matchesPositive) {
     return false
   }
-  return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
+  return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(file, entry))
 }
 
 export function createTailwindSourceEntryMatcher(entries: TailwindSourceEntry[] | undefined) {

--- a/packages/weapp-tailwindcss/src/tailwindcss/source-scan.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/source-scan.ts
@@ -124,8 +124,7 @@ function normalizeEntryPattern(entry: TailwindSourceEntry) {
 function isFileMatchedByTailwindSourceEntry(file: string, entry: TailwindSourceEntry) {
   const pathApi = isWindowsPath(entry.base) || isWindowsPath(file) ? path.win32 : path
   const base = resolveSourceScanPathWithApi(entry.base, pathApi)
-  const resolvedFile = resolveSourceScanPathWithApi(file, pathApi)
-  const relative = toPosixPath(pathApi.relative(base, resolvedFile))
+  const relative = toPosixPath(pathApi.relative(base, file))
   return relative && !relative.startsWith('../') && !pathApi.isAbsolute(relative) && micromatch.isMatch(relative, normalizeEntryPattern(entry))
 }
 
@@ -137,23 +136,32 @@ export function isFileExcludedByTailwindSourceEntries(file: string, entries: Tai
   if (!entries?.length) {
     return false
   }
-  return entries.some(entry => entry.negated && isFileMatchedByTailwindSourceEntry(file, entry))
+  const resolvedFile = resolveSourceScanMatcherFile(file, entries)
+  return entries.some(entry => entry.negated && isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
 }
 
 export function isFileMatchedByTailwindSourceEntries(file: string, entries: TailwindSourceEntry[] | undefined) {
   if (!entries?.length) {
     return true
   }
+  const resolvedFile = resolveSourceScanMatcherFile(file, entries)
   const positiveEntries = entries.filter(entry => !entry.negated)
   const negativeEntries = entries.filter(entry => entry.negated)
   if (positiveEntries.length === 0) {
-    return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(file, entry))
+    return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
   }
-  const matchesPositive = positiveEntries.some(entry => isFileMatchedByTailwindSourceEntry(file, entry))
+  const matchesPositive = positiveEntries.some(entry => isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
   if (!matchesPositive) {
     return false
   }
-  return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(file, entry))
+  return !negativeEntries.some(entry => isFileMatchedByTailwindSourceEntry(resolvedFile, entry))
+}
+
+function resolveSourceScanMatcherFile(file: string, entries: TailwindSourceEntry[]) {
+  const useWindowsApi = isWindowsPath(file) || entries.some(entry => isWindowsPath(entry.base) || isWindowsPath(entry.pattern))
+  return useWindowsApi
+    ? resolveSourceScanPathWithApi(file, path.win32)
+    : resolveSourceScanPath(file)
 }
 
 export function createTailwindSourceEntryMatcher(entries: TailwindSourceEntry[] | undefined) {

--- a/packages/weapp-tailwindcss/src/typedoc.export.ts
+++ b/packages/weapp-tailwindcss/src/typedoc.export.ts
@@ -1,6 +1,7 @@
 export type {
   Compiler,
   CompilerCacheReuseState,
+  CompilerCssTransformOptions,
   CompilerGenerateRequest,
   CompilerGenerateResult,
   CompilerSnapshot,

--- a/packages/weapp-tailwindcss/src/types/index.ts
+++ b/packages/weapp-tailwindcss/src/types/index.ts
@@ -153,6 +153,8 @@ export interface ITemplateHandlerOptions extends ICommonReplaceOptions {
   // 是否转译首字母，默认转译，传入 true 不转
   ignoreHead?: boolean | undefined
   wrapExpression?: boolean | undefined
+  /** 当前正在转换的模板模块标识。 */
+  filename?: string | undefined
 }
 
 export interface InternalUserDefinedOptions extends InternalUserDefinedOptionsBase {

--- a/packages/weapp-tailwindcss/test/compiler/core-compiler-lifecycle.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/core-compiler-lifecycle.test.ts
@@ -26,6 +26,7 @@ function generated(candidates: Iterable<string> = [], target = 'weapp') {
 describe('createCompiler lifecycle', () => {
   afterEach(() => {
     vi.doUnmock('@/generator')
+    vi.doUnmock('@/context')
     vi.resetModules()
   })
 
@@ -233,6 +234,46 @@ describe('createCompiler lifecycle', () => {
 
     await compiler.dispose()
     expect(disposals.get('source-b')).toHaveBeenCalledTimes(1)
+  })
+
+  it('notifies after automatic root eviction but not explicit removal', async () => {
+    const evicted = vi.fn()
+    vi.doMock('@/generator', async (importOriginal) => ({
+      ...await importOriginal<typeof import('@/generator')>(),
+      createWeappTailwindcssGenerator: (source: typeof sourceA) => ({
+        dispose: vi.fn(),
+        generate: async (options: { candidates?: Iterable<string>, target?: string }) => generated(options.candidates, options.target),
+        source,
+        validateCandidates: vi.fn(),
+      }),
+    }))
+    const { createCompiler } = await import('@/core/compiler')
+    const compiler = createCompiler({ compiler: { maxRoots: 1, onRootEvicted: evicted } })
+
+    await compiler.generate({ candidates: ['p-4'], id: 'root-a', source: sourceA as any })
+    await compiler.generate({ candidates: ['m-2'], id: 'root-b', source: sourceB as any })
+    await vi.waitFor(() => expect(evicted).toHaveBeenCalledWith('root-a'))
+    await compiler.remove('root-b')
+    expect(evicted).toHaveBeenCalledTimes(1)
+    await compiler.dispose()
+  })
+
+  it('passes template filename context to custom handlers', async () => {
+    const templateHandler = vi.fn(async (source: string) => source)
+    vi.doMock('@/context', () => ({
+      getCompilerContext: () => ({
+        jsHandler: vi.fn(),
+        styleHandler: Object.assign(vi.fn(), { transformRoot: vi.fn() }),
+        templateHandler,
+      }),
+    }))
+    const { createCompiler } = await import('@/core/compiler')
+    const compiler = createCompiler()
+    const snapshot = compiler.createSnapshot({ classSet: [], id: 'template-root' })
+
+    await compiler.transformTemplate('<view />', snapshot, { filename: '/repo/src/pages/index.wxml' })
+    expect(templateHandler).toHaveBeenCalledWith('<view />', expect.objectContaining({ filename: '/repo/src/pages/index.wxml' }))
+    await compiler.dispose()
   })
 
   it('returns to the root limit after parallel work settles', async () => {

--- a/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
@@ -18,6 +18,34 @@ async function createSource() {
 }
 
 describe('createCompiler', () => {
+  it('finalizes mini-program CSS by default and exposes explicit finalizers', async () => {
+    const compiler = createCompiler()
+    const weapp = compiler.createSnapshot({ classSet: [], id: 'root:weapp', target: 'weapp' })
+    const tailwind = compiler.createSnapshot({ classSet: [], id: 'root:tailwind', target: 'tailwind' })
+    const source = '@plugin "@iconify/tailwind4" { prefixes: mdi; }\n@source "./**/*.vue";\n.card { display: flex; }'
+
+    const finalized = await compiler.transformCss(source, weapp)
+    expect(finalized.css).not.toContain('@plugin')
+    expect(finalized.css).not.toContain('@source')
+
+    const optedOut = await compiler.transformCss(source, weapp, { finalize: false })
+    expect(optedOut.css).toContain('@plugin')
+    expect(optedOut.css).toContain('@source')
+
+    const rawTailwind = await compiler.transformCss(source, tailwind)
+    expect(rawTailwind.css).toContain('@plugin')
+    expect(rawTailwind.css).toContain('@source')
+
+    const rootInput = postcss.parse(source)
+    const rootBefore = rootInput.toString()
+    const finalizedRoot = compiler.finalizeCssRoot(rootInput, { isTailwindcssV4: true })
+    expect(rootInput.toString()).toBe(rootBefore)
+    expect(finalizedRoot.toString()).not.toContain('@plugin')
+    expect(compiler.finalizeCss(source, { isTailwindcssV4: true })).not.toContain('@source')
+
+    await compiler.dispose()
+  })
+
   it('uses one explicit snapshot for generation and every transform', async () => {
     const compiler = createCompiler()
     const source = await createSource()
@@ -196,6 +224,46 @@ describe('createCompiler', () => {
     await compiler.dispose()
     await compiler.dispose()
     expect(() => compiler.createSnapshot({ classSet: [], id: 'after-dispose' })).toThrow('已释放')
+  }, 30000)
+
+  it('invalidates roots when changed files match snapshot source globs', async () => {
+    const compiler = createCompiler()
+    const source = await createSource()
+    const generated = await compiler.generate({
+      candidates: ['p-4'],
+      id: 'source-glob-root',
+      scanSources: [
+        { base: '/repo/src', negated: false, pattern: '**/*.{vue,js}' },
+        { base: '/repo/src', negated: true, pattern: '**/generated/**' },
+      ],
+      source,
+    })
+
+    expect(generated.snapshot.sources).toEqual([
+      { base: '/repo/src', negated: false, pattern: '**/*.{vue,js}' },
+      { base: '/repo/src', negated: true, pattern: '**/generated/**' },
+    ])
+    expect(compiler.invalidate(['/repo/src/pages/index.vue?vue&type=template'])).toEqual(['source-glob-root'])
+    expect(compiler.invalidate(['/repo/src/generated/cache.js'])).toEqual([])
+    expect(compiler.invalidate(['/repo/outside/index.vue'])).toEqual([])
+    expect(compiler.invalidate(['virtual:source-glob-root'])).toEqual([])
+
+    await compiler.dispose()
+  }, 30000)
+
+  it('matches Windows source globs without normalizing opaque IDs', async () => {
+    const compiler = createCompiler()
+    const source = await createSource()
+    await compiler.generate({
+      candidates: ['p-4'],
+      id: 'windows-source-root',
+      scanSources: [{ base: 'C:\\repo\\src', negated: false, pattern: '**/*.vue' }],
+      source,
+    })
+
+    expect(compiler.invalidate(['C:\\repo\\src\\pages\\index.vue?vue&type=template'])).toEqual(['windows-source-root'])
+    expect(compiler.invalidate(['C:/repo/src/pages/index.vue'])).toEqual(['windows-source-root'])
+    await compiler.dispose()
   }, 30000)
 
   it('resolves sourceOptions once and reuses the resolved source for the same request object', async () => {

--- a/packages/weapp-tailwindcss/test/tailwindcss/source-scan.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/source-scan.unit.test.ts
@@ -141,6 +141,21 @@ describe('tailwindcss source scan', () => {
     expect(isFileExcludedByTailwindSourceEntries('/project/src/ignored/a.wxml', entries)).toBe(true)
     expect(isFileMatchedByTailwindSourceEntries('/project/src/index.wxml', undefined)).toBe(true)
     expect(isFileMatchedByTailwindSourceEntries('/project/src/ignored/a.wxml', entries)).toBe(false)
+    const windowsEntries = [
+      {
+        base: 'C:\\workspace\\src',
+        negated: false,
+        pattern: '**/*.tsx',
+      },
+      {
+        base: 'C:\\workspace\\src',
+        negated: true,
+        pattern: 'ignored/**',
+      },
+    ]
+    expect(isFileMatchedByTailwindSourceEntries('C:\\workspace\\src\\pages\\index.tsx', windowsEntries)).toBe(true)
+    expect(isFileMatchedByTailwindSourceEntries('C:\\workspace\\src\\ignored\\index.tsx', windowsEntries)).toBe(false)
+    expect(isFileMatchedByTailwindSourceEntries('D:\\workspace\\src\\pages\\index.tsx', windowsEntries)).toBe(false)
     expect(createTailwindSourceEntryMatcher(undefined)).toBeUndefined()
     expect(createTailwindSourceEntryMatcher(entries)?.('/project/src/index.wxml')).toBe(true)
     expect(resolveTailwindV4CssSourceBase({ base: '/base', file: '/file.css' }, '/fallback')).toBe('/base')

--- a/skills/weapp-tailwindcss-custom-build/references/core-api.md
+++ b/skills/weapp-tailwindcss-custom-build/references/core-api.md
@@ -33,7 +33,7 @@ const generated = await compiler.generate({
 
 1. 框架从模块图确定一个逻辑样式 root 及其实际 candidates。
 2. `generate()` 生成 `web`、`weapp` 或 `tailwind` CSS，并提交递增 revision。
-3. 框架运行自己的 PostCSS 后，把同一个 `snapshot` 交给 `transformCss()` 或 `transformCssRoot()`。
+3. 框架运行自己的 PostCSS 后，把同一个 `snapshot` 交给 `transformCss()` 或 `transformCssRoot()`；小程序目标默认执行 CSS 最终化，也可传入 `finalize: false` 保留构建期 at-rule。
 4. 从模块图投影实际可达的样式 root，用 `mergeSnapshots()` 合并普通分包；独立分包保持独立 snapshot。
 5. `transformTemplate()` 与 `transformJavaScript()` 消费投影后的同一 snapshot。
 6. 检查 JS `error`、`map`、`linked`，再通过 bundler API 写回。
@@ -51,7 +51,9 @@ await compiler.remove(removedRootId)
 await compiler.dispose()
 ```
 
-`invalidate()` 精确匹配 root/dependency ID，不规范化 module ID。`remove()` 和 `dispose()` 幂等，等待进行中的工作结束；开始释放后拒绝新任务。
+`invalidate()` 同时精确匹配 root/dependency ID，并按 snapshot 中的 `sources` glob 匹配文件变化；root/dependency ID 仍不规范化。`remove()` 和 `dispose()` 幂等，等待进行中的工作结束；开始释放后拒绝新任务。
+
+`sourceOptions.cssSources` 可传入内存 CSS source 及其 `base`、`file`、`dependencies`，适合 virtual module 和尚未写回磁盘的 HMR 内容。
 
 ## 返回值与错误
 

--- a/website/docs/api/interfaces/Compiler.md
+++ b/website/docs/api/interfaces/Compiler.md
@@ -45,6 +45,46 @@ keywords:
 
 ***
 
+### finalizeCss()
+
+> **finalizeCss()**: `(css: string, options?: FinalizeMiniProgramCssOptions) => string`
+
+#### 参数
+
+##### css
+
+`string`
+
+##### options?
+
+`any`
+
+#### 返回
+
+`string`
+
+***
+
+### finalizeCssRoot()
+
+> **finalizeCssRoot()**: `(root: Root, options?: FinalizeMiniProgramCssOptions) => Root`
+
+#### 参数
+
+##### root
+
+`Root`
+
+##### options?
+
+`any`
+
+#### 返回
+
+`Root`
+
+***
+
 ### generate()
 
 > **generate()**: `(request: CompilerGenerateRequest) => Promise<CompilerGenerateResult>`
@@ -111,7 +151,7 @@ keywords:
 
 ### transformCss()
 
-> **transformCss()**: `(css: string, snapshot: CompilerSnapshot, options?: Partial<IStyleHandlerOptions>) => Promise<PostcssResult<Root | Document>>`
+> **transformCss()**: `(css: string, snapshot: CompilerSnapshot, options?: CompilerCssTransformOptions) => Promise<PostcssResult<Root | Document>>`
 
 #### 参数
 
@@ -125,7 +165,7 @@ keywords:
 
 ##### options?
 
-`Partial<IStyleHandlerOptions>`
+[`CompilerCssTransformOptions`](./CompilerCssTransformOptions.md)
 
 #### 返回
 
@@ -135,7 +175,7 @@ keywords:
 
 ### transformCssRoot()
 
-> **transformCssRoot()**: `(root: Root, snapshot: CompilerSnapshot, options?: Partial<IStyleHandlerOptions>) => Promise<PostcssResult<Root>>`
+> **transformCssRoot()**: `(root: Root, snapshot: CompilerSnapshot, options?: CompilerCssTransformOptions) => Promise<PostcssResult<Root>>`
 
 #### 参数
 
@@ -149,7 +189,7 @@ keywords:
 
 ##### options?
 
-`Partial<IStyleHandlerOptions>`
+[`CompilerCssTransformOptions`](./CompilerCssTransformOptions.md)
 
 #### 返回
 

--- a/website/docs/api/interfaces/CompilerCssTransformOptions.md
+++ b/website/docs/api/interfaces/CompilerCssTransformOptions.md
@@ -1,0 +1,104 @@
+---
+title: "CompilerCssTransformOptions"
+description: "CompilerCssTransformOptions 的类型说明，列出公开属性、参数和使用边界。"
+keywords:
+  - "weapp-tailwindcss"
+  - "API"
+  - "接口文档"
+  - "配置项"
+  - "小程序"
+  - "tailwindcss"
+  - "微信小程序"
+  - "CompilerCssTransformOptions"
+  - "CompilerCssTransformOptions 接口"
+  - "CompilerCssTransformOptions 类型定义"
+  - "TypeScript"
+---
+
+# CompilerCssTransformOptions
+
+## 属性
+
+### isMainChunk?
+
+> 可选 | **isMainChunk**: `boolean`
+
+***
+
+### cssPreflight?
+
+> 可选 | **cssPreflight**: `CssPreflightOptions`
+
+***
+
+### cssInjectPreflight()?
+
+> 可选 | **cssInjectPreflight()**: `InjectPreflight`
+
+#### 返回
+
+`IPropValue[]`
+
+***
+
+### escapeMap?
+
+> 可选 | **escapeMap**: `Record<string, string>`
+
+***
+
+### finalize?
+
+> 可选 | **finalize**: `boolean`
+
+是否在样式兼容转换后执行小程序 CSS 最终化。
+
+***
+
+### appType?
+
+> 可选 | **appType**: `PostcssAppType`
+
+***
+
+### ctx?
+
+> 可选 | **ctx**: `{ variablesScopeWeakMap: WeakMap<object, any>; isVariablesScope: (rule: WeakKey) => boolean; markVariablesScope: (rule: WeakKey) => void; }`
+
+***
+
+### postcssOptions?
+
+> 可选 | **postcssOptions**: `Partial<Omit<Result, "file">>`
+
+***
+
+### cssOptions?
+
+> 可选 | **cssOptions**: `CssOptions`
+
+***
+
+### uniAppX?
+
+> 可选 | **uniAppX**: `boolean`
+
+***
+
+### uniAppXCssTarget?
+
+> 可选 | **uniAppXCssTarget**: `"uvue"`
+
+uni-app x 的 CSS 输出目标；`uvue` 表示原生 uvue/nvue 样式链路，未设置时按 WebView CSS 处理。
+
+***
+
+### uniAppXUnsupported?
+
+> 可选 | **uniAppXUnsupported**: `UniAppXUnsupportedMode`
+
+***
+
+### majorVersion?
+
+> 可选 | **majorVersion**: `4`

--- a/website/docs/api/interfaces/CompilerTemplateTransformOptions.md
+++ b/website/docs/api/interfaces/CompilerTemplateTransformOptions.md
@@ -88,3 +88,11 @@ keywords:
 ### wrapExpression?
 
 > 可选 | **wrapExpression**: `boolean`
+
+***
+
+### filename?
+
+> 可选 | **filename**: `string`
+
+当前正在转换的模板模块标识。

--- a/website/docs/api/interfaces/CreateCompilerOptions.md
+++ b/website/docs/api/interfaces/CreateCompilerOptions.md
@@ -703,4 +703,4 @@ Babel 8 链路要求 Node `^22.18.0 || >=24.11.0`。OXC 加载失败时仍会自
 
 ### compiler?
 
-> 可选 | **compiler**: `{ maxRoots?: number | undefined; }`
+> 可选 | **compiler**: `{ maxRoots?: number | undefined; onRootEvicted?: ((id: string) => void) | undefined; }`

--- a/website/docs/api/other-interfaces.items.json
+++ b/website/docs/api/other-interfaces.items.json
@@ -3,6 +3,7 @@
   "api/interfaces/CacheOptions",
   "api/interfaces/Compiler",
   "api/interfaces/CompilerCacheReuseState",
+  "api/interfaces/CompilerCssTransformOptions",
   "api/interfaces/CompilerGenerateRequest",
   "api/interfaces/CompilerGenerateResult",
   "api/interfaces/CompilerSnapshot",

--- a/website/docs/api/other-interfaces.md
+++ b/website/docs/api/other-interfaces.md
@@ -2,7 +2,7 @@
 title: "🗂️ 其他接口"
 sidebar_label: "🗂️ 其他接口"
 sidebar_position: 2
-description: "其他接口索引，列出 23 个 weapp-tailwindcss 运行时接口和补充类型。"
+description: "其他接口索引，列出 24 个 weapp-tailwindcss 运行时接口和补充类型。"
 keywords:
   - "weapp-tailwindcss"
   - "API"
@@ -23,6 +23,7 @@ keywords:
 - [CacheOptions](./interfaces/CacheOptions.md) - Tailwind 类名缓存配置。
 - [Compiler](./interfaces/Compiler.md)
 - [CompilerCacheReuseState](./interfaces/CompilerCacheReuseState.md)
+- [CompilerCssTransformOptions](./interfaces/CompilerCssTransformOptions.md)
 - [CompilerGenerateRequest](./interfaces/CompilerGenerateRequest.md)
 - [CompilerGenerateResult](./interfaces/CompilerGenerateResult.md)
 - [CompilerSnapshot](./interfaces/CompilerSnapshot.md) - 一次生成事务的只读转换凭据。

--- a/website/docs/quick-start/frameworks/api.md
+++ b/website/docs/quick-start/frameworks/api.md
@@ -74,12 +74,13 @@ const jsResult = await compiler.transformJavaScript(rawJs, generated.snapshot)
 | `generate(request)` | 按 opaque root `id` 生成 `web`、`weapp` 或 Tailwind 原始 CSS；返回 revision、增量 CSS、依赖、source patterns、缓存复用状态和 snapshot |
 | `createSnapshot(request)` | 接入其他 Tailwind 生成链已经验证过的 classSet；输入集合会被隔离 |
 | `mergeSnapshots(snapshots)` | 确定性合并模块图实际可达的 root；拒绝同 root 冲突 revision、冲突内容和混合 target |
-| `transformCss()` | 转换字符串 CSS，不扫描 runtime classSet |
-| `transformCssRoot()` | 转换 PostCSS Root；不修改输入，输出 AST 不与缓存共享 |
+| `finalizeCss()` / `finalizeCssRoot()` | 将 CSS 或 PostCSS Root 最终化为可交给小程序工具的样式；Root 输入会先 clone |
+| `transformCss()` | 转换字符串 CSS；`snapshot.target === 'weapp'` 时默认清理 Tailwind 构建期 at-rule，可用 `finalize: false` 关闭 |
+| `transformCssRoot()` | 转换 PostCSS Root；同样遵循 `finalize` 选项，且不修改输入 |
 | `transformTemplate()` | 只转换 snapshot 精确命中的静态 class 和表达式候选 |
 | `transformJavaScript()` | 返回现有 `JsHandlerResult`，保留 `error`、`map` 和 `linked` |
-| `invalidate(ids)` | 精确匹配 root/dependency ID，返回需要重新生成的 root；不做路径或 query 规范化 |
-| `remove(id)` / `dispose()` | 幂等等待进行中工作，并释放 root/generator/Scanner 状态 |
+| `invalidate(ids)` | 精确匹配 root/dependency ID，并按 `snapshot.sources` 做 glob-aware 文件匹配；只在 glob 匹配边界剥离 query |
+| `remove(id)` / `dispose()` | 幂等等待进行中工作，并释放 root/generator/Scanner 状态；自动淘汰可通过 `onRootEvicted` 观察 |
 
 同一 root 的 `generate()` 串行提交，不同 root 可以并行。candidate-only 更新复用 engine；CSS 或配置依赖失效后替换会话。生成失败不会替换上一次成功 snapshot。开始 `dispose()` 后所有新任务都会被拒绝。
 

--- a/website/docs/tailwindcss/postcss.mdx
+++ b/website/docs/tailwindcss/postcss.mdx
@@ -88,6 +88,20 @@ import TailwindTopicHero from '@site/src/components/docs/TailwindTopicHero'
 
 ## 典型配置与顺序示例
 
+## 小程序 CSS 最终化 API
+
+`@weapp-tailwindcss/postcss` 提供字符串和 AST 两种最终化入口，用于移除 `@plugin`、`@source`、`@theme`、`@utility` 等构建期指令，并完成小程序不支持语法的兼容处理：
+
+```ts
+import { finalizeMiniProgramCss, finalizeMiniProgramCssRoot, postcss } from '@weapp-tailwindcss/postcss'
+
+const css = finalizeMiniProgramCss('@source "./src"; .card { display: flex; }')
+const root = postcss.parse('@plugin "example"; .card { display: flex; }')
+finalizeMiniProgramCssRoot(root)
+```
+
+Root 入口会原地更新传入 AST；`weapp-tailwindcss/core` 的 `compiler.finalizeCssRoot()` 会先 clone，再返回最终化后的 Root。Compiler 的 `transformCss()` 和 `transformCssRoot()` 在 `snapshot.target === 'weapp'` 时默认执行相同最终化，可传 `finalize: false` 保留构建期 at-rule。
+
 ```js title="postcss.config.cjs"
 module.exports = {
   plugins: [

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/api/interfaces/CompilerCssTransformOptions.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/api/interfaces/CompilerCssTransformOptions.md
@@ -7,6 +7,9 @@ keywords:
   - "compiler"
   - "CSS"
   - "TypeScript"
+  - "Tailwind CSS"
+  - "mini-program"
+  - "PostCSS"
 ---
 
 # CompilerCssTransformOptions

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/api/interfaces/CompilerCssTransformOptions.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/api/interfaces/CompilerCssTransformOptions.md
@@ -1,0 +1,28 @@
+---
+title: "CompilerCssTransformOptions"
+description: "Options for transforming CSS through the core compiler."
+keywords:
+  - "weapp-tailwindcss"
+  - "API"
+  - "compiler"
+  - "CSS"
+  - "TypeScript"
+---
+
+# CompilerCssTransformOptions
+
+Options accepted by `Compiler.transformCss()` and `Compiler.transformCssRoot()`.
+
+## Properties
+
+### finalize?
+
+> **finalize**: `boolean`
+
+Whether to finalize CSS for mini-program output after the style compatibility transform. It defaults to `true` when `snapshot.target` is `"weapp"`; set it to `false` to preserve build-time at-rules.
+
+### isMainChunk?
+
+> **isMainChunk**: `boolean`
+
+Whether this CSS is the main chunk. The remaining properties are inherited from the PostCSS style handler options, including `cssPreflight`, `cssOptions`, `postcssOptions`, `majorVersion`, and `appType`.


### PR DESCRIPTION
## Summary

- 完善 Compiler CSS finalization、Root API 与公开类型导出。
- 增加 source glob-aware invalidation、virtual CSS source 生命周期和 root 淘汰回调。
- 透传 template filename，并同步回归测试、API 文档和中文 changeset。

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build:ci`
- `pnpm --filter @weapp-tailwindcss/postcss test -- --coverage.enabled=false`
- `pnpm --filter weapp-tailwindcss exec vitest run test/compiler/core-compiler.test.ts test/compiler/core-compiler-lifecycle.test.ts --coverage.enabled=false`
- `pnpm --filter @weapp-tailwindcss/postcss lint`
- `pnpm --filter weapp-tailwindcss lint`
- `pnpm tsd:weapp-tailwindcss`

全量 `test:core` 与 `test:plugins` 另有既有环境问题，详见任务记录。

Refs #1133
Refs #1134