### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/compiler-finalization-api.md
+++ b/.changeset/compiler-finalization-api.md
@@ -1,6 +1,0 @@
----
-"weapp-tailwindcss": patch
-"@weapp-tailwindcss/postcss": minor
----
-
-完善 Core Compiler 与 PostCSS 集成能力：小程序目标默认完成 CSS 最终化，支持 source glob 增量失效、内存 CSS source、root 淘汰回调、模板 filename 上下文，并公开最终化相关 API。

--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -48,6 +48,10 @@
     - bright-package-homepages
     - clever-issues-1113
     - metal-geese-work
+"@weapp-tailwindcss/postcss@3.3.0":
+  dir: packages/postcss
+  intents:
+    - compiler-finalization-api
 "@weapp-tailwindcss/react-native@0.2.5":
   dir: packages/react-native
   intents:
@@ -144,6 +148,10 @@ weapp-tailwindcss@5.4.0:
     - fifty-papayas-camp
     - quiet-issue-1127
     - soft-lines-flow
+weapp-tailwindcss@5.4.1:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - compiler-finalization-api
 weapp-tw@0.0.3:
   dir: packages/weapp-tw
   intents:

--- a/examples/react-lynx-promo/CHANGELOG.md
+++ b/examples/react-lynx-promo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.7
+
+## 0.0.0
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.6
 
 ## 0.0.0

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.7
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.6
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.10
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.9
 
 ## 0.1.3

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/experimental@0.0.37
+  - @weapp-tailwindcss/postcss@3.3.0
+  - weapp-tailwindcss@5.4.1
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/debug-uni-app-x@1.0.5
   - @weapp-tailwindcss/experimental@0.0.36
   - @weapp-tailwindcss/init@1.0.16

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.4.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.4.1
+
 ## 5.4.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/experimental
 
+## 0.0.37
+
+### Patch Changes
+
+- Updated dependencies:
+  - @weapp-tailwindcss/postcss@3.3.0
+
 ## 0.0.36
 
 ### Patch Changes

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/experimental",
   "type": "module",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "Experimental integrations for cross-platform Tailwind CSS. 跨端 Tailwind CSS 实验性集成能力。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "ISC",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.4.1
+
 ## 0.3.6
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "homepage": "https://tw.weapp.dev/docs/quick-start/frameworks/lynx",

--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @weapp-tailwindcss/postcss
 
+## 3.3.0
+
+### Minor Changes
+
+- 完善 Core Compiler 与 PostCSS 集成能力：小程序目标默认完成 CSS 最终化，支持 source glob 增量失效、内存 CSS source、root 淘汰回调、模板 filename 上下文，并公开最终化相关 API。
+
 ## 3.2.12
 
 ### Patch Changes

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/postcss",
   "type": "module",
-  "version": "3.2.12",
+  "version": "3.3.0",
   "description": "PostCSS transforms that bring Tailwind CSS compatibility to every platform. 将 Tailwind CSS 兼容能力带到全端的 PostCSS 转换工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.10
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.4.1
+
 ## 0.2.9
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "homepage": "https://tw.weapp.dev/docs/quick-start/react-native-expo",

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,14 @@
 # weapp-tailwindcss
 
+## 5.4.1
+
+### Patch Changes
+
+- 完善 Core Compiler 与 PostCSS 集成能力：小程序目标默认完成 CSS 最终化，支持 source glob 增量失效、内存 CSS source、root 淘汰回调、模板 filename 上下文，并公开最终化相关 API。
+
+- Updated dependencies:
+  - @weapp-tailwindcss/postcss@3.3.0
+
 ## 5.4.0
 
 ### Minor Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.4.1
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/cva@0.1.9
   - @weapp-tailwindcss/merge@2.2.3
   - @weapp-tailwindcss/variants@0.2.5

--- a/website/static/en/llms-index-full.json
+++ b/website/static/en/llms-index-full.json
@@ -1,12 +1,12 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-28T17:21:19.091Z",
+  "generatedAt": "2026-08-29T18:10:33.558Z",
   "locale": "en-US",
   "contentTier": "full",
   "siteUrl": "https://tw.weapp.dev",
   "totals": {
-    "all": 153,
-    "docs": 152,
+    "all": 154,
+    "docs": 153,
     "blog": 1
   },
   "documents": [
@@ -1286,6 +1286,47 @@
         "output"
       ],
       "source": "i18n/en/docs/api/interfaces/CompilerCacheReuseState.md"
