### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/bright-deps-migrate.md
+++ b/.changeset/bright-deps-migrate.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-升级兼容范围内的工作区依赖，迁移 Tailwind CSS 4 测试辅助工具的可选配置处理，并修正 PostCSS 本地 `postcss-calc` 链接路径。

--- a/.changeset/dx-vite-doctor-init.md
+++ b/.changeset/dx-vite-doctor-init.md
@@ -1,7 +1,0 @@
----
-"weapp-tailwindcss": minor
-"@weapp-tailwindcss/cli": minor
-"@weapp-tailwindcss/init": major
----
-
-改善开发体验：新增固定 Generic Web target 的 `weapp-tailwindcss/vite/web` 入口，修正 `doctor` 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 `mode: 'legacy'` 显式启用。

--- a/.changeset/issue-1144-uvue-hmr.md
+++ b/.changeset/issue-1144-uvue-hmr.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-修复 uni-app x Web 热更新将完整 `.uvue` 源码误交给 PostCSS 解析，导致模板插值触发 `Unknown word` 警告的问题。

--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -2,6 +2,10 @@
   dir: packages/cli
   intents:
     - bright-package-homepages
+"@weapp-tailwindcss/cli@5.5.0":
+  dir: packages/cli
+  intents:
+    - dx-vite-doctor-init
 "@weapp-tailwindcss/cva@0.1.9":
   dir: packages-runtime/cva
   intents:
@@ -22,6 +26,10 @@
   dir: packages/init
   intents:
     - bright-package-homepages
+"@weapp-tailwindcss/init@2.0.0":
+  dir: packages/init
+  intents:
+    - dx-vite-doctor-init
 "@weapp-tailwindcss/logger@2.0.3":
   dir: packages/logger
   intents:
@@ -52,6 +60,11 @@
   dir: packages/postcss
   intents:
     - compiler-finalization-api
+"@weapp-tailwindcss/postcss@3.3.1":
+  dir: packages/postcss
+  intents:
+    - steady-compiler-boundary
+    - strict-tailwind-source-media
 "@weapp-tailwindcss/react-native@0.2.5":
   dir: packages/react-native
   intents:
@@ -76,14 +89,26 @@
   dir: packages-runtime/typography
   intents:
     - bright-package-homepages
+"@weapp-tailwindcss/typography@1.0.5":
+  dir: packages-runtime/typography
+  intents:
+    - steady-compiler-boundary
 "@weapp-tailwindcss/ui@0.0.12":
   dir: packages-runtime/ui
   intents:
     - bright-package-homepages
+"@weapp-tailwindcss/ui@0.0.13":
+  dir: packages-runtime/ui
+  intents:
+    - steady-compiler-boundary
 "@weapp-tailwindcss/variants@0.2.5":
   dir: packages-runtime/variants
   intents:
     - bright-package-homepages
+"@weapp-tailwindcss/variants@0.2.6":
+  dir: packages-runtime/variants
+  intents:
+    - steady-compiler-boundary
 tailwindcss-config@2.0.4:
   dir: packages/tailwindcss-config
   intents:
@@ -157,6 +182,16 @@ weapp-tailwindcss@5.4.2:
   intents:
     - quick-web-candidates-skip
     - quiet-vite-boundary
+weapp-tailwindcss@5.5.0:
+  dir: packages/weapp-tailwindcss
+  intents:
+    - bright-deps-migrate
+    - dx-vite-doctor-init
+    - issue-1144-uvue-hmr
+    - steady-compiler-boundary
+    - strict-ci-platform-gates
+    - strict-tailwind-source-media
+    - web-css-only
 weapp-tw@0.0.3:
   dir: packages/weapp-tw
   intents:

--- a/.changeset/steady-compiler-boundary.md
+++ b/.changeset/steady-compiler-boundary.md
@@ -1,9 +1,0 @@
----
-"weapp-tailwindcss": minor
-"@weapp-tailwindcss/postcss": patch
-"@weapp-tailwindcss/variants": patch
-"@weapp-tailwindcss/typography": patch
-"@weapp-tailwindcss/ui": patch
----
-
-统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。

