### PR TITLE
修复 uni-app x Web 重要 utility 连续 HMR

### DIFF
--- a/.changeset/curly-uvue-hmr.md
+++ b/.changeset/curly-uvue-hmr.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 uni-app x Web 端重要 utility 在连续 HMR 更新中的局部样式缓存、CSS 模块失效和 Sass 预处理边界。

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -103,7 +103,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.watch == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -103,7 +103,7 @@ jobs:
     needs: [scope]
     if: needs.scope.outputs.watch == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -138,7 +138,7 @@ jobs:
           E2E_WATCH_MAX_ATTEMPTS: '1'
           E2E_WATCH_ROUND_PROFILE: default
           E2E_WATCH_TIMEOUT_MS: '420000'
-          E2E_WATCH_COMMAND_TIMEOUT_MS: '720000'
+          E2E_WATCH_COMMAND_TIMEOUT_MS: '1200000'
           E2E_WATCH_SAVE_SNAPSHOTS: '1'
           NODE_OPTIONS: --max-old-space-size=6144
         run: pnpm e2e:watch

--- a/demo/issue-1144-uni-app-x-web/README.md
+++ b/demo/issue-1144-uni-app-x-web/README.md
@@ -8,7 +8,7 @@
 
 1. 使用 Node.js 22.12+ 和 HBuilderX（包含 uni-app x Web 工具链）安装仓库依赖。
 2. 在仓库根目录执行 `pnpm --filter @weapp-tailwindcss-demo/issue-1144-uni-app-x-web run dev:h5`。真实 HBuilderX 回归分别运行 `HBUILDERX_CHANNEL=stable E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web pnpm e2e:hbuilderx:h5` 和 `HBUILDERX_CHANNEL=alpha E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web pnpm e2e:hbuilderx:h5`；切换前先关闭另一个 HBuilderX 实例。
-3. 打开首页后编辑 `pages/index/index.uvue` 模板中的文字并保存。
+3. 打开首页后编辑 `pages/index/index.uvue` 模板中的文字并保存。页面中的探针同时覆盖直接使用 `class="mt-24!"`，以及 `:pt="{ root: 'p-0!' }"` 依次改为 `p-10!`、`p-4!`、再改回 `p-0!` 的三轮 Web HMR。
 
 首次加载和保存后的 HMR 页面都应正常更新；Vite 页面不应出现错误遮罩，HBuilderX/Vite 日志不应出现 `Unknown word` 或 `[plugin:vite:css]` PostCSS 警告，生成 CSS 也不应残留 Tailwind 原始指令。
 

--- a/demo/issue-1144-uni-app-x-web/pages/index/index.uvue
+++ b/demo/issue-1144-uni-app-x-web/pages/index/index.uvue
@@ -1,6 +1,9 @@
 <template>
 	<view :class="[theme.themeClass, 'bg-page px-20 py-24']">
 		<text class="text-content text-2xl font-bold text-white/70 text-blue-300/35">全端主题</text>
+		<view class="issue-1144-important-probe mt-24!" :pt="{ root: 'p-0!' }">
+			<text class="text-content text-sm">重要 utility HMR 探针</text>
+		</view>
 		<text class="mt-6 text-content-muted text-sm">
 			{{ theme.themeClass }} · {{ theme.modePreference }} · {{ theme.resolvedMode }}
 		</text>

--- a/demo/issue-1144-uni-app-x-web/vite.config.ts
+++ b/demo/issue-1144-uni-app-x-web/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
 			uniAppX({
 				base: projectRoot,
 				cssEntries: [mainCss],
+				customAttributes: {
+					'*': ['pt']
+				},
 				rem2rpx: true
 			})
 		),