+    },
+    {
+      "kind": "doc",
+      "id": "doc:api/interfaces/CompilerCssTransformOptions",
+      "locale": "en-US",
+      "contentTier": "primary",
+      "productArea": "api",
+      "title": "CompilerCssTransformOptions",
+      "description": "Options for transforming CSS through the core compiler.",
+      "summary": "Options accepted by Compiler.transformCss() and Compiler.transformCssRoot().",
+      "url": "/docs/api/interfaces/CompilerCssTransformOptions",
+      "canonical": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions",
+      "alternates": {
+        "en-US": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions",
+        "zh-CN": "https://tw.weapp.dev/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+        "x-default": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions"
+      },
+      "keywords": [
+        "weapp-tailwindcss",
+        "API",
+        "compiler",
+        "CSS",
+        "TypeScript",
+        "Tailwind CSS",
+        "mini-program",
+        "PostCSS",
+        "reference",
+        "options",
+        "CompilerCssTransformOptions",
+        "interfaces",
+        "Tailwind CSS 4",
+        "cross-platform",
+        "mini app",
+        "uni-app"
+      ],
+      "headings": [
+        "Properties",
+        "finalize?",
+        "isMainChunk?"
+      ],
+      "source": "i18n/en/docs/api/interfaces/CompilerCssTransformOptions.md"
     },
     {
       "kind": "doc",

--- a/website/static/en/llms-index.json
+++ b/website/static/en/llms-index.json
@@ -1,12 +1,12 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-28T17:21:19.091Z",
+  "generatedAt": "2026-08-29T18:10:33.558Z",
   "locale": "en-US",
   "contentTier": "primary",
   "siteUrl": "https://tw.weapp.dev",
   "totals": {
-    "all": 94,
-    "docs": 94,
+    "all": 95,
+    "docs": 95,
     "blog": 0
   },
   "documents": [
@@ -226,6 +226,47 @@
         "output"
       ],
       "source": "i18n/en/docs/api/interfaces/CompilerCacheReuseState.md"
+    },
+    {
+      "kind": "doc",
+      "id": "doc:api/interfaces/CompilerCssTransformOptions",
+      "locale": "en-US",
+      "contentTier": "primary",
+      "productArea": "api",
+      "title": "CompilerCssTransformOptions",
+      "description": "Options for transforming CSS through the core compiler.",
+      "summary": "Options accepted by Compiler.transformCss() and Compiler.transformCssRoot().",
+      "url": "/docs/api/interfaces/CompilerCssTransformOptions",
+      "canonical": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions",
+      "alternates": {
+        "en-US": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions",
+        "zh-CN": "https://tw.weapp.dev/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+        "x-default": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions"
+      },
+      "keywords": [
+        "weapp-tailwindcss",
+        "API",
+        "compiler",
+        "CSS",
+        "TypeScript",
+        "Tailwind CSS",
+        "mini-program",
+        "PostCSS",
+        "reference",
+        "options",
+        "CompilerCssTransformOptions",
+        "interfaces",
+        "Tailwind CSS 4",
+        "cross-platform",
+        "mini app",
+        "uni-app"
+      ],
+      "headings": [
+        "Properties",
+        "finalize?",
+        "isMainChunk?"
+      ],
+      "source": "i18n/en/docs/api/interfaces/CompilerCssTransformOptions.md"
     },
     {
       "kind": "doc",

--- a/website/static/llms-index-full.json
+++ b/website/static/llms-index-full.json
@@ -1,12 +1,12 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-29T07:21:16.207Z",
+  "generatedAt": "2026-08-29T18:10:33.558Z",
   "locale": "zh-CN",
   "contentTier": "full",
   "siteUrl": "https://tw.weapp.dev/zh-cn",
   "totals": {
-    "all": 156,
-    "docs": 152,
+    "all": 157,
+    "docs": 153,
     "blog": 4
   },
   "documents": [
@@ -1378,14 +1378,15 @@
         "属性",
         "createSnapshot()",
         "dispose()",
+        "finalizeCss()",
+        "finalizeCssRoot()",
         "generate()",
         "invalidate()",
         "mergeSnapshots()",
         "remove()",
         "transformCss()",
         "transformCssRoot()",
-        "transformJavaScript()",
-        "transformTemplate()"
+        "transformJavaScript()"
       ],
       "source": "docs/api/interfaces/Compiler.md"
     },
