### PR TITLE
fix(ci): 修复发布认证证书竞态

### DIFF
--- a/.github/workflows/e2e-coverage-nightly.yml
+++ b/.github/workflows/e2e-coverage-nightly.yml
@@ -73,10 +73,7 @@ jobs:
         shell: bash
         run: pnpm exec playwright install chromium chromium-headless-shell
       - name: Run hosted static suite
-        run: >-
-          pnpm e2e:static
-          --exclude e2e/uni-app-vite-vue3-hbuilderx-tailwindcss-v4.test.ts
-          --exclude e2e/uni-app-x-vdom-tailwindcss-v4.test.ts
+        run: pnpm e2e:static
       - run: pnpm e2e:frameworks:matrix
       - run: pnpm e2e:multiplatform-build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,31 @@ jobs:
           RELEASE_CERTIFICATE_RUN_ID: ${{ vars.RELEASE_CERTIFICATE_RUN_ID }}
         run: |
           run_id="$RELEASE_CERTIFICATE_RUN_ID"
-          if [ -z "$run_id" ]; then
-            run_id="$(gh run list --workflow e2e-coverage-nightly.yml --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
-          fi
-          test -n "$run_id" || { echo "No successful same-commit coverage workflow run" >&2; exit 1; }
+          test -n "$run_id" || {
+            echo "Release certificate is not configured. Set RELEASE_CERTIFICATE_RUN_ID to a completed run that uploaded the signed certificate artifact for this commit." >&2
+            exit 1
+          }
+          run_metadata="$(gh run view "$run_id" --json headSha,status,conclusion)"
+          run_head_sha="$(jq -r '.headSha' <<<"$run_metadata")"
+          run_status="$(jq -r '.status' <<<"$run_metadata")"
+          run_conclusion="$(jq -r '.conclusion' <<<"$run_metadata")"
+          test "$run_head_sha" = "$GITHUB_SHA" || {
+            echo "Release certificate run $run_id belongs to $run_head_sha, expected $GITHUB_SHA" >&2
+            exit 1
+          }
+          test "$run_status" = completed && test "$run_conclusion" = success || {
+            echo "Release certificate run $run_id is not a successful completed run (status=$run_status conclusion=$run_conclusion)" >&2
+            exit 1
+          }
+          certificate_name="coverage-certificate-$GITHUB_SHA"
+          certificate_artifact="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" --paginate --jq '.artifacts[] | select(.expired == false) | .name' | grep -Fx "$certificate_name" || true)"
+          test "$certificate_artifact" = "$certificate_name" || {
+            echo "Run $run_id did not upload the required $certificate_name artifact" >&2
+            exit 1
+          }
           rm -rf e2e/.artifacts/release-certificate
           mkdir -p e2e/.artifacts/release-certificate
-          gh run download "$run_id" --name "coverage-certificate-$GITHUB_SHA" --dir e2e/.artifacts/release-certificate
+          gh run download "$run_id" --name "$certificate_name" --dir e2e/.artifacts/release-certificate
 
       - name: Validate release certificate
         shell: bash

--- a/e2e/RELEASE-CERTIFICATION.md
+++ b/e2e/RELEASE-CERTIFICATION.md
@@ -31,4 +31,6 @@ pnpm e2e:coverage:release-gate --report <coverage-report.json>
 
 validator 会重新计算 summary，检查 registry/catalog/toolchain identity、required layer、artifact checksum 和 cosign 签名元数据。没有同 SHA 的认证 artifact、没有 local-required 证据或签名校验失败时，`repo release ci` 不会执行。
 
+认证 artifact 必须来自仓库变量 `RELEASE_CERTIFICATE_RUN_ID` 指定的已完成成功 workflow run。Release 不会自动选择 nightly run：hosted nightly 当前只上传诊断 artifact，且在发布启动时可能仍处于运行状态，自动选择会造成竞态并可能把诊断报告误当认证证书。生成本地/自托管认证报告后，应将上传该 artifact 的 workflow run ID 写入 `RELEASE_CERTIFICATE_RUN_ID`，并确保其 head SHA 等于发布 commit。
+
 GitHub branch protection 应将 `Multiplatform Coverage Gate` 和 `Release Certificate Gate` 设为 required check，并通过受保护 Environment 配置审批。self-hosted runner 尚未配置前，发布认证会保持阻断，这是预期行为。

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -584,6 +584,19 @@ describe('ci workflows', () => {
     expect(source).not.toContain('NODE_AUTH_TOKEN:')
   })
 
+  it('requires an explicit same-commit release certificate run', () => {
+    const { source } = readWorkflow('release.yml')
+
+    expect(source).toContain('RELEASE_CERTIFICATE_RUN_ID: ${{ vars.RELEASE_CERTIFICATE_RUN_ID }}')
+    expect(source).toContain('Release certificate is not configured')
+    expect(source).toContain('gh run view "$run_id" --json headSha,status,conclusion')
+    expect(source).toContain('test "$run_head_sha" = "$GITHUB_SHA"')
+    expect(source).toContain('test "$run_status" = completed && test "$run_conclusion" = success')
+    expect(source).toContain('certificate_name="coverage-certificate-$GITHUB_SHA"')
+    expect(source).toContain('did not upload the required $certificate_name artifact')
+    expect(source).not.toContain('gh run list --workflow e2e-coverage-nightly.yml')
+  })
+
   it('runs release verification and npmmirror sync through repoctl hooks', () => {
     const config = readText('repoctl.config.ts')
     const packageJson = readPackageJson<{ scripts: Record<string, string> }>('package.json')

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -441,6 +441,16 @@ describe('ci workflows', () => {
     expect(nightlySource).not.toContain('--source nightly')
   })
 
+  it('keeps nightly hosted static invocation cross-platform', () => {
+    const { workflow } = readWorkflow('e2e-coverage-nightly.yml')
+    const runStep = workflow.jobs['framework-matrix'].steps.find((step: Record<string, unknown>) => {
+      return step.name === 'Run hosted static suite'
+    })
+
+    expect(runStep.run).toBe('pnpm e2e:static')
+    expect(workflow.jobs['framework-matrix'].env.E2E_SKIP_OPEN_AUTOMATOR).toBe('1')
+  })
+
   it('keeps a lightweight cross-platform e2e watch gate in CI', () => {
     const { workflow } = readWorkflow('ci.yml')
     const job = workflow.jobs['e2e-watch']


### PR DESCRIPTION
修复 Release 在 nightly 尚未完成时自动扫描同 SHA workflow 的竞态，并阻止把 hosted diagnostic artifact 当作 release certificate。

- Release 仅接受仓库变量 `RELEASE_CERTIFICATE_RUN_ID` 指定的成功 run
- 校验 run 的 head SHA、完成状态、成功结论和精确 certificate artifact
- 同步发布认证文档与 workflow 契约测试

Refs #1144