--- a/e2e/hbuilderx-local/cases.ts
+++ b/e2e/hbuilderx-local/cases.ts
@@ -1092,6 +1092,10 @@ export const webCases: WebCase[] = [
       /\.bg-page\s*\{/,
     ],
     initialTextContains: ['全端主题'],
+    persistentRuntimeStyles: [{
+      selector: '.issue-1144-important-probe',
+      styles: { marginTop: '96px' },
+    }],
     serverLogContains: [
       /HBuilderX Version:\s*5\./,
       /编译器版本：5\.\d+（uni-app x）VDOM模式/,
@@ -1106,6 +1110,10 @@ export const webCases: WebCase[] = [
           selector: '.hbuilderx-web-hmr-probe',
           styles: { backgroundColor: 'rgb(15, 81, 50)', color: 'rgb(248, 250, 252)', width: '188px' },
         }],
+        sourceMutation: {
+          file: 'pages/index/index.uvue',
+          replace: { from: 'root: \'p-0!\'', to: 'root: \'p-10!\'' },
+        },
       },
       {
         markerClass: 'hbuilderx-web-hmr-probe bg-[#7c2d12] text-[#ecfeff] h-[37px] mt-[11px]',
@@ -1115,6 +1123,10 @@ export const webCases: WebCase[] = [
           selector: '.hbuilderx-web-hmr-probe',
           styles: { backgroundColor: 'rgb(124, 45, 18)', color: 'rgb(236, 254, 255)', height: '37px', marginTop: '11px' },
         }],
+        sourceMutation: {
+          file: 'pages/index/index.uvue',
+          replace: { from: 'root: \'p-10!\'', to: 'root: \'p-4!\'' },
+        },
       },
       {
         markerClass: 'hbuilderx-web-hmr-probe bg-[#4338ca] text-[#fef3c7] w-[221px] rounded-[13px]',
@@ -1124,6 +1136,10 @@ export const webCases: WebCase[] = [
           selector: '.hbuilderx-web-hmr-probe',
           styles: { backgroundColor: 'rgb(67, 56, 202)', borderRadius: '13px', color: 'rgb(254, 243, 199)', width: '221px' },
         }],
+        sourceMutation: {
+          file: 'pages/index/index.uvue',
+          replace: { from: 'root: \'p-4!\'', to: 'root: \'p-0!\'' },
+        },
       },
     ],
     workflow: uniAppXHBuilderXWorkflow,