@@ -1430,6 +1431,56 @@
         "output"
       ],
       "source": "docs/api/interfaces/CompilerCacheReuseState.md"
+    },
+    {
+      "kind": "doc",
+      "id": "doc:api/interfaces/CompilerCssTransformOptions",
+      "locale": "zh-CN",
+      "contentTier": "primary",
+      "productArea": "api",
+      "title": "CompilerCssTransformOptions",
+      "description": "CompilerCssTransformOptions 的类型说明，列出公开属性、参数和使用边界。",
+      "summary": "IPropValue[]",
+      "url": "/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+      "canonical": "https://tw.weapp.dev/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+      "alternates": {
+        "en-US": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions",
+        "zh-CN": "https://tw.weapp.dev/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+        "x-default": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions"
+      },
+      "keywords": [
+        "weapp-tailwindcss",
+        "API",
+        "接口文档",
+        "配置项",
+        "小程序",
+        "tailwindcss",
+        "微信小程序",
+        "CompilerCssTransformOptions",
+        "CompilerCssTransformOptions 接口",
+        "CompilerCssTransformOptions 类型定义",
+        "TypeScript",
+        "interfaces",
+        "Tailwind CSS 4",
+        "跨端",
+        "uni-app",
+        "Taro"
+      ],
+      "headings": [
+        "属性",
+        "isMainChunk?",
+        "cssPreflight?",
+        "cssInjectPreflight()?",
+        "escapeMap?",
+        "finalize?",
+        "appType?",
+        "ctx?",
+        "postcssOptions?",
+        "cssOptions?",
+        "uniAppX?",
+        "uniAppXCssTarget?"
+      ],
+      "source": "docs/api/interfaces/CompilerCssTransformOptions.md"
     },
     {
       "kind": "doc",
@@ -1740,7 +1791,8 @@
         "disabledDefaultTemplateHandler?",
         "quote?",
         "ignoreHead?",
-        "wrapExpression?"
+        "wrapExpression?",
+        "filename?"
       ],
       "source": "docs/api/interfaces/CompilerTemplateTransformOptions.md"
     },
@@ -2530,7 +2582,7 @@
       "contentTier": "primary",
       "productArea": "api",
       "title": "🗂️ 其他接口",
-      "description": "其他接口索引，列出 23 个 weapp-tailwindcss 运行时接口和补充类型。",
+      "description": "其他接口索引，列出 24 个 weapp-tailwindcss 运行时接口和补充类型。",
       "summary": "以下接口用于补充配置或运行时能力，本页面仅提供索引。",
       "url": "/zh-cn/docs/api/other-interfaces",
       "canonical": "https://tw.weapp.dev/zh-cn/docs/api/other-interfaces",
@@ -6561,7 +6613,7 @@
       "productArea": "tailwindcss",
       "title": "PostCSS：插件化 CSS 引擎、历史地位与生态",
       "description": "回顾 PostCSS 的发展、核心机制与对现代 CSS 的贡献，并梳理常用插件与最佳实践。",
-      "summary": "回顾 PostCSS 的发展、核心机制与对现代 CSS 的贡献，并梳理常用插件与最佳实践。",
+      "summary": "@weapp-tailwindcss/postcss 提供字符串和 AST 两种最终化入口，用于移除 @plugin、@source、@theme、@utility 等构建期指令，并完成小程序不支持语法的兼容处理：",
       "url": "/zh-cn/docs/tailwindcss/postcss",
       "canonical": "https://tw.weapp.dev/zh-cn/docs/tailwindcss/postcss",
       "alternates": {
@@ -6596,6 +6648,7 @@
         "对 CSS 的贡献与影响",
         "与其他方案的边界",
         "典型配置与顺序示例",
+        "小程序 CSS 最终化 API",
         "调试、性能与迁移建议"
       ],
       "source": "docs/tailwindcss/postcss.mdx"

