### PR TITLE
完善跨平台 Dev、Build 与 HMR 生命周期

### DIFF
--- a/.changeset/cross-platform-dev-build-hmr.md
+++ b/.changeset/cross-platform-dev-build-hmr.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss-monorepo": patch
+---
+
+补充跨平台 Dev、Build 与 HMR 覆盖契约，统一开发服务启动 smoke 与 coverage 报告中的 dev 生命周期验证。

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -143,10 +143,39 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
         run: pnpm e2e:watch
 
+  platform-dev:
+    name: Platform dev startup smoke (${{ matrix.runner_label }})
+    needs: [scope]
+    if: needs.scope.outputs.core == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runner_label: linux
+          - os: macos-latest
+            runner_label: macos
+          - os: windows-latest
+            runner_label: windows
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-pnpm
+      - name: Build dev dependencies for this OS
+        run: pnpm build:ci
+      - name: Run normal dev startup smoke
+        env:
+          E2E_DEV_STARTUP_RUN: '1'
+          E2E_DEV_STARTUP_CASE: weapp-vite-tailwindcss-v4
+          E2E_DEV_STARTUP_TIMEOUT_MS: '180000'
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: pnpm e2e:dev:smoke
+
   pr-gate:
     name: PR Gate
     if: always()
-    needs: [scope, quality, core-smoke, platform-watch]
+    needs: [scope, quality, core-smoke, platform-watch, platform-dev]
     runs-on: ubuntu-latest
     steps:
       - name: Require enabled PR checks
@@ -155,8 +184,9 @@ jobs:
           QUALITY_RESULT: ${{ needs.quality.result }}
           SMOKE_RESULT: ${{ needs.core-smoke.result }}
           PLATFORM_RESULT: ${{ needs.platform-watch.result }}
+          DEV_RESULT: ${{ needs.platform-dev.result }}
         run: |
           test "$SCOPE_RESULT" = success
-          for result in "$QUALITY_RESULT" "$SMOKE_RESULT" "$PLATFORM_RESULT"; do
+          for result in "$QUALITY_RESULT" "$SMOKE_RESULT" "$PLATFORM_RESULT" "$DEV_RESULT"; do
             test "$result" = success || test "$result" = skipped
           done

--- a/e2e/coverage-contract.test.ts
+++ b/e2e/coverage-contract.test.ts
@@ -24,6 +24,17 @@ describe('多端 coverage registry contract', () => {
     }
   })
 
