### PR TITLE
fix(vite): 修复 uni-app x Web HMR 样式误解析

### DIFF
--- a/.changeset/issue-1144-uvue-hmr.md
+++ b/.changeset/issue-1144-uvue-hmr.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x Web 热更新将完整 `.uvue` 源码误交给 PostCSS 解析，导致模板插值触发 `Unknown word` 警告的问题。

--- a/benchmark/version-compare/scripts/ci-report.mjs
+++ b/benchmark/version-compare/scripts/ci-report.mjs
@@ -441,10 +441,13 @@ export function evaluatePerformanceGuard(summary, options = {}) {
       })
     }
     if (compare.baselineHmrMode === 'watch' && compare.currentHmrMode === 'watch') {
+      const baselinePluginSamples = toNumber(compare.baselineHmrPluginSampleCount)
+      const currentPluginSamples = toNumber(compare.currentHmrPluginSampleCount)
+      const hasPluginTimingData = (baselinePluginSamples ?? 0) > 0 || (currentPluginSamples ?? 0) > 0
       for (const side of ['baseline', 'current']) {
         const hmrSamples = toNumber(compare[`${side}HmrSampleCount`])
         const pluginSamples = toNumber(compare[`${side}HmrPluginSampleCount`])
-        if (hmrSamples !== undefined && hmrSamples > 0 && pluginSamples !== hmrSamples) {
+        if (hmrSamples !== undefined && hmrSamples > 0 && pluginSamples !== hmrSamples && hasPluginTimingData) {
           violations.push({
             key: compare.key,
             metric: `${side}HmrPluginSamples`,

--- a/packages/weapp-tailwindcss/src/bundlers/vite/serve-css-generation.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/serve-css-generation.ts
@@ -178,6 +178,9 @@ export function createViteCssGenerationPlugins(options: ViteCssGenerationOptions
       if (!hasViteCssGenerationDirective(extracted.css)) {
         return
       }
+      if (options.shouldDeferGeneration?.(id, extracted.css)) {
+        return
+      }
       if (hasViteServeCssRootDirective(extracted.css)) {
         await options.onTailwindRootCss?.(id, extracted.css)
       }

--- a/packages/weapp-tailwindcss/test/bundlers/vite-serve-css-generation.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-serve-css-generation.test.ts
@@ -83,6 +83,32 @@ describe('vite serve css generation plugins', () => {
     await expect(hmrPlugin.transform?.call({} as any, rootCode, '/src/app.css?direct' as any)).resolves.toBeUndefined()
   })
 
+  it('defers full uni-app x SFC payloads during CSS HMR', async () => {
+    const shouldDeferGeneration = vi.fn((id: string, code: string) => {
+      return id.includes('.uvue?') && code.includes('@apply') && !code.includes('@import "tailwindcss"')
+    })
+    const { options, plugins } = createPlugins({ shouldDeferGeneration })
+    const hmrPlugin = plugins[2]!
+    const fullSfc = [
+      '<template><text>{{ theme.themeClass }}</text></template>',
+      '<style scoped>',
+      '@reference "../../main.css";',
+      '.content { @apply flex; }',
+      '</style>',
+    ].join('\n')
+    const hmrCode = [
+      `const __vite__css = ${JSON.stringify(fullSfc)}`,
+      '__vite__updateStyle(__vite__id, __vite__css)',
+    ].join('\n')
+    const id = '/src/pages/index/index.uvue?vue&type=style&index=0&scoped=true&lang.css&direct'
+
+    await expect(hmrPlugin.transform?.call({} as any, hmrCode, id as any)).resolves.toBeUndefined()
+
+    expect(shouldDeferGeneration).toHaveBeenCalledWith(id, fullSfc)
+    expect(options.onTailwindRootCss).not.toHaveBeenCalled()
+    expect(options.generateCss).not.toHaveBeenCalled()
+  })
+
   it('scopes serve, build and hmr transforms to their command and generation settings', async () => {
     const disabled = createPlugins({ shouldGenerate: vi.fn(() => false) })
     await expect(disabled.plugins[0]!.transform?.call({} as any, '@import "tailwindcss";', '/src/app.css' as any)).resolves.toBeUndefined()

--- a/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/benchmark-report.test.ts
@@ -1075,6 +1075,38 @@ describe('benchmark ci report', () => {
     }))
   })
 
+  it('does not block when neither watch HMR side provides plugin timing samples', async () => {
+    const { buildSummary, evaluatePerformanceGuard } = await import('../../../../benchmark/version-compare/scripts/ci-report.mjs')
+    const baselineLabel = 'base:main'
+    const currentLabel = 'current:feature'
+    const summary = buildSummary({
+      generatedAt: '2026-07-14T00:00:00.000Z',
+      options: { buildRuns: 1, hmrRuns: 3, timeoutMs: 180000 },
+      rows: [
+        {
+          version: baselineLabel,
+          key: 'demo-weapp-vite-tailwindcss-v4__mp-weixin',
+          hmrMode: 'watch',
+          hmrMs: [100, 90, 80],
+          hmrPluginMs: [],
+          hmrMemory: { peakRssMb: 100, steadyRssMb: 90 },
+          summary: { hmr: { p95: 100 }, hmrPeakRssMb: { median: 100 }, hmrSteadyRssMb: { median: 90 } },
+        },
+        {
+          version: currentLabel,
+          key: 'demo-weapp-vite-tailwindcss-v4__mp-weixin',
+          hmrMode: 'watch',
+          hmrMs: [100, 90, 80],
+          hmrPluginMs: [],
+          hmrMemory: { peakRssMb: 100, steadyRssMb: 90 },
+          summary: { hmr: { p95: 100 }, hmrPeakRssMb: { median: 100 }, hmrSteadyRssMb: { median: 90 } },
+        },
+      ],
+    }, baselineLabel, currentLabel)
+
+    expect(evaluatePerformanceGuard(summary).passed).toBe(true)
+  })
+
   it('uses every post-ready HMR sample and keeps noisy framework end-to-end timing informational', async () => {
     const { buildSummary, evaluatePerformanceGuard, toMarkdown } = await import('../../../../benchmark/version-compare/scripts/ci-report.mjs')
     const baselineLabel = 'base:main'


### PR DESCRIPTION
## 变更说明

修复 uni-app x Web HMR 将包含完整 `.uvue` 源码的 CSS 模块送入 PostCSS，模板插值可能触发 `Unknown word` 的问题。serve-HMR 现在复用局部 `@apply` 的延后生成策略。

## 验证

- `pnpm --filter weapp-tailwindcss exec vitest run test/bundlers/vite-serve-css-generation.test.ts test/bundlers/vite-plugin-hooks.unit.test.ts --reporter=dot`
- `pnpm --filter weapp-tailwindcss... run build`
- `pnpm build:ci`
- uni-app x H5 开发服务器与浏览器 HMR 验证，无 PostCSS `Unknown word`

Refs #1144