--- a/website/static/llms-index.json
+++ b/website/static/llms-index.json
@@ -1,12 +1,12 @@
 {
   "version": "2.0.0",
-  "generatedAt": "2026-08-29T07:21:16.207Z",
+  "generatedAt": "2026-08-29T18:10:33.558Z",
   "locale": "zh-CN",
   "contentTier": "primary",
   "siteUrl": "https://tw.weapp.dev/zh-cn",
   "totals": {
-    "all": 94,
-    "docs": 94,
+    "all": 95,
+    "docs": 95,
     "blog": 0
   },
   "documents": [
@@ -175,14 +175,15 @@
         "属性",
         "createSnapshot()",
         "dispose()",
+        "finalizeCss()",
+        "finalizeCssRoot()",
         "generate()",
         "invalidate()",
         "mergeSnapshots()",
         "remove()",
         "transformCss()",
         "transformCssRoot()",
-        "transformJavaScript()",
-        "transformTemplate()"
+        "transformJavaScript()"
       ],
       "source": "docs/api/interfaces/Compiler.md"
     },
@@ -227,6 +228,56 @@
         "output"
       ],
       "source": "docs/api/interfaces/CompilerCacheReuseState.md"
+    },
+    {
+      "kind": "doc",
+      "id": "doc:api/interfaces/CompilerCssTransformOptions",
+      "locale": "zh-CN",
+      "contentTier": "primary",
+      "productArea": "api",
+      "title": "CompilerCssTransformOptions",
+      "description": "CompilerCssTransformOptions 的类型说明，列出公开属性、参数和使用边界。",
+      "summary": "IPropValue[]",
+      "url": "/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+      "canonical": "https://tw.weapp.dev/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+      "alternates": {
+        "en-US": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions",
+        "zh-CN": "https://tw.weapp.dev/zh-cn/docs/api/interfaces/CompilerCssTransformOptions",
+        "x-default": "https://tw.weapp.dev/docs/api/interfaces/CompilerCssTransformOptions"
+      },
+      "keywords": [
+        "weapp-tailwindcss",
+        "API",
+        "接口文档",
+        "配置项",
+        "小程序",
+        "tailwindcss",
+        "微信小程序",
+        "CompilerCssTransformOptions",
+        "CompilerCssTransformOptions 接口",
+        "CompilerCssTransformOptions 类型定义",
+        "TypeScript",
+        "interfaces",
+        "Tailwind CSS 4",
+        "跨端",
+        "uni-app",
+        "Taro"
+      ],
+      "headings": [
+        "属性",
+        "isMainChunk?",
+        "cssPreflight?",
+        "cssInjectPreflight()?",
+        "escapeMap?",
+        "finalize?",
+        "appType?",
+        "ctx?",
+        "postcssOptions?",
+        "cssOptions?",
+        "uniAppX?",
+        "uniAppXCssTarget?"
+      ],
+      "source": "docs/api/interfaces/CompilerCssTransformOptions.md"
     },
     {
       "kind": "doc",
@@ -537,7 +588,8 @@
         "disabledDefaultTemplateHandler?",
         "quote?",
         "ignoreHead?",
-        "wrapExpression?"
+        "wrapExpression?",
+        "filename?"
       ],
       "source": "docs/api/interfaces/CompilerTemplateTransformOptions.md"
     },
@@ -1327,7 +1379,7 @@
       "contentTier": "primary",
       "productArea": "api",
       "title": "🗂️ 其他接口",
-      "description": "其他接口索引，列出 23 个 weapp-tailwindcss 运行时接口和补充类型。",
+      "description": "其他接口索引，列出 24 个 weapp-tailwindcss 运行时接口和补充类型。",
       "summary": "以下接口用于补充配置或运行时能力，本页面仅提供索引。",
       "url": "/zh-cn/docs/api/other-interfaces",
       "canonical": "https://tw.weapp.dev/zh-cn/docs/api/other-interfaces",
@@ -3728,7 +3780,7 @@
       "productArea": "tailwindcss",
       "title": "PostCSS：插件化 CSS 引擎、历史地位与生态",
       "description": "回顾 PostCSS 的发展、核心机制与对现代 CSS 的贡献，并梳理常用插件与最佳实践。",
