### PR TITLE
chore(release): 将 weapp-tailwindcss 发布级别调整为 patch

### DIFF
--- a/.changeset/compiler-finalization-api.md
+++ b/.changeset/compiler-finalization-api.md
@@ -1,5 +1,5 @@
 ---
-"weapp-tailwindcss": minor
+"weapp-tailwindcss": patch
 "@weapp-tailwindcss/postcss": minor
 ---
 


### PR DESCRIPTION
## 变更
- 将合并后的 Compiler/PostCSS API changeset 中 `weapp-tailwindcss` 的发布级别从 `minor` 调整为 `patch`。
- 保留 `@weapp-tailwindcss/postcss` 的 `minor` 发布级别。

Related to #1135