--- a/.changeset/strict-ci-platform-gates.md
+++ b/.changeset/strict-ci-platform-gates.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": patch
----
-
-修复多端 CI 构建依赖闭包、Playwright headless 浏览器安装和小程序样式产物收尾，避免兼容性测试因缺少构建入口或残留 CSS 哨兵失败。

--- a/.changeset/strict-tailwind-source-media.md
+++ b/.changeset/strict-tailwind-source-media.md
@@ -1,6 +1,0 @@
----
-"@weapp-tailwindcss/postcss": patch
-"weapp-tailwindcss": patch
----
-
-统一处理 Tailwind source media 尾部残片，避免非法 CSS 进入小程序最终产物。

--- a/.changeset/web-css-only.md
+++ b/.changeset/web-css-only.md
@@ -1,5 +1,0 @@
----
-"weapp-tailwindcss": minor
----
-
-将 `weapp-tailwindcss/vite/web` 拆分为真正的 Generic Web CSS-only 管线：默认只处理 CSS 生成与 HMR，不注册 JS/template、框架扩展、分包和小程序收尾；主入口识别为 Generic Web 后复用相同 profile，`styleInjector` 改为显式 opt-in。

--- a/.github/workflows/benchmark-pr-report.yml
+++ b/.github/workflows/benchmark-pr-report.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Upload aggregate report artifact
         id: upload
         if: always() && steps.metadata.outputs.stale != 'true' && steps.metadata.outputs.pr_number != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-benchmark-report-${{ steps.metadata.outputs.pr_number }}-${{ steps.metadata.outputs.head_sha }}
           path: .tmp/benchmark-pr-report/output/**

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload benchmark artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-performance-${{ matrix.case_name }}
           path: .tmp/benchmark-ci/result/**

--- a/.github/workflows/canonical-templates.yml
+++ b/.github/workflows/canonical-templates.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload canonical template artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: canonical-template-artifacts-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload CI memory reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-memory-quality-static-${{ github.run_id }}
           path: e2e/benchmark/ci-memory/**
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload CI memory reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-memory-unit-${{ matrix.shard }}-${{ github.run_id }}
           path: e2e/benchmark/ci-memory/**
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload CI memory reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-memory-e2e-static-${{ matrix.shard }}-${{ github.run_id }}
           path: e2e/benchmark/ci-memory/**
@@ -305,7 +305,7 @@ jobs:
 
       - name: Upload CI memory reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-memory-e2e-focused-${{ matrix.case_name }}-${{ github.run_id }}
           path: e2e/benchmark/ci-memory/**
@@ -368,7 +368,7 @@ jobs:
 
       - name: Upload CI memory reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-memory-e2e-multiplatform-${{ matrix.case_name }}-${{ github.run_id }}
           path: e2e/benchmark/ci-memory/**
@@ -517,7 +517,7 @@ jobs:
 
       - name: Upload e2e watch reports (always)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-watch-hmr-ci-${{ matrix.runner_label }}-node${{ matrix.node-version }}-${{ matrix.artifact_case || matrix.watch_case }}-${{ matrix.round_profile }}-${{ github.run_id }}
           path: |
@@ -529,7 +529,7 @@ jobs:
 
       - name: Upload e2e watch failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-watch-hmr-ci-failure-${{ matrix.runner_label }}-node${{ matrix.node-version }}-${{ matrix.artifact_case || matrix.watch_case }}-${{ matrix.round_profile }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/e2e-coverage-nightly.yml
+++ b/.github/workflows/e2e-coverage-nightly.yml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm e2e:coverage:contract
       - name: Generate hosted coverage diagnostic
         run: pnpm e2e:coverage:report --source aggregate --include-baselines --out e2e/.artifacts/coverage/nightly-diagnostic-report.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-diagnostic-${{ github.sha }}
@@ -95,7 +95,7 @@ jobs:
       - run: pnpm e2e:react-native-compatibility
       - run: pnpm e2e:react-native:web
       - run: pnpm e2e:lynx
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: e2e-coverage-native-${{ github.run_id }}

--- a/.github/workflows/e2e-coverage-pr.yml
+++ b/.github/workflows/e2e-coverage-pr.yml
@@ -38,7 +38,7 @@ jobs:
         run: pnpm e2e:coverage:report --source aggregate --include-baselines --out e2e/.artifacts/coverage/pr-diagnostic-report.json
       - name: Upload coverage diagnostic
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-diagnostic-${{ github.sha }}
           path: e2e/.artifacts/coverage/**

--- a/.github/workflows/e2e-ide.yml
+++ b/.github/workflows/e2e-ide.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Upload IDE HMR reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-ide-hmr-memory-${{ matrix.case_name }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/e2e-watch.yml
+++ b/.github/workflows/e2e-watch.yml
@@ -866,7 +866,7 @@ jobs:
 
       - name: Upload e2e watch reports (always)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-watch-hmr-pr-${{ matrix.runner_label }}-node${{ matrix['node-version'] || 22 }}-${{ matrix.artifact_case || matrix.watch_case }}-${{ matrix.round_profile }}-${{ github.run_id }}
           path: |
@@ -878,7 +878,7 @@ jobs:
 
       - name: Upload e2e watch failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-watch-hmr-pr-failure-${{ matrix.runner_label }}-node${{ matrix['node-version'] || 22 }}-${{ matrix.artifact_case || matrix.watch_case }}-${{ matrix.round_profile }}-${{ github.run_id }}
           path: |
@@ -1426,7 +1426,7 @@ jobs:
 
       - name: Upload e2e watch reports (always)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-watch-hmr-nightly-${{ matrix.runner_label }}-node${{ matrix['node-version'] || 22 }}-${{ matrix.artifact_case || matrix.watch_case }}-${{ matrix.round_profile }}-${{ github.run_id }}
           path: |
@@ -1438,7 +1438,7 @@ jobs:
 
       - name: Upload e2e watch failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-watch-hmr-nightly-failure-${{ matrix.runner_label }}-node${{ matrix['node-version'] || 22 }}-${{ matrix.artifact_case || matrix.watch_case }}-${{ matrix.round_profile }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/lynx-native.yml
+++ b/.github/workflows/lynx-native.yml
@@ -52,7 +52,7 @@ jobs:
             echo 'The hosted Ubuntu Android emulator is diagnostic-only because this runner has no KVM hardware acceleration.'
             echo 'Artifacts remain available for investigation; the submitted arm64 simulator report remains the authoritative Android baseline.'
           } >> "$GITHUB_STEP_SUMMARY"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: lynx-android-${{ github.run_id }}
@@ -82,7 +82,7 @@ jobs:
           xcrun simctl boot "$udid"
           xcrun simctl bootstatus "$udid" -b
       - run: pnpm e2e:lynx:ios
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: lynx-ios-${{ github.run_id }}

--- a/.github/workflows/react-native-compatibility.yml
+++ b/.github/workflows/react-native-compatibility.yml
@@ -44,7 +44,7 @@ jobs:
           pnpm exec playwright install chromium chromium-headless-shell
       - run: pnpm e2e:react-native-compatibility
       - run: pnpm e2e:react-native:web
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: react-native-web-${{ github.run_id }}
@@ -87,7 +87,7 @@ jobs:
           disable-animations: true
           disable-spellchecker: true
           script: RN_ANDROID_DEVICE_ID=emulator-5554 RN_ANDROID_BINARY=examples/react-native-expo/android/app/build/outputs/apk/debug/app-debug.apk pnpm e2e:react-native:android
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: react-native-android-${{ github.run_id }}
@@ -121,7 +121,7 @@ jobs:
         env:
           RN_IOS_HOST: 127.0.0.1
         run: pnpm e2e:react-native:ios
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: react-native-ios-${{ github.run_id }}

--- a/benchmark/tailwindcss4/CHANGELOG.md
+++ b/benchmark/tailwindcss4/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/variants@0.2.6
+
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/cva@0.1.9
   - @weapp-tailwindcss/merge@2.2.3
   - @weapp-tailwindcss/variants@0.2.5

--- a/examples/react-lynx-promo/CHANGELOG.md
+++ b/examples/react-lynx-promo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.9
+
+## 0.0.0
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.8
 
 ## 0.0.0

--- a/examples/react-lynx/CHANGELOG.md
+++ b/examples/react-lynx/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/lynx@0.3.9
+
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/lynx@0.3.8
 
 ## 0.1.2

--- a/examples/react-native-expo/CHANGELOG.md
+++ b/examples/react-native-expo/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/react-native@0.2.12
+
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies:
   - @weapp-tailwindcss/react-native@0.2.11
 
 ## 0.1.3

--- a/packages-runtime/typography/CHANGELOG.md
+++ b/packages-runtime/typography/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @weapp-tailwindcss/typography
 
+## 1.0.5
+
+### Patch Changes
+
+- 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages-runtime/typography/package.json
+++ b/packages-runtime/typography/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/typography",
   "type": "module",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Tailwind CSS Typography plugin and markup transforms for cross-platform apps. 面向跨端应用的 Tailwind CSS Typography 插件与标记转换工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages-runtime/ui/CHANGELOG.md
+++ b/packages-runtime/ui/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @weapp-tailwindcss/ui
 
+## 0.0.13
+
+### Patch Changes
+
+- 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。
+
+- Updated dependencies:
+  - @weapp-tailwindcss/variants@0.2.6
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages-runtime/ui/package.json
+++ b/packages-runtime/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/ui",
   "type": "module",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Cross-platform utility-first UI components for Tailwind CSS. 面向跨端 Tailwind CSS 的 utility-first UI 组件库。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "ISC",

--- a/packages-runtime/variants/CHANGELOG.md
+++ b/packages-runtime/variants/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @weapp-tailwindcss/variants
 
+## 0.2.6
+
+### Patch Changes
+
+- 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。
+
 ## 0.2.5
 
 ### Patch Changes

--- a/packages-runtime/variants/package.json
+++ b/packages-runtime/variants/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/variants",
   "type": "module",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Cross-platform tailwind-variants runtime with Tailwind CSS class compatibility. 兼容 Tailwind CSS 类名的跨端 tailwind-variants 运行时封装。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/build-all/CHANGELOG.md
+++ b/packages/build-all/CHANGELOG.md
@@ -5,6 +5,16 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/experimental@0.0.38
+  - @weapp-tailwindcss/init@2.0.0
+  - @weapp-tailwindcss/postcss@3.3.1
+  - weapp-tailwindcss@5.5.0
+
+## 0.0.72
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.4.2
 
 ## 0.0.72

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @weapp-tailwindcss/cli
 
+## 5.5.0
+
+### Minor Changes
+
+- 改善开发体验：新增固定 Generic Web target 的 `weapp-tailwindcss/vite/web` 入口，修正 `doctor` 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 `mode: 'legacy'` 显式启用。
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.5.0
+
 ## 5.4.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/cli",
   "type": "module",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "description": "Cross-platform Tailwind CSS CLI for Web and mini-program builds. 面向 Web 与小程序构建的跨端 Tailwind CSS CLI。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/experimental
 
+## 0.0.38
+
+### Patch Changes
+
+- Updated dependencies:
+  - @weapp-tailwindcss/postcss@3.3.1
+
 ## 0.0.37
 
 ### Patch Changes

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/experimental",
   "type": "module",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Experimental integrations for cross-platform Tailwind CSS. 跨端 Tailwind CSS 实验性集成能力。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "ISC",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @weapp-tailwindcss/init
 
+## 2.0.0
+
+### Major Changes
+
+- 改善开发体验：新增固定 Generic Web target 的 `weapp-tailwindcss/vite/web` 入口，修正 `doctor` 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 `mode: 'legacy'` 显式启用。
+
 ## 1.0.16
 
 ### Patch Changes

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/init",
   "type": "module",
-  "version": "1.0.16",
+  "version": "2.0.0",
   "description": "Project initializer for cross-platform Tailwind CSS with weapp-tailwindcss. 用于初始化跨端 Tailwind CSS 项目的 weapp-tailwindcss 工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/lynx/CHANGELOG.md
+++ b/packages/lynx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/lynx
 
+## 0.3.9
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.5.0
+
 ## 0.3.8
 
 ### Patch Changes

--- a/packages/lynx/package.json
+++ b/packages/lynx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/lynx",
   "type": "module",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Tailwind CSS integration for ReactLynx and Rspeedy cross-platform builds. 面向 ReactLynx 与 Rspeedy 跨端构建的 Tailwind CSS 集成。",
   "license": "MIT",
   "homepage": "https://tw.weapp.dev/docs/quick-start/frameworks/lynx",

--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @weapp-tailwindcss/postcss
 
+## 3.3.1
+
+### Patch Changes
+
+- 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。
+
+- 统一处理 Tailwind source media 尾部残片，避免非法 CSS 进入小程序最终产物。
+
 ## 3.3.0
 
 ### Minor Changes

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/postcss",
   "type": "module",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "PostCSS transforms that bring Tailwind CSS compatibility to every platform. 将 Tailwind CSS 兼容能力带到全端的 PostCSS 转换工具。",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @weapp-tailwindcss/react-native
 
+## 0.2.12
+
+### Patch Changes
+
+- Updated dependencies:
+  - weapp-tailwindcss@5.5.0
+
 ## 0.2.11
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@weapp-tailwindcss/react-native",
   "type": "module",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Tailwind CSS compiler and Expo Metro integration for cross-platform React Native apps. 面向跨端 React Native 应用的 Tailwind CSS 编译器与 Expo Metro 集成。",
   "license": "MIT",
   "homepage": "https://tw.weapp.dev/docs/quick-start/react-native-expo",

--- a/packages/weapp-tailwindcss/CHANGELOG.md
+++ b/packages/weapp-tailwindcss/CHANGELOG.md
@@ -1,5 +1,28 @@
 # weapp-tailwindcss
 
+## 5.5.0
+
+### Minor Changes
+
+- 改善开发体验：新增固定 Generic Web target 的 `weapp-tailwindcss/vite/web` 入口，修正 `doctor` 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 `mode: 'legacy'` 显式启用。
+
+- 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。
+
+- 将 `weapp-tailwindcss/vite/web` 拆分为真正的 Generic Web CSS-only 管线：默认只处理 CSS 生成与 HMR，不注册 JS/template、框架扩展、分包和小程序收尾；主入口识别为 Generic Web 后复用相同 profile，`styleInjector` 改为显式 opt-in。
+
+### Patch Changes
+
+- 升级兼容范围内的工作区依赖，迁移 Tailwind CSS 4 测试辅助工具的可选配置处理，并修正 PostCSS 本地 `postcss-calc` 链接路径。
+
+- 修复 uni-app x Web 热更新将完整 `.uvue` 源码误交给 PostCSS 解析，导致模板插值触发 `Unknown word` 警告的问题。
+
+- 修复多端 CI 构建依赖闭包、Playwright headless 浏览器安装和小程序样式产物收尾，避免兼容性测试因缺少构建入口或残留 CSS 哨兵失败。
+
+- 统一处理 Tailwind source media 尾部残片，避免非法 CSS 进入小程序最终产物。
+
+- Updated dependencies:
+  - @weapp-tailwindcss/postcss@3.3.1
+
 ## 5.4.2
 
 ### Patch Changes

--- a/packages/weapp-tailwindcss/package.json
+++ b/packages/weapp-tailwindcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weapp-tailwindcss",
   "type": "module",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "description": "Bring Tailwind CSS to every platform! 把 Tailwind CSS 的原子化开发体验带到全端！",
   "author": "ice breaker <1324318532@qq.com>",
   "license": "MIT",

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -7,6 +7,7 @@ import YAML from 'yaml'
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(dirname, '../../../..')
 const workflowsRoot = path.join(repoRoot, '.github/workflows')
+const uploadArtifactAction = 'actions/upload-artifact@v7'
 
 function readWorkflow(filename: string) {
   const source = fs.readFileSync(path.join(workflowsRoot, filename), 'utf8')
@@ -493,7 +494,7 @@ describe('ci workflows', () => {
     expect(runStep.env.E2E_WATCH_WEB_ONLY).toBe("${{ matrix.watch_web_only || '0' }}")
     expect(runStep.env.E2E_WATCH_MAX_PLUGIN_PROCESS_MS).toBe("${{ matrix.watch_max_plugin_process_ms || '6000' }}")
     const uploadSteps = job.steps.filter((step: Record<string, unknown>) => {
-      return step.uses === 'actions/upload-artifact@v4'
+      return step.uses === uploadArtifactAction
     })
     expect(uploadSteps).toHaveLength(2)
     for (const step of uploadSteps) {
@@ -503,7 +504,7 @@ describe('ci workflows', () => {
     }
     expect(job.steps.some((step: Record<string, unknown>) => {
       const withConfig = step.with as Record<string, unknown> | undefined
-      return step.uses === 'actions/upload-artifact@v4'
+      return step.uses === uploadArtifactAction
         && typeof withConfig?.path === 'string'
         && withConfig.path.includes('e2e/benchmark/e2e-watch-hmr/hmr-speed-report.md')
     })).toBe(true)
@@ -763,7 +764,7 @@ describe('ci workflows', () => {
     expect(runs).toContain('--result-dir .tmp/benchmark-ci/result')
     expect(job.steps.some((step: Record<string, unknown>) => {
       const withConfig = step.with as Record<string, unknown> | undefined
-      return step.uses === 'actions/upload-artifact@v4'
+      return step.uses === uploadArtifactAction
         && withConfig?.name === 'benchmark-performance-${{ matrix.case_name }}'
     })).toBe(true)
   })
@@ -1631,7 +1632,7 @@ describe('e2e watch workflow', () => {
     const uploadSteps = [
       ...workflow.jobs['pr-quick-gate'].steps,
       ...workflow.jobs['nightly-full-regression'].steps,
-    ].filter((step: Record<string, unknown>) => step.uses === 'actions/upload-artifact@v4')
+    ].filter((step: Record<string, unknown>) => step.uses === uploadArtifactAction)
 
     expect(uploadSteps.length).toBe(4)
     for (const step of uploadSteps) {
@@ -1651,7 +1652,7 @@ describe('e2e watch workflow', () => {
       expect(runs).toContain('node .github/scripts/e2e-watch-report.cjs job-summary')
       expect(job.steps.some((step: Record<string, unknown>) => {
         const withConfig = step.with as Record<string, unknown> | undefined
-        return step.uses === 'actions/upload-artifact@v4'
+        return step.uses === uploadArtifactAction
           && typeof withConfig?.path === 'string'
           && withConfig.path.includes('e2e/benchmark/e2e-watch-hmr/hmr-speed-report.md')
       })).toBe(true)

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Patch Changes
 
 - Updated dependencies:
+  - @weapp-tailwindcss/variants@0.2.6
+  - weapp-tailwindcss@5.5.0
+
+## 1.0.65
+
+### Patch Changes
+
+- Updated dependencies:
   - weapp-tailwindcss@5.4.2
 
 ## 1.0.65


### PR DESCRIPTION
# Release Notes

> 10 packages updated · 20 changes

## 🚀 Features

- **@weapp-tailwindcss/cli@5.5.0**: 改善开发体验：新增固定 Generic Web target 的 weapp-tailwindcss/vite/web 入口，修正 doctor 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 mode: 'legacy' 显式启用。 [`d65a6c4`](https://github.com/sonofmagic/weapp-tailwindcss/commit/d65a6c45a6f381f70c352d7f6b08aaa7bdeff0f9) · [#1149](https://github.com/sonofmagic/weapp-tailwindcss/pull/1149)
- **@weapp-tailwindcss/init@2.0.0**: 改善开发体验：新增固定 Generic Web target 的 weapp-tailwindcss/vite/web 入口，修正 doctor 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 mode: 'legacy' 显式启用。 [`d65a6c4`](https://github.com/sonofmagic/weapp-tailwindcss/commit/d65a6c45a6f381f70c352d7f6b08aaa7bdeff0f9) · [#1149](https://github.com/sonofmagic/weapp-tailwindcss/pull/1149)
- **weapp-tailwindcss@5.5.0**: 改善开发体验：新增固定 Generic Web target 的 weapp-tailwindcss/vite/web 入口，修正 doctor 对官方 Tailwind 生成器和 CSS 入口的诊断，并将初始化器默认切换为 Tailwind CSS 4 CSS-first 流程；旧版初始化配置改为通过 mode: 'legacy' 显式启用。 [`d65a6c4`](https://github.com/sonofmagic/weapp-tailwindcss/commit/d65a6c45a6f381f70c352d7f6b08aaa7bdeff0f9) · [#1149](https://github.com/sonofmagic/weapp-tailwindcss/pull/1149)
- **weapp-tailwindcss@5.5.0**: 将 weapp-tailwindcss/vite/web 拆分为真正的 Generic Web CSS-only 管线：默认只处理 CSS 生成与 HMR，不注册 JS/template、框架扩展、分包和小程序收尾；主入口识别为 Generic Web 后复用相同 profile，styleInjector 改为显式 opt-in。 [`d65a6c4`](https://github.com/sonofmagic/weapp-tailwindcss/commit/d65a6c45a6f381f70c352d7f6b08aaa7bdeff0f9) · [#1149](https://github.com/sonofmagic/weapp-tailwindcss/pull/1149)

## 🐞 Bug Fixes

- **@weapp-tailwindcss/postcss@3.3.1**: 统一处理 Tailwind source media 尾部残片，避免非法 CSS 进入小程序最终产物。 [`bc28aa2`](https://github.com/sonofmagic/weapp-tailwindcss/commit/bc28aa27709f96f7b59e8277e96b714e63734a09)
- **weapp-tailwindcss@5.5.0**: 修复 uni-app x Web 热更新将完整 .uvue 源码误交给 PostCSS 解析，导致模板插值触发 Unknown word 警告的问题。 [`8861800`](https://github.com/sonofmagic/weapp-tailwindcss/commit/886180053f2778baa1f90ab6d9a1bfaef7dab534) · [#1145](https://github.com/sonofmagic/weapp-tailwindcss/pull/1145) · [#1144](https://github.com/sonofmagic/weapp-tailwindcss/issues/1144)
- **weapp-tailwindcss@5.5.0**: 修复多端 CI 构建依赖闭包、Playwright headless 浏览器安装和小程序样式产物收尾，避免兼容性测试因缺少构建入口或残留 CSS 哨兵失败。 [`12f6dc2`](https://github.com/sonofmagic/weapp-tailwindcss/commit/12f6dc2e6556318174bfb38037987baf8869b939)
- **weapp-tailwindcss@5.5.0**: 统一处理 Tailwind source media 尾部残片，避免非法 CSS 进入小程序最终产物。 [`bc28aa2`](https://github.com/sonofmagic/weapp-tailwindcss/commit/bc28aa27709f96f7b59e8277e96b714e63734a09)

<details>
<summary>🧰 Maintenance</summary>

- **@weapp-tailwindcss/typography@1.0.5**: 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。 [`b3902ab`](https://github.com/sonofmagic/weapp-tailwindcss/commit/b3902ab4618b1e74f92ca50af384b43e358181c6)
- **@weapp-tailwindcss/ui@0.0.13**: 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。 [`b3902ab`](https://github.com/sonofmagic/weapp-tailwindcss/commit/b3902ab4618b1e74f92ca50af384b43e358181c6)
- **@weapp-tailwindcss/ui@0.0.13**: Updated dependency to @weapp-tailwindcss/variants@0.2.6. [`b3902ab`](https://github.com/sonofmagic/weapp-tailwindcss/commit/b3902ab4618b1e74f92ca50af384b43e358181c6)
- **@weapp-tailwindcss/variants@0.2.6**: 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。 [`b3902ab`](https://github.com/sonofmagic/weapp-tailwindcss/commit/b3902ab4618b1e74f92ca50af384b43e358181c6)
- **@weapp-tailwindcss/cli@5.5.0**: Updated dependency to weapp-tailwindcss@5.5.0. [`d65a6c4`](https://github.com/sonofmagic/weapp-tailwindcss/commit/d65a6c45a6f381f70c352d7f6b08aaa7bdeff0f9) · [#1149](https://github.com/sonofmagic/weapp-tailwindcss/pull/1149)
- **@weapp-tailwindcss/experimental@0.0.38**: Updated dependency to @weapp-tailwindcss/postcss@3.3.1.
- **@weapp-tailwindcss/lynx@0.3.9**: Updated dependency to weapp-tailwindcss@5.5.0.
- **@weapp-tailwindcss/postcss@3.3.1**: 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。 [`b3902ab`](https://github.com/sonofmagic/weapp-tailwindcss/commit/b3902ab4618b1e74f92ca50af384b43e358181c6)
- **@weapp-tailwindcss/react-native@0.2.12**: Updated dependency to weapp-tailwindcss@5.5.0.
- **weapp-tailwindcss@5.5.0**: 统一跨构建器编译状态与生命周期协议，新增可复用的 compiler host、事件总线和 runtime state，同时收敛 PostCSS、编译器和运行时衍生包的依赖版本 catalog，保持现有导入路径兼容。 [`b3902ab`](https://github.com/sonofmagic/weapp-tailwindcss/commit/b3902ab4618b1e74f92ca50af384b43e358181c6)
- **weapp-tailwindcss@5.5.0**: 升级兼容范围内的工作区依赖，迁移 Tailwind CSS 4 测试辅助工具的可选配置处理，并修正 PostCSS 本地 postcss-calc 链接路径。 [`fd3b1be`](https://github.com/sonofmagic/weapp-tailwindcss/commit/fd3b1bed4ee82d282fdecae6e8c86a440b1a7373)
- **weapp-tailwindcss@5.5.0**: Updated dependency to @weapp-tailwindcss/postcss@3.3.1.

</details>

## Packages

| Package | From | To |
| --- | --- | --- |
| `@weapp-tailwindcss/typography` | [`1.0.4`](https://www.npmjs.com/package/@weapp-tailwindcss/typography/v/1.0.4) | `1.0.5` |
| `@weapp-tailwindcss/ui` | [`0.0.12`](https://www.npmjs.com/package/@weapp-tailwindcss/ui/v/0.0.12) | `0.0.13` |
| `@weapp-tailwindcss/variants` | [`0.2.5`](https://www.npmjs.com/package/@weapp-tailwindcss/variants/v/0.2.5) | `0.2.6` |
| `@weapp-tailwindcss/cli` | [`5.4.2`](https://www.npmjs.com/package/@weapp-tailwindcss/cli/v/5.4.2) | `5.5.0` |
| `@weapp-tailwindcss/experimental` | [`0.0.37`](https://www.npmjs.com/package/@weapp-tailwindcss/experimental/v/0.0.37) | `0.0.38` |
| `@weapp-tailwindcss/init` | [`1.0.16`](https://www.npmjs.com/package/@weapp-tailwindcss/init/v/1.0.16) | `2.0.0` |
| `@weapp-tailwindcss/lynx` | [`0.3.8`](https://www.npmjs.com/package/@weapp-tailwindcss/lynx/v/0.3.8) | `0.3.9` |
| `@weapp-tailwindcss/postcss` | [`3.3.0`](https://www.npmjs.com/package/@weapp-tailwindcss/postcss/v/3.3.0) | `3.3.1` |
| `@weapp-tailwindcss/react-native` | [`0.2.11`](https://www.npmjs.com/package/@weapp-tailwindcss/react-native/v/0.2.11) | `0.2.12` |
| `weapp-tailwindcss` | [`5.4.2`](https://www.npmjs.com/package/weapp-tailwindcss/v/5.4.2) | `5.5.0` |

## ❤️ Contributors

Thanks to @hujinchen · ice breaker · @sonofmagic