+  it('requires an explicit normal dev contract for every demo platform', () => {
+    for (const cell of COVERAGE_REGISTRY.filter(item => item.source === 'demo')) {
+      const dev = cell.layers.dev
+      expect(dev.executor, `${cell.id}:dev`).toBeTruthy()
+      expect(dev.evidenceSchema, `${cell.id}:dev`).toBe('demo-dev-v1')
+      if (dev.status === 'not-applicable' || dev.status === 'unsupported-verified') {
+        expect(dev.reason, `${cell.id}:dev exemption should include a reason`).toBeTruthy()
+      }
+    }
+  })
+
   it('does not treat blocked or not-run required cells as passing', () => {
     const report = createCoverageReport([], 'aggregate')
     expect(report.summary.requiredUnverified).toBeGreaterThan(0)

--- a/e2e/coverageRegistry.ts
+++ b/e2e/coverageRegistry.ts
@@ -3,7 +3,7 @@ import { compatibilityCases as lynxCases } from '../examples/react-lynx/src/comp
 import { DEMO_COVERAGE_MATRIX } from './demoCoverageMatrix'
 import { compatibilityCases as reactNativeCases } from './react-native/catalog'
 
-export const COVERAGE_LAYERS = ['static', 'runtime', 'hmr', 'visual', 'negative'] as const
+export const COVERAGE_LAYERS = ['static', 'dev', 'runtime', 'hmr', 'visual', 'negative'] as const
 export type CoverageLayer = typeof COVERAGE_LAYERS[number]
 
 export const COVERAGE_STATUSES = [
@@ -69,8 +69,9 @@ function layer(
 }
 
 function demoCell(project: string, entry: typeof DEMO_COVERAGE_MATRIX[number], platform: DemoPlatformCoverage): CoverageCell {
-  const local = entry.hbuilderxLocal || platform.staticCoverage === 'local' || platform.hmrCoverage === 'local'
+  const local = entry.hbuilderxLocal || platform.staticCoverage === 'local' || platform.devCoverage === 'local' || platform.hmrCoverage === 'local'
   const staticStatus = explicitStatus(platform.staticCoverage, local)
+  const devStatus = explicitStatus(platform.devCoverage, local)
   const runtimeStatus = explicitStatus(platform.hmrCoverage, local)
   const hmrStatus = explicitStatus(platform.hmrCoverage, local)
   const visualStatus = platform.hmrCoverage === 'automated'
@@ -94,6 +95,7 @@ function demoCell(project: string, entry: typeof DEMO_COVERAGE_MATRIX[number], p
     subpackage,
     layers: {
       static: layer(staticStatus, platform.command, 'demo-static-v1', reasonForLegacy(platform.staticCoverage, platform)),
+      dev: layer(devStatus, platform.command, 'demo-dev-v1', reasonForLegacy(platform.devCoverage, platform)),
       runtime: layer(runtimeStatus, platform.command, 'demo-runtime-v1', legacyReason),
       hmr: layer(hmrStatus, platform.command, 'demo-hmr-v1', legacyReason),
       visual: layer(visualStatus, platform.command, 'demo-visual-v1', legacyReason),
@@ -117,6 +119,7 @@ function compatibilityCell(source: 'react-native' | 'lynx', project: string, fra
     subpackage: false,
     layers: {
       static: layer(source === 'lynx' && isNative ? 'ci-nightly' : 'ci-required', executor, `${source}-static-v1`),
+      dev: layer(isNative ? 'ci-nightly' : 'ci-required', executor, `${source}-dev-v1`),
       runtime: layer(isNative ? 'ci-nightly' : 'ci-required', executor, `${source}-runtime-v1`),
       hmr: layer('not-applicable', 'catalog:no-hmr', `${source}-hmr-v1`, '该原生兼容性 catalog 当前验证静态/运行时，不提供 HMR 语义。'),
       visual: layer(isNative ? 'ci-nightly' : 'ci-required', executor, `${source}-visual-v1`),

--- a/e2e/coverageReport.ts
+++ b/e2e/coverageReport.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 import { compareCoverageIdentity } from './coverageIdentity'
 import { COVERAGE_LAYERS, COVERAGE_REGISTRY, validateCoverageRegistry } from './coverageRegistry'
 
-export const COVERAGE_REPORT_SCHEMA_VERSION = 3 as const
+export const COVERAGE_REPORT_SCHEMA_VERSION = 4 as const
 export type CoverageResultStatus = 'passed' | 'failed' | 'blocked' | 'not-run' | 'not-applicable' | 'unsupported'
 const COVERAGE_RESULT_STATUSES: readonly CoverageResultStatus[] = ['passed', 'failed', 'blocked', 'not-run', 'not-applicable', 'unsupported']
 
@@ -134,7 +134,7 @@ export async function readCommittedCompatibilityEvidence(repoRoot: string): Prom
         const cellId = `${item.source}/${platform}/${result.id}`
         const status: CoverageResultStatus = result.status === 'supported' ? 'passed' : 'unsupported'
         const reason = result.reason ?? (status === 'unsupported' ? '兼容性 catalog 明确标记为 unsupported。' : undefined)
-        for (const layerName of ['static', 'runtime', 'visual', 'negative'] as const) {
+        for (const layerName of ['static', 'dev', 'runtime', 'visual', 'negative'] as const) {
           evidence.push({
             cellId,
             layer: layerName,

--- a/e2e/demoCoverageMatrix.ts
+++ b/e2e/demoCoverageMatrix.ts
@@ -24,9 +24,17 @@ export type DemoCoverageStatus = 'automated' | 'local' | 'exempt'
 export interface DemoPlatformCoverage {
   platform: string
   buildScript?: string
+  buildCommand: string
+  buildEvidence: string
   devScript?: string
+  devCommand: string
+  devEvidence: string
   staticCoverage: DemoCoverageStatus
+  /** 正常开发服务首次编译与可访问性覆盖状态。 */
+  devCoverage: DemoCoverageStatus
   hmrCoverage: DemoCoverageStatus
+  hmrCommand: string
+  hmrEvidence: string
   devHmrSnapshotCoverage: DemoCoverageStatus
   rootStyleShellHmrCoverage?: DemoCoverageStatus
   evidence: string
@@ -57,8 +65,15 @@ function automated(platform: string, options: {
 }): DemoPlatformCoverage {
   return {
     platform,
+    buildCommand: options.buildScript ? `pnpm run ${options.buildScript}` : options.command,
+    buildEvidence: options.evidence,
+    devCommand: options.devScript ? `pnpm run ${options.devScript}` : options.command,
+    devEvidence: options.devScript ? '开发服务首次编译、进程存活与错误日志 smoke' : options.evidence,
     staticCoverage: 'automated',
+    devCoverage: 'automated',
     hmrCoverage: 'automated',
+    hmrCommand: options.command,
+    hmrEvidence: options.evidence,
     devHmrSnapshotCoverage: 'automated',
     ...(options.buildScript ? { buildScript: options.buildScript } : {}),
     ...(options.devScript ? { devScript: options.devScript } : {}),
@@ -74,12 +89,21 @@ function local(platform: string, options: {
   command: string
   reason: string
   staticCoverage?: DemoCoverageStatus
+  devCoverage?: DemoCoverageStatus
   hmrCoverage?: DemoCoverageStatus
 }): DemoPlatformCoverage {
+  const devCoverage = options.devCoverage ?? (options.devScript ? (options.staticCoverage === 'automated' ? 'automated' : 'local') : 'exempt')
   return {
     platform,
+    buildCommand: options.buildScript ? `pnpm run ${options.buildScript}` : options.command,
+    buildEvidence: options.evidence,
+    devCommand: options.devScript ? `pnpm run ${options.devScript}` : options.command,
+    devEvidence: options.devScript ? '开发服务首次编译、进程存活与错误日志 smoke' : options.evidence,
     staticCoverage: options.staticCoverage ?? 'local',
+    devCoverage,
     hmrCoverage: options.hmrCoverage ?? 'local',
+    hmrCommand: options.command,
+    hmrEvidence: options.evidence,
     devHmrSnapshotCoverage: options.hmrCoverage ?? 'local',
     ...(options.buildScript ? { buildScript: options.buildScript } : {}),
     ...(options.devScript ? { devScript: options.devScript } : {}),

--- a/e2e/dev-startup-matrix.test.ts
+++ b/e2e/dev-startup-matrix.test.ts
@@ -1,0 +1,59 @@
+import path from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { buildCases, demoWatchShardCases } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/cases'
+import { createWatchSession, sleep } from '../tools/weapp-tailwindcss-scripts/src/watch-hmr-regression/session'
+
+const repoRoot = path.resolve(__dirname, '..')
+const startupTimeoutMs = Number(process.env['E2E_DEV_STARTUP_TIMEOUT_MS'] ?? 180_000)
+const settleMs = Number(process.env['E2E_DEV_STARTUP_SETTLE_MS'] ?? 1_500)
+const enabled = process.env['E2E_DEV_STARTUP_RUN'] === '1'
+const requested = process.env['E2E_DEV_STARTUP_CASE']
+
+const stableNames = new Set(Object.values(demoWatchShardCases).flat())
+const cases = buildCases(repoRoot)
+  .filter(item => item.group === 'demo' && stableNames.has(item.name))
+  .filter(item => !requested || requested === 'all' || requested.split(',').includes(item.name))
+
+async function waitForInitialCompile(session: ReturnType<typeof createWatchSession>, name: string) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < startupTimeoutMs) {
+    session.ensureRunning()
+    if (session.lastCompileSuccessAt() > 0) {
+      await sleep(settleMs)
+      session.ensureRunning()
+      return
+    }
+    // 部分 demo 的 dev 脚本是等待内部 builder 就绪的 wrapper，不会转发 builder 的成功行。
+    // wrapper 已输出 Tailwind 初始化日志且进程持续运行时，使用稳定窗口作为首次编译证据。
+    if (Date.now() - startedAt >= 8_000 && /Tailwind CSS|Weapp-tailwindcss/u.test(session.logs())) {
+      await sleep(settleMs)
+      session.ensureRunning()
+      return
+    }
+    await sleep(250)
+  }
+  throw new Error(`[${name}] dev server did not complete its first compile in ${startupTimeoutMs}ms\n${session.logs()}`)
+}
+
+describe('demo normal dev startup matrix', () => {
+  it('declares an explicit executable selection', () => {
+    expect(cases.length, 'dev startup selection should resolve at least one registered case').toBeGreaterThan(0)
+  })
+
+  const run = enabled ? it : it.skip
+  for (const item of cases) {
+    run(`starts ${item.name} and keeps the process alive after the first compile`, async () => {
+      const session = createWatchSession(item.cwd, item.devScript, { quietSass: true }, {
+        WEAPP_TW_WATCH_REGRESSION: '1',
+      })
+      try {
+        await waitForInitialCompile(session, item.name)
+        const logs = session.logs()
+        expect(logs, `${item.name} should not report CSS/PostCSS parse errors`).not.toMatch(/Unknown word|\[plugin:vite:css\]|SassError|invalid declaration/i)
+      }
+      finally {
+        await session.stop()
+      }
+    }, startupTimeoutMs + settleMs + 15_000)
+  }
+})

--- a/e2e/e2e-matrix.test.ts
+++ b/e2e/e2e-matrix.test.ts
@@ -384,12 +384,31 @@ describe('e2e matrix', () => {
       const pkg = readDemoPackageJson(entry.packageJson)
       expect(entry.platforms.length, `${entry.name} should declare at least one platform`).toBeGreaterThan(0)
       for (const platform of entry.platforms) {
+        expect(platform.buildCommand, `${entry.name} ${platform.platform} should document build command`).toBeTruthy()
+        expect(platform.buildEvidence, `${entry.name} ${platform.platform} should document build evidence`).toBeTruthy()
+        expect(platform.devCommand, `${entry.name} ${platform.platform} should document dev command`).toBeTruthy()
+        expect(platform.devEvidence, `${entry.name} ${platform.platform} should document dev evidence`).toBeTruthy()
+        expect(platform.hmrCommand, `${entry.name} ${platform.platform} should document HMR command`).toBeTruthy()
+        expect(platform.hmrEvidence, `${entry.name} ${platform.platform} should document HMR evidence`).toBeTruthy()
+        if (platform.staticCoverage === 'automated') {
+          expect(platform.buildScript, `${entry.name} ${platform.platform} automated build should expose a build script`).toBeTruthy()
+        }
         expect(platform.command.length, `${entry.name} ${platform.platform} should document a validation command`).toBeGreaterThan(0)
         expect(platform.evidence.length, `${entry.name} ${platform.platform} should document validation evidence`).toBeGreaterThan(0)
         expect(
           platform.devHmrSnapshotCoverage,
           `${entry.name} ${platform.platform} dev/HMR snapshot coverage should match its HMR execution status`,
         ).toBe(platform.hmrCoverage)
+        expect(
+          platform.devCoverage,
+          `${entry.name} ${platform.platform} should declare normal dev coverage`,
+        ).toBeTruthy()
+        if (platform.devCoverage === 'exempt') {
+          expect(platform.reason?.length, `${entry.name} ${platform.platform} dev exemption should explain why`).toBeGreaterThan(0)
+        }
+        if (platform.devCoverage !== 'exempt') {
+          expect(platform.devScript, `${entry.name} ${platform.platform} covered dev target should expose a dev script`).toBeTruthy()
+        }
         if (platform.buildScript) {
           expect(
             pkg.scripts?.[scriptName(platform.buildScript)],

--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "e2e:hot-update:demo": "cross-env E2E_HOT_UPDATE_TARGET=demo pnpm e2e:hot-update",
     "e2e:hot-update:apps": "echo \"apps hot-update target has moved to demo\"",
     "e2e:watch": "vitest run -c ./e2e/vitest.e2e.watch.config.ts",
+    "e2e:dev:smoke": "cross-env E2E_DEV_STARTUP_RUN=1 vitest run --bail=1 -c ./e2e/vitest.e2e.config.ts e2e/dev-startup-matrix.test.ts",
     "e2e:root-style-shell-hmr": "cross-env E2E_ROOT_STYLE_SHELL_HMR=1 vitest run --bail=1 -c ./e2e/vitest.e2e.watch.config.ts e2e/watch/root-style-import-shell-hmr.test.ts",
     "e2e:uni-app-css-post-hmr": "cross-env E2E_UNI_APP_CSS_POST_HMR=1 vitest run --bail=1 -c ./e2e/vitest.e2e.watch.config.ts e2e/watch/uni-app-css-post-hmr.test.ts",
     "e2e:watch:full": "cross-env E2E_WATCH_SKIP_BUILD=0 pnpm e2e:watch",

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -125,7 +125,15 @@ describe('ci workflows', () => {
       expect.objectContaining({ runner_label: 'macos', case_name: 'uni-app-vite-tailwindcss-v4:mp-weixin', web_only: '0' }),
     ]))
     expect(platformJob.strategy['fail-fast']).toBe(false)
-    expect(workflow.jobs['pr-gate'].needs).toEqual(['scope', 'quality', 'core-smoke', 'platform-watch'])
+    const platformDevJob = workflow.jobs['platform-dev']
+    expect(platformDevJob.strategy['fail-fast']).toBe(false)
+    expect(platformDevJob.strategy.matrix.include).toEqual(expect.arrayContaining([
+      expect.objectContaining({ runner_label: 'linux' }),
+      expect.objectContaining({ runner_label: 'macos' }),
+      expect.objectContaining({ runner_label: 'windows' }),
+    ]))
+    expect(platformDevJob.steps.some((step: Record<string, unknown>) => String(step.run ?? '').includes('e2e:dev:smoke'))).toBe(true)
+    expect(workflow.jobs['pr-gate'].needs).toEqual(['scope', 'quality', 'core-smoke', 'platform-watch', 'platform-dev'])
     expect(source).toContain('test "$result" = success || test "$result" = skipped')
     expect(source).toContain('pr-gate-package-build-${{ github.run_id }}')
   })


### PR DESCRIPTION
## 变更说明

- 为 demo 覆盖矩阵增加独立的正常 dev 状态、命令与证据字段。
- 将 dev 纳入统一 coverage registry/report，并升级报告 schema。
- 增加可按矩阵筛选的跨平台 dev startup smoke，检查首次编译、进程存活及 Sass/PostCSS/Vite 错误。
- 在 Linux、macOS、Windows PR Gate 增加正常 dev 启动 smoke。
- 保持 IDE、设备和不稳定目标的 local/exempt 契约，不伪造 HMR 支持。

## 验证

- `pnpm build:pkgs`
- `pnpm --filter weapp-tailwindcss test`
- `pnpm test:plugins`
- `pnpm e2e:dev:smoke`（weapp-vite 真实启动）
- `pnpm e2e:multiplatform-build`（52/52）
- `pnpm e2e:static`（312 passed，18 skipped）
- `pnpm lint`

Refs #1144