-      "summary": "回顾 PostCSS 的发展、核心机制与对现代 CSS 的贡献，并梳理常用插件与最佳实践。",
+      "summary": "@weapp-tailwindcss/postcss 提供字符串和 AST 两种最终化入口，用于移除 @plugin、@source、@theme、@utility 等构建期指令，并完成小程序不支持语法的兼容处理：",
       "url": "/zh-cn/docs/tailwindcss/postcss",
       "canonical": "https://tw.weapp.dev/zh-cn/docs/tailwindcss/postcss",
       "alternates": {
@@ -3763,6 +3815,7 @@
         "对 CSS 的贡献与影响",
         "与其他方案的边界",
         "典型配置与顺序示例",
+        "小程序 CSS 最终化 API",
         "调试、性能与迁移建议"
       ],
       "source": "docs/tailwindcss/postcss.mdx"

--- a/website/static/seo-quality-report.json
+++ b/website/static/seo-quality-report.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-29T07:21:17.766Z",
+  "generatedAt": "2026-08-29T18:10:34.768Z",
   "totals": {
-    "files": 309,
+    "files": 311,
     "issues": 0
   },
   "coverage": {
@@ -23,12 +23,12 @@
   },
   "geo": {
     "en": {
-      "primary": 94,
-      "full": 153
+      "primary": 95,
+      "full": 154
     },
     "zh-cn": {
-      "primary": 94,
-      "full": 156
+      "primary": 95,
+      "full": 157
     }
   },
   "routeConsistency": {


### PR DESCRIPTION
# Release Notes

> 6 packages updated · 7 changes

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.4.1**: Updated dependency to weapp-tailwindcss@5.4.1.
- **@weapp-tailwindcss/experimental@0.0.37**: Updated dependency to @weapp-tailwindcss/postcss@3.3.0.
- **@weapp-tailwindcss/lynx@0.3.7**: Updated dependency to weapp-tailwindcss@5.4.1.
- **@weapp-tailwindcss/postcss@3.3.0**: 完善 Core Compiler 与 PostCSS 集成能力：小程序目标默认完成 CSS 最终化，支持 source glob 增量失效、内存 CSS source、root 淘汰回调、模板 filename 上下文，并公开最终化相关 API。 [`6a87d79`](https://github.com/sonofmagic/weapp-tailwindcss/commit/6a87d7962be3f40827b32a69fb7e829842576506) · [#1136](https://github.com/sonofmagic/weapp-tailwindcss/pull/1136)
- **@weapp-tailwindcss/react-native@0.2.10**: Updated dependency to weapp-tailwindcss@5.4.1.
- **weapp-tailwindcss@5.4.1**: 完善 Core Compiler 与 PostCSS 集成能力：小程序目标默认完成 CSS 最终化，支持 source glob 增量失效、内存 CSS source、root 淘汰回调、模板 filename 上下文，并公开最终化相关 API。 [`6a87d79`](https://github.com/sonofmagic/weapp-tailwindcss/commit/6a87d7962be3f40827b32a69fb7e829842576506) · [#1136](https://github.com/sonofmagic/weapp-tailwindcss/pull/1136)
- **weapp-tailwindcss@5.4.1**: Updated dependency to @weapp-tailwindcss/postcss@3.3.0. [`6a87d79`](https://github.com/sonofmagic/weapp-tailwindcss/commit/6a87d7962be3f40827b32a69fb7e829842576506) · [#1136](https://github.com/sonofmagic/weapp-tailwindcss/pull/1136)

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.4.0`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.4.0) | `5.4.1` |
| `@weapp-tailwindcss/experimental` | [`0.0.36`](https://www.npmjs.com/package/@weapp-tailwindcss/experimental/v/0.0.36) | `0.0.37` |
| `@weapp-tailwindcss/lynx` | [`0.3.6`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.6) | `0.3.7` |
| `@weapp-tailwindcss/postcss` | [`3.2.12`](https://www.npmjs.com/package/@weapp-tailwindcss/postcss/v/3.2.12) | `3.3.0` |
| `@weapp-tailwindcss/react-native` | [`0.2.9`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.9) | `0.2.10` |
| `weapp-tailwindcss` | [`5.4.0`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.4.0) | `5.4.1` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic