### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -152,6 +152,11 @@ weapp-tailwindcss@5.4.1:
   dir: packages/weapp-tailwindcss
   intents:
     - compiler-finalization-api
+weapp-tailwindcss@5.4.2:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - quick-web-candidates-skip
+    - quiet-vite-boundary
 weapp-tw@0.0.3:
   dir: packages/weapp-tw
   intents:

--- a/.changeset/quick-web-candidates-skip.md
+++ b/.changeset/quick-web-candidates-skip.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-优化 Generic Web 非 watch 生产构建：跳过不需要的小程序 source-candidates 状态维护，减少重复扫描与构建生命周期开销。

--- a/.changeset/quiet-vite-boundary.md
+++ b/.changeset/quiet-vite-boundary.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-修复 Generic Vite Web 项目在 monorepo 中误继承上层框架配置的问题，并默认收敛成功构建时的 Tailwind CSS 运行时信息日志；显式日志级别和多端框架配置保持不变。

--- a/examples/react-lynx-promo/CHANGELOG.md
+++ b/examples/react-lynx-promo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.8
+
+## 0.0.0
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.7
 
 ## 0.0.0

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.8
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.7
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.11
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.10
 
 ## 0.1.3

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.4.2
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/experimental@0.0.37
   - @weapp-tailwindcss/postcss@3.3.0
   - weapp-tailwindcss@5.4.1

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/cli
 
+## 5.4.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.4.2
+
 ## 5.4.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.4.2
+
 ## 0.3.7
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "homepage": "https://tw.weapp.dev/docs/quick-start/frameworks/lynx",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.4.2
+
 ## 0.2.10
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "homepage": "https://tw.weapp.dev/docs/quick-start/react-native-expo",

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,13 @@
 # weapp-tailwindcss
 
+## 5.4.2
+
+### Patch Changes
+
+- 优化 Generic Web 非 watch 生产构建：跳过不需要的小程序 source-candidates 状态维护，减少重复扫描与构建生命周期开销。
+
+- 修复 Generic Vite Web 项目在 monorepo 中误继承上层框架配置的问题，并默认收敛成功构建时的 Tailwind CSS 运行时信息日志；显式日志级别和多端框架配置保持不变。
+
 ## 5.4.1
 
 ### Patch Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - weapp-tailwindcss@5.4.2
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.4.1
 
 ## 1.0.65


### PR DESCRIPTION
# Release Notes

> 4 packages updated · 5 changes

## 🐞 Bug Fixes

- **weapp-tailwindcss@5.4.2**: 修复 Generic Vite Web 项目在 monorepo 中误继承上层框架配置的问题，并默认收敛成功构建时的 Tailwind CSS 运行时信息日志；显式日志级别和多端框架配置保持不变。 [`28f4984`](https://github.com/sonofmagic/weapp-tailwindcss/commit/28f49847e597b8c3ac04328fda57dbddc5d3d07c) · [#1141](https://github.com/sonofmagic/weapp-tailwindcss/pull/1141) · [#1106](https://github.com/sonofmagic/weapp-tailwindcss/issues/1106)

## 🏎 Performance

- **weapp-tailwindcss@5.4.2**: 优化 Generic Web 非 watch 生产构建：跳过不需要的小程序 source-candidates 状态维护，减少重复扫描与构建生命周期开销。 [`459ba1c`](https://github.com/sonofmagic/weapp-tailwindcss/commit/459ba1cdb6ac84f2d5df99fca49b4d4f752ac12a) · [#1140](https://github.com/sonofmagic/weapp-tailwindcss/pull/1140) · [#1107](https://github.com/sonofmagic/weapp-tailwindcss/issues/1107)

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/cli@5.4.2**: Updated dependency to weapp-tailwindcss@5.4.2.
- **@weapp-tailwindcss/lynx@0.3.8**: Updated dependency to weapp-tailwindcss@5.4.2.
- **@weapp-tailwindcss/react-native@0.2.11**: Updated dependency to weapp-tailwindcss@5.4.2.

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/cli` | [`5.4.1`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.4.1) | `5.4.2` |
| `@weapp-tailwindcss/lynx` | [`0.3.7`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.7) | `0.3.8` |
| `@weapp-tailwindcss/react-native` | [`0.2.10`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.10) | `0.2.11` |
| `weapp-tailwindcss` | [`5.4.1`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.4.1) | `5.4.2` |

## ❤️ Contributors

Thanks to ice breaker · @sonofmagic