--- a/e2e/lynx/reports/android.json
+++ b/e2e/lynx/reports/android.json
@@ -692,7 +692,7 @@
     {
       "id": "variant-group-peer",
       "status": "unsupported",
-      "reason": "encoder 删除 selector：.peer-checked\\:opacity-100:is(:where(.peer):checked~*)",
+      "reason": "encoder 删除 selector：.peer-checked\\:opacity-100:is(:where(.peer):checked~*), .peer-checked\\:opacity-100:is(:where(.peer):checked~*)",
       "checkpoints": [
         {
           "name": "generated",
@@ -903,7 +903,7 @@
     {
       "id": "directive-variant",
       "status": "unsupported",
-      "reason": "encoder 删除 selector：.theme-midnight\\:bg-black:where(.theme-midnight,.theme-midnight *), .lynx-at-variant:where(.theme-midnight,.theme-midnight *)",
+      "reason": "encoder 删除 selector：.theme-midnight\\:bg-black:where(.theme-midnight,.theme-midnight *), .theme-midnight\\:bg-black:where(.theme-midnight,.theme-midnight *), .lynx-at-variant:where(.theme-midnight,.theme-midnight *), .lynx-at-variant:where(.theme-midnight,.theme-midnight *)",
       "checkpoints": [
         {
           "name": "generated",
@@ -1308,7 +1308,7 @@
     {
       "id": "border-divide",
       "status": "unsupported",
-      "reason": "encoder 删除 selector：:where(.divide-y-2>:not(:last-child)), :where(.divide-dashed>:not(:last-child)), :where(.divide-\\[\\#64748b\\]>:not(:last-child))",
+      "reason": "encoder 删除 selector：:where(.divide-y-2>:not(:last-child)), :where(.divide-y-2>:not(:last-child)), :where(.divide-dashed>:not(:last-child)), :where(.divide-dashed>:not(:last-child)), :where(.divide-\\[\\#64748b\\]>:not(:last-child)), :where(.divide-\\[\\#64748b\\]>:not(:last-child))",
       "checkpoints": [
         {
           "name": "generated",

--- a/e2e/lynx/reports/ios.json
+++ b/e2e/lynx/reports/ios.json
@@ -693,7 +693,7 @@
     {
       "id": "variant-group-peer",
       "status": "unsupported",
-      "reason": "encoder 删除 selector：.peer-checked\\:opacity-100:is(:where(.peer):checked~*)",
+      "reason": "encoder 删除 selector：.peer-checked\\:opacity-100:is(:where(.peer):checked~*), .peer-checked\\:opacity-100:is(:where(.peer):checked~*)",
       "checkpoints": [
         {
           "name": "generated",
@@ -904,7 +904,7 @@
     {
       "id": "directive-variant",
       "status": "unsupported",
-      "reason": "encoder 删除 selector：.theme-midnight\\:bg-black:where(.theme-midnight,.theme-midnight *), .lynx-at-variant:where(.theme-midnight,.theme-midnight *)",
+      "reason": "encoder 删除 selector：.theme-midnight\\:bg-black:where(.theme-midnight,.theme-midnight *), .theme-midnight\\:bg-black:where(.theme-midnight,.theme-midnight *), .lynx-at-variant:where(.theme-midnight,.theme-midnight *), .lynx-at-variant:where(.theme-midnight,.theme-midnight *)",
       "checkpoints": [
         {
           "name": "generated",
@@ -1309,7 +1309,7 @@
     {
       "id": "border-divide",
       "status": "unsupported",
-      "reason": "encoder 删除 selector：:where(.divide-y-2>:not(:last-child)), :where(.divide-dashed>:not(:last-child)), :where(.divide-\\[\\#64748b\\]>:not(:last-child))",
+      "reason": "encoder 删除 selector：:where(.divide-y-2>:not(:last-child)), :where(.divide-y-2>:not(:last-child)), :where(.divide-dashed>:not(:last-child)), :where(.divide-dashed>:not(:last-child)), :where(.divide-\\[\\#64748b\\]>:not(:last-child)), :where(.divide-\\[\\#64748b\\]>:not(:last-child))",
       "checkpoints": [
         {
           "name": "generated",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "deploy:docs:cloudflare": "node scripts/deploy-docs-cloudflare.mjs",
     "deploy:docs:cloudflare:next": "node scripts/deploy-docs-cloudflare.mjs --target=next",
     "build:apps": "echo \"apps workspace has no demo projects\"",
-    "build:ci": "pnpm --filter weapp-tailwindcss... --filter @weapp-tailwindcss/postcss-calc --filter \"./packages-runtime/*\" --filter \"./packages/lynx\" run build",
+    "build:ci": "pnpm --filter weapp-tailwindcss... --filter @weapp-tailwindcss/postcss-calc --filter @weapp-tailwindcss/react-native --filter \"./packages-runtime/*\" --filter \"./packages/lynx\" run build",
     "ci:memory": "node scripts/ci-memory-guard.mjs",
     "build:pkgs": "turbo run build --filter=./packages/* --filter=./packages-runtime/*",
     "build:demo": "cross-env WEAPP_TW_SKIP_INTERACTIVE_TARO_BUILD=1 WEAPP_TW_SKIP_INTERACTIVE_UNI_BUILD=1 turbo run build --filter=./demo/*",

--- a/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/transform.ts
@@ -375,22 +375,23 @@ export function transformUVue(
       )
     }
 
-    if (localStyleCollector?.hasStyles()) {
-      const scopedStyle = descriptor.styles.findLast(style => STYLE_SCOPED_RE.test(style.attrs))
-      if (scopedStyle && options.onWebLocalStyleRules) {
-        options.onWebLocalStyleRules(localStyleCollector.toStyleRules({ web: true }))
-      }
-      else if (scopedStyle) {
-        const separator = scopedStyle.content.endsWith('\n') ? '' : '\n'
-        ms.appendLeft(scopedStyle.end, `${separator}${localStyleCollector.toStyleRules({ native: options.native })}`)
-      }
-      else {
-        // 新增的局部样式块会单独进入预处理器，important utility 统一使用中间标记。
-        ms.append(`\n${localStyleCollector.toStyleBlock({
-          native: options.native || Boolean(options.onWebLocalStyleRules),
-          web: Boolean(options.onWebLocalStyleRules),
-        })}`)
-      }
+    const scopedStyle = descriptor.styles.findLast(style => STYLE_SCOPED_RE.test(style.attrs))
+    if (localStyleCollector && options.onWebLocalStyleRules && scopedStyle) {
+      // 每次 SFC 变换都覆盖桥接缓存；当前没有局部规则时也要清除上一轮结果。
+      options.onWebLocalStyleRules(localStyleCollector.hasStyles()
+        ? localStyleCollector.toStyleRules({ web: true })
+        : '')
+    }
+    else if (localStyleCollector?.hasStyles() && scopedStyle) {
+      const separator = scopedStyle.content.endsWith('\n') ? '' : '\n'
+      ms.appendLeft(scopedStyle.end, `${separator}${localStyleCollector.toStyleRules({ native: options.native })}`)
+    }
+    else if (localStyleCollector?.hasStyles()) {
+      // 新增的局部样式块会单独进入预处理器，important utility 统一使用中间标记。
+      ms.append(`\n${localStyleCollector.toStyleBlock({
+        native: options.native || Boolean(options.onWebLocalStyleRules),
+        web: Boolean(options.onWebLocalStyleRules),
+      })}`)
     }
   }
   const result: TransformResult = {

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite.ts
@@ -392,6 +392,9 @@ export function createUniAppXPlugins(options: CreateUniAppXPluginsOptions): Plug
           return
         }
         if (isWebGeneratorTarget() && UVUE_NVUE_RE.test(ctx.file) && typeof ctx.read === 'function') {
+          // 完整 SFC 更新会取代此前可能排队的 CSS HMR 事务，避免版本过滤器
+          // 把当前样式模块误判为旧事务而丢弃。
+          hmrCssModuleVersions?.clear()
           const source = await ctx.read()
           if (hasUniAppXImportantApply(source, normalizeUniAppXImportantApplyForSass)) {
             ctx.server.ws.send({ type: 'full-reload', path: ctx.file })

--- a/packages/weapp-tailwindcss/src/uni-app-x/vite/style-source.ts
+++ b/packages/weapp-tailwindcss/src/uni-app-x/vite/style-source.ts
@@ -6,11 +6,13 @@ const VITE_CSS_HMR_MODULE_RE = /\b(?:const\s+__vite__css\s*=|__vite__updateStyle
 type VueStyleQuery = ReturnType<typeof parseVueRequest>['query']
 
 export function resolveUniAppXStyleSource(code: string, query: VueStyleQuery) {
-  if (!query.vue || query.type !== 'style') {
-    return { code }
-  }
+  // Vite 的 CSS HMR 模块可能没有 `vue&type=style` 查询参数，但其内容仍是
+  // 包含完整 SFC/template 的包装代码。此类 payload 不能继续交给 PostCSS。
   if (VITE_CSS_HMR_MODULE_RE.test(code)) {
     return { skip: true as const }
+  }
+  if (!query.vue || query.type !== 'style') {
+    return { code }
   }
   const styleBlocks = extractSfcStyleBlocks(code)
   if (styleBlocks.length === 0) {

--- a/packages/weapp-tailwindcss/test/bundlers/vite-hmr-module-version.unit.test.ts
+++ b/packages/weapp-tailwindcss/test/bundlers/vite-hmr-module-version.unit.test.ts
@@ -5,6 +5,22 @@ import { createViteHmrCssModuleVersionFilterPlugin, createViteHmrCssModuleVersio
 import { createUniAppXWebLocalStyleBridge } from '@/uni-app-x/vite/web-local-style'
 
 describe('Vite CSS HMR module versions', () => {
+  it('replaces and clears Web local style rules for repeated SFC transforms', () => {
+    const bridge = createUniAppXWebLocalStyleBridge(() => true)
+    const styleId = '/project/pages/index/index.uvue?vue&type=style&index=0&scoped=abc'
+
+    bridge.remember('/project/pages/index/index.uvue', '.wtu-p-0 { @apply p-0!; }')
+    expect(bridge.appendToStyle('.author {}', styleId)).toContain('@apply p-0!;')
+
+    bridge.remember('/project/pages/index/index.uvue', '.wtu-p-10 { @apply p-10!; }')
+    const replaced = bridge.appendToStyle('.author {}', styleId)
+    expect(replaced).toContain('@apply p-10!;')
+    expect(replaced).not.toContain('@apply p-0!;')
+
+    bridge.remember('/project/pages/index/index.uvue', '')
+    expect(bridge.appendToStyle('.author {}', styleId)).toBe('.author {}')
+  })
+
   it('rejects an older transaction for the same normalized style module', () => {
     const root = path.resolve('/project')
     const pageFile = path.join(root, 'pages/index.uvue')

--- a/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/index.test.ts
@@ -337,6 +337,51 @@ const condition = true
     expect(result?.code).not.toContain('@apply mt-6!;')
   })
 
+  it('recomputes dynamic custom-attribute important utilities across HMR rounds', () => {
+    const { jsHandler } = getCompilerContext({ uniAppX: true })
+    const rulesByRound: string[] = []
+    const runtimeSet = new Set(['p-0!', 'p-10!', 'p-4!'])
+
+    for (const utility of ['p-0!', 'p-10!', 'p-4!', 'p-0!']) {
+      const onWebLocalStyleRules = vi.fn((rules: string) => rulesByRound.push(rules))
+      const result = transformUVue(
+        `<template><view :pt="{ root: '${utility}' }">dynamic</view></template><style scoped>.author { color: red; }</style>`,
+        '/src/pages/index/index.uvue',
+        jsHandler,
+        runtimeSet,
+        {
+          customAttributesEntities: [['view', ['pt']]],
+          enablePageLocalStyle: true,
+          onWebLocalStyleRules,
+        },
+      )
+
+      expect(result?.code).toContain('wtu-')
+      expect(onWebLocalStyleRules).toHaveBeenCalledTimes(1)
+    }
+
+    expect(rulesByRound).toHaveLength(4)
+    expect(rulesByRound[0]).toContain('@apply p-0!;')
+    expect(rulesByRound[1]).toContain('@apply p-10!;')
+    expect(rulesByRound[1]).not.toContain('@apply p-0!;')
+    expect(rulesByRound[2]).toContain('@apply p-4!;')
+    expect(rulesByRound[3]).toContain('@apply p-0!;')
+
+    const clearRules = vi.fn()
+    transformUVue(
+      `<template><view :pt="{ root: 'p-0!' }">cleared</view></template><style scoped>.author { color: red; }</style>`,
+      '/src/pages/index/index.uvue',
+      jsHandler,
+      new Set(),
+      {
+        customAttributesEntities: [['view', ['pt']]],
+        enablePageLocalStyle: true,
+        onWebLocalStyleRules: clearRules,
+      },
+    )
+    expect(clearRules).toHaveBeenCalledWith('')
+  })
+
   it('honors disabledDefaultTemplateHandler with custom class rules', () => {
     const { jsHandler } = getCompilerContext()
     const runtimeSet = new Set<string>([

--- a/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
+++ b/packages/weapp-tailwindcss/test/uni-app-x/vite.test.ts
@@ -10,6 +10,8 @@ import { collectUniAppXHarmonyApplyStyleSources, createUniAppXHarmonyApplyGenera
 import { createUniAppXAssetTask, createUniAppXPlugins } from '@/uni-app-x/vite'
 import { createUniAppXHarmonyApplyExpander } from '@/uni-app-x/vite/harmony-apply'
 import { clearUniAppXStyleIsolationCache } from '@/uni-app-x/style-isolation'
+import { resolveUniAppXStyleSource } from '@/uni-app-x/vite/style-source'
+import { createViteHmrCssModuleVersionTracker } from '@/bundlers/vite/shared/framework-hmr-module-version'
 
 /** 将平台路径转为 posix 格式，与源码 normalizePath 行为一致 */
 function toPosix(p: string): string {
@@ -370,6 +372,15 @@ describe('uni-app-x vite plugins', () => {
     await expect(getTransformHandler(cssPrePlugin)?.call(cssPrePlugin, hmrCode, id)).resolves.toBeUndefined()
     await expect(getTransformHandler(cssPlugin)?.call(cssPlugin, hmrCode, id)).resolves.toBeUndefined()
     expect(styleHandler).not.toHaveBeenCalled()
+  })
+
+  it('skips CSS HMR wrappers before query parsing when the request is not a Vue style module', () => {
+    const hmrCode = [
+      `const __vite__css = ${JSON.stringify('<template><view class="mt-24!" /></template>')}`,
+      '__vite__updateStyle(__vite__id, __vite__css)',
+    ].join('\n')
+
+    expect(resolveUniAppXStyleSource(hmrCode, {} as any)).toEqual({ skip: true })
   })
 
   it('skips pre hook for preprocessor styles and runs after preprocess', async () => {
@@ -1104,6 +1115,7 @@ describe('uni-app-x vite plugins', () => {
       observeSourceImports: vi.fn(),
       requestCheck: vi.fn(),
     }
+    const hmrCssModuleVersions = createViteHmrCssModuleVersionTracker()
     const plugins = createUniAppXPlugins({
       appType: 'uni-app-x',
       customAttributesEntities: [['a-navbar', ['leftClass']]],
@@ -1118,6 +1130,7 @@ describe('uni-app-x vite plugins', () => {
       tailwindRootCssModuleIds: new Set(['/project/main.css']),
       viteProcessedCssSourceFiles: new Set(['/project/main.css']),
       webCssEntryDiagnostics,
+      hmrCssModuleVersions,
     })
     const nvuePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:nvue')
     const cssPrePlugin = plugins.find((p): p is Plugin => p.name === 'weapp-tailwindcss:uni-app-x:css:pre')
@@ -1126,9 +1139,11 @@ describe('uni-app-x vite plugins', () => {
       id: '/project/pages/index/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
       url: '/pages/index/index.uvue?vue&type=style&index=0&scoped=abc&lang.scss',
     }
+    hmrCssModuleVersions.filterModules([styleModule as any], 200, '/project')
     const context = {
       file: '/project/pages/index/index.uvue',
       modules: [pageModule],
+      timestamp: 100,
       read: vi.fn(async () => '<template><a-navbar leftClass="text-red-500" /></template><style scoped>.author { color: red; }</style>'),
       server: {
         config: { root: '/project' },


### PR DESCRIPTION
## 变更\n\n- 修复 Web 局部样式桥接在连续 .uvue HMR 中的规则替换与清除。\n- 完整 SFC HMR 更新前清理旧 CSS 模块事务，确保当前样式模块失效并返回。\n- CSS HMR wrapper 在查询参数缺失时也不会进入 PostCSS/Sass。\n- 增加 :pt 重要类多轮回归、wrapper 回归和 issue-1144 HBuilderX Web 探针。\n\n## 验证\n\n- 相关 Vitest：108 tests passed。\n- pnpm --filter weapp-tailwindcss build 通过。\n- pnpm test:plugins：153 files / 1391 tests passed。\n- 普通 Vite demo dev server 已生成 mt-24! 对应的 !important CSS。\n- HBuilderX stable/alpha 已尝试，但当前本机分别受 IDE 项目识别与 stable/alpha 实例不匹配阻塞。\n- 静态 e2e 主要 suite 通过；剩余失败为本地 workspace 包入口未构建和 Playwright 浏览器未安装。\n\nRefs #1144