### PR TITLE
test(uni-app-x): 补齐 alpha 验证并拒绝 Harmony 重启误报 HMR

### DIFF
--- a/demo/issue-1144-uni-app-x-web/README.md
+++ b/demo/issue-1144-uni-app-x-web/README.md
@@ -2,15 +2,25 @@
 
 此目录完整保留 [Gitee 复现仓库](https://gitee.com/my_hujinchen/weapp-tailwind-test-uniappx) 的页面与主题源码，登记为 [weapp-tailwindcss#1144](https://github.com/sonofmagic/weapp-tailwindcss/issues/1144) 的独立回归 demo。
 
-仓库锁定的 HBuilderX 5.22 Web 编译器无法运行该仓库原有的 `script setup lang="uts"` descriptor 代码，因此仅将 App 和首页脚本改为等价的经典 UTS options 写法；模板、样式块和 `@apply` 复现内容保持不变。
+demo 默认保留经典 UTS Options 写法。原始 `script setup lang="uts"` 脚本位于 `e2e/fixtures/issue-1144`，alpha 专项用例临时替换 App 与首页脚本，运行后恢复。2026-09-08 的 HBuilderX 5.25 alpha 实测两种写法均完成 16 轮保存及两次刷新；CLI 生产构建也覆盖两种写法。此前的 descriptor 失败记录不能作为 setup 普遍不受支持的结论。
 
 ### 复现步骤
 
-1. 使用 Node.js 22.12+ 和 HBuilderX（包含 uni-app x Web 工具链）安装仓库依赖。
-2. 在仓库根目录执行 `pnpm --filter @weapp-tailwindcss-demo/issue-1144-uni-app-x-web run dev:h5`。真实 HBuilderX 回归分别运行 `HBUILDERX_CHANNEL=stable E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web pnpm e2e:hbuilderx:h5` 和 `HBUILDERX_CHANNEL=alpha E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web pnpm e2e:hbuilderx:h5`；切换前先关闭另一个 HBuilderX 实例。
+1. 使用根 package.json engines 指定的 Node.js 版本 和 HBuilderX（包含 uni-app x Web 工具链）安装仓库依赖。
+2. 在仓库根目录执行 `pnpm --filter @weapp-tailwindcss-demo/issue-1144-uni-app-x-web run dev:h5`。真实 HBuilderX 回归分别运行 `HBUILDERX_CHANNEL=stable E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web pnpm e2e:hbuilderx:h5` 和 `HBUILDERX_CHANNEL=alpha E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web pnpm e2e:hbuilderx:h5`；同时固定 `HBUILDERX_HOST`，不要终止其他任务持有的 IDE 会话。
 3. 打开首页后编辑 `pages/index/index.uvue` 模板中的文字并保存。页面中的探针同时覆盖直接使用 `class="mt-24!"`，以及 `:pt="{ root: 'p-0!' }"` 依次改为 `p-10!`、`p-4!`、再改回 `p-0!` 的三轮 Web HMR。
 
 首次加载和保存后的 HMR 页面都应正常更新；Vite 页面不应出现错误遮罩，HBuilderX/Vite 日志不应出现 `Unknown word` 或 `[plugin:vite:css]` PostCSS 警告，生成 CSS 也不应残留 Tailwind 原始指令。
+
+### 原始 setup 的 alpha 回归
+
+从仓库根目录运行：
+
+```sh
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1144_ALPHA=1 E2E_HBUILDERX_WEB_TIMEOUT_MS=45000 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1144-alpha.test.ts --update=none
+```
+
+该用例检查真正消费 `pt.root` 的组件、important 竞争样式、style 块切换与每轮 marker。公开仓库完整第三方组件包仍不在本回归范围内。
 
 ### 在 UTS 中读取主题变量
 

--- a/docs/engineering/lessons/issue-1144.md
+++ b/docs/engineering/lessons/issue-1144.md
@@ -12,6 +12,8 @@ regressions:
 
 # Issue #1144：SCSS important 与可靠 HMR 验收
 
+2026-09-08 补充：[5.25 alpha 与 Harmony 更新证据](uni-app-x-alpha-hmr.md) 已验证原始 setup，并用无插件原生对照区分符号链接失败、增量重启和纯 HMR。以下保留本次历史修复证据；未验证边界以后续记录为准。
+
 ## 症状
 
 [用户最新评论](https://github.com/sonofmagic/weapp-tailwindcss/issues/1144#issuecomment-5551182026)（2026-09-05 更新）包含两类 Web 症状：多次切换 `:pt="{ root: 'p-0!' }"` / `p-10!` 后不再更新，刷新也无效；新增 `mt-24!` 后报错。截图中使用 HBuilderX 5.25 alpha，错误是 `[plugin:vite:css] [sass] expected ";"`，位置为生成的 `@apply mt-24!`。

--- a/docs/engineering/lessons/issue-1164.md
+++ b/docs/engineering/lessons/issue-1164.md
@@ -10,6 +10,8 @@ regressions:
 
 # Issue 1164：Harmony scoped SCSS 行注释
 
+2026-09-08 补充：[5.25 alpha 与 Harmony 更新证据](uni-app-x-alpha-hmr.md) 已验证原始 setup，并用无插件原生对照区分符号链接失败、增量重启和纯 HMR。以下保留本次历史修复证据；未验证边界以后续记录为准。
+
 ## 症状
 
 uni-app x、weapp-tailwindcss 5.5.1、Tailwind CSS 4.3.3。

--- a/docs/engineering/lessons/uni-app-x-alpha-hmr.md
+++ b/docs/engineering/lessons/uni-app-x-alpha-hmr.md
@@ -1,0 +1,116 @@
+---
+status: partial
+issue: https://github.com/sonofmagic/weapp-tailwindcss/issues/1164
+baseline: 6873b33a5b396ec3155f4c9d28d30286473ccb6e
+regressions:
+  - e2e/issue-1144-alpha.test.ts
+  - e2e/issue-1144-static.test.ts
+  - e2e/issue-1144-runner.test.ts
+  - e2e/hbuilderx-hmr-lifecycle.test.ts
+  - e2e/issue-1164-native-static.test.ts
+  - e2e/issue-1160-mini-static.test.ts
+---
+
+# uni-app x：5.25 alpha 与 Harmony 更新证据
+
+## 症状
+
+本记录补齐 [Issue 1144 记录](issue-1144.md) 中未验证的 alpha / 原始 setup 环境，以及 [Issue 1164 记录](issue-1164.md) 中“产物更新但自动重装”的边界。旧记录的 Sass、SCSS 解析修复仍有效；本次没有复现需要新增产品解析补丁的失败。
+
+2026-09-08，从上述最新 origin/main 创建仓库外 worktree，分支 `codex/uni-app-x-alpha-hmr-root-fix`。Node 24.18.0、pnpm 11.25.0，冻结安装成功，锁文件未改。聚合包构建完成后直接重建 postcss 与主包；demo 解析到该 worktree 的 `packages/weapp-tailwindcss/dist/vite.cjs` 与 `packages/postcss`，消费 npm 版 tailwindcss-patch。
+
+固定使用正在运行的 HBuilderX **5.25.2026082902-alpha**、host `HBuilderX`，CLI 位于 alpha 应用内。Harmony 为 Pura 90 模拟器、OpenHarmony 6.1.1.125，DevEco Studio 6.1.1.280；编译日志明确为 5.25、VDOM、样式隔离策略 1.0。
+
+## 根因与纠正
+
+### #1144：补齐原始 setup，纠正 static 读取器
+
+同一 alpha 服务中，Options 与公开复现仓库原始 `script setup lang="uts"` 两种写法分别完成 16 轮保存、第 12/16 轮后刷新。每轮检查真正消费 `pt.root` 的组件 class、CSS、computed padding、important 竞争样式与本轮 marker；交错新增/删除 important，并切换 scoped、非 scoped、无 style 和恢复 style。没有 Sass/PostCSS 错误。
+
+static 的 setup 首次运行失败在测试读取器：编译器将 pt 包装成 `new UTSJSONObject({ root: ... })`，旧读取器只接受直接对象字面量，读不到类名。仅解开这个确定的编译器包装后，相同产物通过，两种脚本共用的语义基线未变化。未放宽 class/selector/声明断言，也未改产品行为。
+
+这替代旧记录中“alpha 会话冲突，尚未验证”的限制，以及 demo README 对 setup 普遍不支持的推断；不扩展成任意第三方组件包均已验证。
+
+### #1160：小程序测试需要明确打开项目
+
+旧专项直接传入未打开的 worktree 路径，CLI 返回后不存在 mp-weixin 产物，12 个探针全部缺失。测试改用现有独立项目别名，显式打开、固定本轮 runner 的 alpha/host、清理旧目标产物后编译并关闭自己的项目。同用例修复前 0/12，修复后 12/12，原有 border 基线不变；没有修改任何产品边框行为。
+
+### #1164：分开符号链接失败、增量重启与纯 HMR
+
+有插件的原 demo 四组首次渲染正确。通过旧 runner 的项目根符号链接启动时，删注释、加注释并改蓝色/120px/12px、恢复三轮均出现：
+
+```text
+热更新失败
+安装 .hap 到鸿蒙设备 ...
+App Launch
+```
+
+CLI 隐去的 HBuilderX 内部日志同时包含：
+
+```text
+hvigor ERROR: 10310009 ArkTS: INTERNAL ERROR
+Failed to find module info with '<project-alias>/unpackage/dist/dev/app-harmony/entry/src/main/ets/entryability/EntryAbility.ets' from the context information.
+```
+
+随后在外部独立真实目录复制同一项目（仅 node_modules 链接），固定同一 IDE/compiler/device，重复三轮。每轮增量完成，没有 `.hap` 重装，但仍重新 App Launch。项目根符号链接与 realpath 混用是本轮 ArkTS 模块身份失败的触发条件；这属于测试启动边界，不能归为 Tailwind 生成器缓存失效。直接打开嵌套 worktree 路径曾返回“不支持运行到鸿蒙”，本记录不把这进一步推断为特定的项目名称冲突。
+
+再用 [原生 CSS 最小对照](../../../e2e/fixtures/issue-1164-native/README.md)，完全不注册 Tailwind 插件。四组首次样式正确，三轮增量仍会重启，点击按钮得到的内存状态在首次更新后清零。
+
+| 场景 | 初始 PID | 删除注释 | 加回注释并修改样式 | 恢复 | 结论 |
+| --- | --- | --- | --- | --- | --- |
+| 插件、真实目录 | 23681 | 23773 | 28495 | 29558 | 增量完成，无重装，但重启 |
+| 原生 CSS、真实目录 | 2970 | 3051 | 4595 | 5789 | 同上，且 state=1 → state=0 |
+
+原生对照关键时序（本机日志时区）：
+
+```text
+10:33:25.902 App Launch
+10:34:32.026 开始热更新 ...
+10:34:36.750 热更新完成
+10:34:37.615 App Launch
+10:35:30.767 开始热更新 ...
+10:35:35.008 热更新完成
+10:35:35.813 App Launch
+```
+
+因此本次不为“纯 HMR 通过”修改插件语义。修正两条验收入口：每轮源文件写入前订阅 stdout/stderr，保留完整日志（32 MiB 上限）；失败、重装、App Launch 都不能被后续成功信息覆盖。传输完成后另查设备当前 marker、布局、截图与同一 PID，避免“产物新、运行时旧”的假成功。单测覆盖日志分片、超过旧 160 片段窗口、迟到的 App Launch、旧 marker 与 PID 变化。
+
+## 验证
+
+完整命令输出与设备原始证据位于忽略目录 `e2e/.artifacts/alpha-hmr`，Web 每轮证据位于 `e2e/.artifacts/web-hmr`。版本化基线只保留语义声明，不含本机路径或构建哈希。
+
+```sh
+pnpm install --frozen-lockfile
+pnpm build:pkgs
+pnpm --filter @weapp-tailwindcss/postcss build
+pnpm --filter weapp-tailwindcss build
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_HBUILDERX_CASE=issue-1144-uni-app-x-web E2E_HBUILDERX_WEB_TIMEOUT_MS=45000 pnpm e2e:hbuilderx:h5
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1144_ALPHA=1 E2E_HBUILDERX_WEB_TIMEOUT_MS=45000 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1144-alpha.test.ts --update=none
+pnpm e2e:windows-utilities
+pnpm exec cross-env CI=1 pnpm exec vitest run --project=weapp-tailwindcss --project=@weapp-tailwindcss/postcss --update=none --coverage.enabled=false
+pnpm exec cross-env CI=1 pnpm exec vitest run --project=@weapp-tailwindcss/hbuilderx-runner --update=none --coverage.enabled=false
+pnpm exec cross-env CI=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1144-static.test.ts -u
+pnpm exec cross-env CI=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1144-static.test.ts e2e/issue-1144-runner.test.ts e2e/hbuilderx-hmr-lifecycle.test.ts --update=none
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1164_NATIVE=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1164-native-static.test.ts -u
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1164_NATIVE=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1164-native-static.test.ts --update=none
+pnpm exec cross-env CI=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1160-static.test.ts e2e/issue-1166-webpack-radius.test.ts --update=none
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1160_MINI=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1160-mini-static.test.ts -u
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1160_MINI=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1160-mini-static.test.ts --update=none
+pnpm typecheck
+pnpm agents:check
+git diff --check
+```
+
+通过：core + postcss 4,158 项、38 跳过；HBuilderX runner 19 项；static/setup/生命周期 14 项；最终运行器、渲染模式与视觉主题专项合计 37 项通过；原生四组 Harmony static 1 项；#1160 H5 与 #1166 webpack 合计 3 项；#1160 alpha mini 1 项。#1144 static 限定本项目重新生成后禁止更新复验，两种脚本共用原有基线；新增原生 CSS 对照同样先更新、后禁止更新复验。原生 static 首次清理遇到编译后台落盘的 ENOTEMPTY，测试清理加入有限重试后相同编译与断言通过。
+
+#1159 独立 Taro 消费已通过：发布版 5.5.1 dev/prod、当前打包主包及运行时依赖闭包 dev/prod 四阶段均通过。此前 registry 安装阻塞本轮未再发生，未修改锁文件或弱化断言。本次操作系统是 macOS，不能表述为 Windows 原生复验。定向 lint 为 0 错误（仓库默认忽略的 Markdown/fixture 配置产生提示），`agents:check` 为 0 错误，`git diff --check` 通过。
+
+## 适用边界
+
+Harmony 保持运行状态的纯 HMR 尚未通过；无插件对照已复现，因此保留 Draft 交付与上游环境限制。旧符号链接 runner 的 ArkTS 失败也不能通过重新安装来自动转绿；通用项目暂存方案需保留配置相邻依赖与 source/output 身份，不能简单删除隔离机制。
+
+公开包源码、API、默认配置、原生共享逻辑未改变，所以没有 change intent，也不扩大 Android/iOS/微信运行时验收范围。全仓 `pnpm typecheck` 仍在未改动的主包类型处失败，不宣称类型检查全绿。另在独立干净 HEAD worktree 对照 `pnpm exec tsc -p e2e/tsconfig.json --noEmit --pretty false`：基线与当前各 1,242 条诊断，按文件、错误码和消息比较无新增；不以忽略文件或改断言消除类型错误。修订后的真实 Harmony runner 在初始设备 marker 和截图通过后，于“热更新失败”处拒绝继续报成功；失败现场 `hot-update/state.json` 显示目标 marker 尚未出现在设备上，截图与布局保留。该设备测试保持失败是本次修正的预期结果。未等待远端 CI、发布 npm 或关闭 Issue。
+
+## 规则评估
+
+不新增 AGENTS 规则。把已有“设备证据、同进程连续更新、拒绝假成功”的要求变成验收代码，并保留最小无插件对照，比新增文字规则更直接。旧记录保留历史根因与证据，通过本记录明确补充和替代未验证边界。

--- a/e2e/__snapshots__/issue-1164/native-control.json
+++ b/e2e/__snapshots__/issue-1164/native-control.json
@@ -1,0 +1,93 @@
+{
+  "author": {
+    "inline": [
+      {
+        "background-color": "#ff7a00",
+        "height": "100px",
+        "width": "100%"
+      },
+      {
+        "color": "#ffffff"
+      },
+      {
+        "background-color": "#f21903",
+        "height": "48px",
+        "width": "48px",
+        "border-radius": "9999px"
+      }
+    ],
+    "scoped": [
+      {
+        "author": {
+          "": {
+            "paddingTop": 8,
+            "paddingRight": 8,
+            "paddingBottom": 8,
+            "paddingLeft": 8
+          }
+        }
+      }
+    ]
+  },
+  "block": {
+    "inline": [
+      {
+        "background-color": "#ff7a00",
+        "height": "100px",
+        "width": "100%"
+      },
+      {
+        "color": "#ffffff"
+      },
+      {
+        "background-color": "#f21903",
+        "height": "48px",
+        "width": "48px",
+        "border-radius": "9999px"
+      }
+    ],
+    "scoped": [
+      {}
+    ]
+  },
+  "empty": {
+    "inline": [
+      {
+        "background-color": "#ff7a00",
+        "height": "100px",
+        "width": "100%"
+      },
+      {
+        "color": "#ffffff"
+      },
+      {
+        "background-color": "#f21903",
+        "height": "48px",
+        "width": "48px",
+        "border-radius": "9999px"
+      }
+    ],
+    "scoped": []
+  },
+  "line": {
+    "inline": [
+      {
+        "background-color": "#ff7a00",
+        "height": "100px",
+        "width": "100%"
+      },
+      {
+        "color": "#ffffff"
+      },
+      {
+        "background-color": "#f21903",
+        "height": "48px",
+        "width": "48px",
+        "border-radius": "9999px"
+      }
+    ],
+    "scoped": [
+      {}
+    ]
+  }
+}

--- a/e2e/fixtures/issue-1144/App-setup.uts
+++ b/e2e/fixtures/issue-1144/App-setup.uts
@@ -1,0 +1,40 @@
+import { disposeTheme, refreshSystemTheme } from '@/stores/theme.uts'
+
+// #ifdef APP-ANDROID || APP-HARMONY
+let firstBackTime = 0
+// #endif
+
+onLaunch(() => {
+	console.log('App Launch')
+})
+
+onAppShow(() => {
+	refreshSystemTheme()
+})
+
+onAppHide(() => {
+	console.log('App Hide')
+})
+
+// #ifdef APP-ANDROID || APP-HARMONY
+onLastPageBackPress(() => {
+	console.log('App LastPageBackPress')
+	if (firstBackTime == 0) {
+		uni.showToast({
+			title: '再按一次退出应用',
+			position: 'bottom'
+		})
+		firstBackTime = Date.now()
+		setTimeout(() => {
+			firstBackTime = 0
+		}, 2000)
+	} else if (Date.now() - firstBackTime < 2000) {
+		firstBackTime = Date.now()
+		uni.exit()
+	}
+})
+
+onExit(() => {
+	disposeTheme()
+})
+// #endif

--- a/e2e/fixtures/issue-1144/README.md
+++ b/e2e/fixtures/issue-1144/README.md
@@ -1,0 +1,7 @@
+# 原始 setup 脚本
+
+2026-09-08 读取公开复现仓库的 [App.uvue](https://gitee.com/my_hujinchen/weapp-tailwind-test-uniappx/raw/master/App.uvue) 与 [首页](https://gitee.com/my_hujinchen/weapp-tailwind-test-uniappx/raw/master/pages/index/index.uvue)，保留其中的 UTS setup 脚本。首页仅增加 PtProbe 的导入，以复用 demo 中实际消费 `pt.root` 的组件。
+
+`withIssue1144Setup` 只替换两个 script 块，保留 demo 模板、主题、样式与 important 竞争样式，并在失败后恢复原文件。它不是完整第三方组件库的替代验收。
+
+持久入口为 `e2e/issue-1144-alpha.test.ts` 和 `e2e/issue-1144-static.test.ts`；alpha 入口显式设置 `E2E_ISSUE_1144_ALPHA=1` 与 `HBUILDERX_CHANNEL=alpha`。

--- a/e2e/fixtures/issue-1144/index-setup.uts
+++ b/e2e/fixtures/issue-1144/index-setup.uts
@@ -1,0 +1,34 @@
+import PtProbe from '../../components/pt-probe/pt-probe.uvue'
+import { setThemeMode, setThemeSkin, useTheme } from '@/stores/theme.uts'
+import type { ThemeModePreference, ThemeSkin } from '@/stores/theme.uts'
+import { getThemeValue } from '@/theme.uts'
+const pageColor = getThemeValue('--theme-primary')
+
+type SkinOption = {
+	label: string
+	value: ThemeSkin
+}
+
+type ModeOption = {
+	label: string
+	value: ThemeModePreference
+}
+
+const theme = useTheme()
+const skins: SkinOption[] = [
+	{ label: '默认', value: 'default' },
+	{ label: '海洋', value: 'ocean' }
+]
+const modes: ModeOption[] = [
+	{ label: '浅色', value: 'light' },
+	{ label: '深色', value: 'dark' },
+	{ label: '跟随系统', value: 'system' }
+]
+
+function selectSkin(skin: ThemeSkin): void {
+	setThemeSkin(skin)
+}
+
+function selectMode(mode: ThemeModePreference): void {
+	setThemeMode(mode)
+}

--- a/e2e/fixtures/issue-1164-native/App.uvue
+++ b/e2e/fixtures/issue-1164-native/App.uvue
@@ -1,0 +1,5 @@
+<script lang="uts">
+export default {
+  onLaunch() { console.log('App Launch') },
+}
+</script>

--- a/e2e/fixtures/issue-1164-native/README.md
+++ b/e2e/fixtures/issue-1164-native/README.md
@@ -1,0 +1,22 @@
+# Harmony 原生 CSS 最小对照
+
+本目录不加载 weapp-tailwindcss、debugX 或官方 Tailwind 插件。背景、尺寸、圆角使用等价原生 inline CSS，组件仍保留空白、`//`、块注释、含作者规则四种 scoped SCSS。作者规则保留 8px padding。页面按钮用于观察更新是否重置内存状态。
+
+复制到仓库外的独立**真实目录**，不要把项目根目录做成符号链接；为它提供 demo 的 `node_modules`（依赖目录可以链接）。使用 HBuilderX 5.25 alpha 打开这个目录，以 VDOM、样式隔离 1.0 运行到 Harmony。编译器版本与渲染模式必须从本轮日志确认。
+
+在同一运行会话依次操作：
+
+1. 确认四组橙色 100px 容器、红色 48px 圆形、作者 padding 均正确；点击按钮，记录 `state=1`、PID、截图与布局树。
+2. 删除 `components/line.uvue` 中单独的 `//`，将文字改为 `line-no-comment`，保存一次。
+3. 加回 `//`；四组背景改为 `#007aff`、容器高度改为 `120px`、圆角改为 `12px`，line 文字改为 `line-blue-comment`。
+4. 恢复四个组件。每轮分别检查编译产物、当前设备文字及样式，记录 PID 与 App Launch 次数。
+
+2026-09-08 实测三轮均显示“热更新完成”，但紧接着 App Launch、PID 变化；第一轮 `state=1 → state=0`。没有失败后重装，仍不属于保持运行状态的纯 HMR。不要将这个结果归因于不存在于配置中的 Tailwind 插件。
+
+仅验证原生编译产物的自动入口：
+
+```sh
+pnpm exec cross-env CI=1 HBUILDERX_CHANNEL=alpha HBUILDERX_HOST=HBuilderX E2E_ISSUE_1164_NATIVE=1 pnpm exec vitest run -c e2e/vitest.e2e.config.ts e2e/issue-1164-native-static.test.ts --update=none
+```
+
+该入口在 `os.tmpdir()` 创建独立物理项目，记录所选 CLI，编译后检查四组实际产物并关闭自己的项目。它不代替以上设备操作。首次基线更新只把末尾参数换为 `-u`，随后再禁止更新复验。

--- a/e2e/fixtures/issue-1164-native/components/author.uvue
+++ b/e2e/fixtures/issue-1164-native/components/author.uvue
@@ -1,0 +1,10 @@
+<template>
+  <view id="issue-1164-author" class="author" style="background-color: #ff7a00; height: 100px; width: 100%;">
+    <text style="color: #ffffff;">author</text>
+    <view style="background-color: #f21903; height: 48px; width: 48px; border-radius: 9999px;" />
+  </view>
+</template>
+<style lang="scss" scoped>
+//
+.author { padding: 8px; }
+</style>

--- a/e2e/fixtures/issue-1164-native/components/block.uvue
+++ b/e2e/fixtures/issue-1164-native/components/block.uvue
@@ -1,0 +1,9 @@
+<template>
+  <view id="issue-1164-block" class="author" style="background-color: #ff7a00; height: 100px; width: 100%;">
+    <text style="color: #ffffff;">block</text>
+    <view style="background-color: #f21903; height: 48px; width: 48px; border-radius: 9999px;" />
+  </view>
+</template>
+<style lang="scss" scoped>
+/* 对照注释 */
+</style>

--- a/e2e/fixtures/issue-1164-native/components/empty.uvue
+++ b/e2e/fixtures/issue-1164-native/components/empty.uvue
@@ -1,0 +1,8 @@
+<template>
+  <view id="issue-1164-empty" class="author" style="background-color: #ff7a00; height: 100px; width: 100%;">
+    <text style="color: #ffffff;">empty</text>
+    <view style="background-color: #f21903; height: 48px; width: 48px; border-radius: 9999px;" />
+  </view>
+</template>
+<style lang="scss" scoped>
+</style>

--- a/e2e/fixtures/issue-1164-native/components/line.uvue
+++ b/e2e/fixtures/issue-1164-native/components/line.uvue
@@ -1,0 +1,9 @@
+<template>
+  <view id="issue-1164-line" class="author" style="background-color: #ff7a00; height: 100px; width: 100%;">
+    <text style="color: #ffffff;">line</text>
+    <view style="background-color: #f21903; height: 48px; width: 48px; border-radius: 9999px;" />
+  </view>
+</template>
+<style lang="scss" scoped>
+//
+</style>

--- a/e2e/fixtures/issue-1164-native/main.uts
+++ b/e2e/fixtures/issue-1164-native/main.uts
@@ -1,0 +1,5 @@
+import App from './App.uvue'
+import { createSSRApp } from 'vue'
+export function createApp() {
+  return { app: createSSRApp(App) }
+}

--- a/e2e/fixtures/issue-1164-native/manifest.json
+++ b/e2e/fixtures/issue-1164-native/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue-1164-native",
+  "appid": "__UNI__F1BA2B3",
+  "versionName": "1.0.0",
+  "versionCode": "100",
+  "uni-app-x": {},
+  "vueVersion": "3",
+  "app-harmony": {}
+}

--- a/e2e/fixtures/issue-1164-native/pages.json
+++ b/e2e/fixtures/issue-1164-native/pages.json
@@ -1,0 +1,10 @@
+{
+  "pages": [
+    {
+      "path": "pages/index/index",
+      "style": {
+        "navigationBarTitleText": "1164 native control"
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/issue-1164-native/pages/index/index.uvue
+++ b/e2e/fixtures/issue-1164-native/pages/index/index.uvue
@@ -1,0 +1,16 @@
+<script lang="uts">
+import Empty from '../../components/empty.uvue'
+import Line from '../../components/line.uvue'
+import Block from '../../components/block.uvue'
+import Author from '../../components/author.uvue'
+export default {
+  components: { Empty, Line, Block, Author },
+  data() { return { count: 0 } },
+}
+</script>
+<template>
+  <scroll-view scroll-y style="flex: 1;">
+    <button @click="count++">state={{ count }}</button>
+    <Empty /><Line /><Block /><Author />
+  </scroll-view>
+</template>

--- a/e2e/fixtures/issue-1164-native/vite.config.js
+++ b/e2e/fixtures/issue-1164-native/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+import uniModule from '@dcloudio/vite-plugin-uni'
+
+const uni = uniModule.default ?? uniModule
+export default defineConfig({ plugins: [uni()] })

--- a/e2e/hbuilderx-hmr-lifecycle.test.ts
+++ b/e2e/hbuilderx-hmr-lifecycle.test.ts
@@ -1,0 +1,55 @@
+import { Buffer } from 'node:buffer'
+import { ChildProcess } from 'node:child_process'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+import { assertHarmonyProcessUnchanged, hasHarmonyMarker } from './hbuilderx-local/harmony-runtime'
+import { classifyHmrStep, observeHmrStep } from './hbuilderx-local/hmr-lifecycle'
+
+describe('Harmony HMR 生命周期验收', () => {
+  it('设备必须出现本轮 marker，并保持同一个有效运行进程', () => {
+    const tree = { children: [{ attributes: { text: 'save-2' } }] }
+    expect(hasHarmonyMarker(tree, 'save-1')).toBe(false)
+    expect(hasHarmonyMarker(tree, 'save-2')).toBe(true)
+    expect(() => assertHarmonyProcessUnchanged('2970', '2970')).not.toThrow()
+    expect(() => assertHarmonyProcessUnchanged('2970', '3051')).toThrow('不能计作纯 HMR')
+    expect(() => assertHarmonyProcessUnchanged('', '')).toThrow('不能计作纯 HMR')
+  })
+  it.each([
+    ['编译完成\n热更新传输完成', 'pending'],
+    ['热更新完成', 'updated'],
+    ['热更新失败\n安装 .hap 到鸿蒙设备\n热更新完成', 'failed'],
+    ['安装 .hap 到鸿蒙设备\n热更新完成', 'reinstalled'],
+    ['热更新完成\n\u001B[0mApp Launch\u001B[0m', 'restarted'],
+  ])('区分产物、传输、重启与重装：%s', (log, state) => {
+    expect(classifyHmrStep(log)).toBe(state)
+  })
+
+  it('按保存隔离，跨流分片的早期失败不能被后续日志挤掉', async () => {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    const child = Object.assign(new ChildProcess(), { stdout, stderr })
+    stdout.on('data', () => {})
+    stderr.on('data', () => {})
+    stdout.emit('data', '安装 .hap 到鸿蒙设备\nApp Launch\n')
+    const first = observeHmrStep(child)
+    const failure = Buffer.from('热更新失败\n')
+    stdout.emit('data', failure.subarray(0, 4))
+    stderr.emit('data', '设备旁路日志\n')
+    stdout.emit('data', failure.subarray(4))
+    for (let index = 0; index < 200; index++) {
+      stdout.emit('data', `设备日志 ${index}\n`)
+    }
+    stdout.emit('data', '热更新完成\n')
+    await expect(first.waitForCompletion(100, () => {})).rejects.toThrow('failed')
+    first.dispose()
+    expect(stdout.listenerCount('data')).toBe(1)
+    expect(stderr.listenerCount('data')).toBe(1)
+    const second = observeHmrStep(child)
+    stdout.emit('data', '热更新完成\n')
+    await second.waitForCompletion(100, () => {})
+    // 完成通知早于 App Launch，运行时取证后仍必须复查。
+    stderr.emit('data', 'App Launch\n')
+    expect(second.assertNoFallback).toThrow('restarted')
+    second.dispose()
+  })
+})

--- a/e2e/hbuilderx-local/harmony-runtime.ts
+++ b/e2e/hbuilderx-local/harmony-runtime.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { setTimeout } from 'node:timers/promises'
+import { resolveHdcCommand } from './process'
+
+interface LayoutNode {
+  attributes?: { text?: string }
+  children?: LayoutNode[]
+}
+
+export function hasHarmonyMarker(node: LayoutNode, marker: string): boolean {
+  return node.attributes?.text === marker || (node.children ?? []).some(child => hasHarmonyMarker(child, marker))
+}
+
+export function assertHarmonyProcessUnchanged(before: string, after: string) {
+  if (!/^\d+$/.test(before) || !/^\d+$/.test(after) || before !== after) {
+    throw new Error(`Harmony 运行进程未保持：before=${before} after=${after}；不能计作纯 HMR`)
+  }
+}
+
+/** 同时保存本轮布局和截图；产物命中不能替代设备 marker 与进程连续性。 */
+interface HarmonyEvidenceOptions {
+  deviceId?: string | undefined
+  directory: string
+  marker: string
+}
+
+export async function captureHarmonyRuntimeEvidence(options: HarmonyEvidenceOptions) {
+  const hdc = resolveHdcCommand()
+  const base = options.deviceId ? ['-t', options.deviceId] : []
+  const bundle = process.env['E2E_HARMONY_BUNDLE_ID'] ?? 'io.dcloud.uniappx'
+  const run = (...args: string[]) => {
+    const result = spawnSync(hdc, [...base, ...args], { encoding: 'utf8', timeout: 15_000 })
+    if (result.status !== 0) {
+      throw new Error(`Harmony 运行时探针失败：${result.stderr || result.stdout || result.error}`)
+    }
+    return result.stdout.trim()
+  }
+  await mkdir(options.directory, { recursive: true })
+  const layout = path.join(options.directory, 'layout.json')
+  const screenshot = path.join(options.directory, 'screenshot.jpeg')
+  // 此处是设备上的逻辑路径，不是宿主机文件系统路径。
+  const remote = `/data/local/tmp/weapp-hmr-${process.pid}-${Date.now()}`
+  try {
+    const pid = run('shell', 'pidof', bundle)
+    run('shell', 'uitest', 'dumpLayout', '-p', `${remote}.json`, '-b', bundle)
+    run('file', 'recv', `${remote}.json`, layout)
+    const root = JSON.parse(await readFile(layout, 'utf8')) as LayoutNode
+    run('shell', 'snapshot_display', '-f', `${remote}.jpeg`)
+    run('file', 'recv', `${remote}.jpeg`, screenshot)
+    const afterPid = run('shell', 'pidof', bundle)
+    const evidence = { pid, afterPid, layout, screenshot, marker: options.marker, markerFound: hasHarmonyMarker(root, options.marker) }
+    await writeFile(path.join(options.directory, 'state.json'), `${JSON.stringify(evidence, null, 2)}\n`)
+    return evidence
+  }
+  finally {
+    spawnSync(hdc, [...base, 'shell', 'rm', '-f', `${remote}.json`, `${remote}.jpeg`], { timeout: 15_000 })
+  }
+}
+
+export async function waitForHarmonyRuntimeEvidence(options: HarmonyEvidenceOptions & {
+  previousPid?: string
+  timeoutMs: number
+  ensureRunning: () => void
+}) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < options.timeoutMs) {
+    options.ensureRunning()
+    const evidence = await captureHarmonyRuntimeEvidence(options)
+    await setTimeout(0)
+    options.ensureRunning()
+    assertHarmonyProcessUnchanged(evidence.pid, evidence.afterPid)
+    if (options.previousPid) {
+      assertHarmonyProcessUnchanged(options.previousPid, evidence.pid)
+    }
+    if (evidence.markerFound) {
+      return evidence
+    }
+    await setTimeout(100)
+  }
+  throw new Error(`Harmony 产物已更新，但设备未出现当前 marker：${options.marker}\n证据：${options.directory}`)
+}

--- a/e2e/hbuilderx-local/hmr-lifecycle.ts
+++ b/e2e/hbuilderx-local/hmr-lifecycle.ts
@@ -1,0 +1,66 @@
+import type { ChildProcess } from 'node:child_process'
+import { Buffer } from 'node:buffer'
+import { StringDecoder } from 'node:string_decoder'
+import { setTimeout } from 'node:timers/promises'
+import { stripVTControlCharacters } from 'node:util'
+
+export function classifyHmrStep(output: string) {
+  const text = stripVTControlCharacters(output)
+  if (text.includes('热更新失败')) {
+    return 'failed'
+  }
+  if (/安装\s*\.hap\s*到/.test(text)) {
+    return 'reinstalled'
+  }
+  if (text.includes('App Launch')) {
+    return 'restarted'
+  }
+  return text.includes('热更新完成') ? 'updated' : 'pending'
+}
+
+/** 在首次运行完成后、源码写入前监听，保留本轮全部日志，避免滚动窗口丢失失败。 */
+export function observeHmrStep(child: ChildProcess) {
+  const outputs = { stdout: '', stderr: '' }
+  let overflow = false
+  const subscribe = (name: 'stdout' | 'stderr') => {
+    const decoder = new StringDecoder('utf8')
+    const receive = (chunk: Buffer | string) => {
+      if (overflow) {
+        return
+      }
+      outputs[name] += typeof chunk === 'string' ? chunk : decoder.write(chunk)
+      overflow = Buffer.byteLength(outputs.stdout) + Buffer.byteLength(outputs.stderr) > 32 * 1024 * 1024
+    }
+    child[name]?.on('data', receive)
+    return () => child[name]?.off('data', receive)
+  }
+  const subscriptions = [subscribe('stdout'), subscribe('stderr')]
+  const output = () => `${outputs.stdout}\n${outputs.stderr}`
+  const assertNoFallback = () => {
+    if (overflow) {
+      throw new Error('HMR 单轮日志超过 32 MiB，不能确认运行结果')
+    }
+    const state = classifyHmrStep(output())
+    if (state !== 'pending' && state !== 'updated') {
+      throw new Error(`纯 HMR 验收失败：${state}；增量重启或重装不能计作保持运行状态的更新\n${output()}`)
+    }
+  }
+  return {
+    assertNoFallback,
+    async waitForCompletion(timeoutMs: number, ensureRunning: () => void) {
+      const startedAt = Date.now()
+      while (Date.now() - startedAt < timeoutMs) {
+        ensureRunning()
+        assertNoFallback()
+        if (classifyHmrStep(output()) === 'updated') {
+          return
+        }
+        await setTimeout(100)
+      }
+      throw new Error(`产物更新后未收到 HBuilderX 热更新完成日志\n${output()}`)
+    },
+    dispose() {
+      subscriptions.forEach(dispose => dispose())
+    },
+  }
+}

--- a/e2e/hbuilderx-local/issue-1144-source.ts
+++ b/e2e/hbuilderx-local/issue-1144-source.ts
@@ -1,0 +1,30 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+/** 使用公开复现仓库的 setup 脚本，保留相同模板与样式，并在失败后恢复源码。 */
+export async function withIssue1144Setup<T>(projectRoot: string, action: () => Promise<T>) {
+  const files = [
+    { file: path.join(projectRoot, 'App.uvue'), fixture: 'App-setup.uts' },
+    { file: path.join(projectRoot, 'pages', 'index', 'index.uvue'), fixture: 'index-setup.uts' },
+  ]
+  const sources = await Promise.all(files.map(async (item) => {
+    const original = await readFile(item.file, 'utf8')
+    const script = await readFile(path.resolve(__dirname, '../fixtures/issue-1144', item.fixture), 'utf8')
+    const blocks = [...original.matchAll(/<script\b[^>]*>[\s\S]*?<\/script>/g)]
+    if (blocks.length !== 1) {
+      throw new Error(`Issue 1144 复现页必须恰有一个 script 块：${item.file}`)
+    }
+    return { ...item, original, setup: original.replace(blocks[0]![0], `<script setup lang="uts">\n${script}</script>`) }
+  }))
+  try {
+    for (const item of sources) {
+      await writeFile(item.file, item.setup)
+    }
+    return await action()
+  }
+  finally {
+    for (const item of sources) {
+      await writeFile(item.file, item.original)
+    }
+  }
+}

--- a/e2e/hbuilderx-local/runner.ts
+++ b/e2e/hbuilderx-local/runner.ts
@@ -15,6 +15,8 @@ import {
   waitForAndroidRuntimeEvidence,
 } from './android-runtime'
 import { rawTailwindDirectiveRE, resolveAppHmrSteps } from './cases'
+import { captureHarmonyRuntimeEvidence, waitForHarmonyRuntimeEvidence } from './harmony-runtime'
+import { observeHmrStep } from './hmr-lifecycle'
 import {
   assertAndroidToolchain,
   assertHarmonyToolchain,
@@ -611,6 +613,8 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
   let projectAlias: string | undefined
   let cleanupProjectAlias: (() => Promise<void>) | undefined
   let restore: (() => Promise<void>) | undefined
+  let harmonyFailureEvidence: Parameters<typeof captureHarmonyRuntimeEvidence>[0] | undefined
+  let hmrLifecycle: ReturnType<typeof observeHmrStep> | undefined
   let child: ChildProcess | undefined
   try {
     restore = await createHmrSourceRestore([
@@ -697,6 +701,17 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
           'weapp-tailwindcss-hbuilderx-runtime',
           `${process.pid}-${item.name.replace(/[^\w-]+/g, '-')}`,
         )
+    const harmonyDeviceIndex = launchArgs.indexOf('--deviceId')
+    const harmonyDeviceId = harmonyDeviceIndex >= 0 ? launchArgs[harmonyDeviceIndex + 1] : undefined
+    const initialHarmony = item.platform === 'app-harmony'
+      ? await waitForHarmonyRuntimeEvidence({
+          deviceId: harmonyDeviceId,
+          directory: path.resolve(runtimeEvidenceRoot, 'initial'),
+          marker: item.markerText,
+          timeoutMs: hbuilderxAppTimeoutMs,
+          ensureRunning: ensureLaunchRunning,
+        })
+      : undefined
     let previousRuntimeScreenshot: string | undefined
     if (item.platform === 'app-android' && item.runtime) {
       const initialScreenshot = path.resolve(runtimeEvidenceRoot, 'initial.png')
@@ -722,6 +737,10 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
     }
     let hmrOutputRoot = initialOutputRoot
     for (const step of resolveAppHmrSteps(item)) {
+      hmrLifecycle?.assertNoFallback()
+      hmrLifecycle?.dispose()
+      hmrLifecycle = item.platform === 'app-harmony' ? observeHmrStep(child) : undefined
+      harmonyFailureEvidence = initialHarmony ? { deviceId: harmonyDeviceId, directory: path.resolve(runtimeEvidenceRoot, step.name), marker: step.markerText } : undefined
       process.stdout.write(`[hbuilderx-app-hmr] ${item.name} step=${step.name} start\n`)
       if (step.sourceMutation) {
         const shouldWaitForOutputRefresh = step.sourceMutation.expectOutputRefresh !== false
@@ -751,6 +770,21 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
           `recentHBuilderXLogs=${formatRecentLogs(logs, 4000)}`,
         ].join('\n')
       }, step.styleContains, [...(item.transformedNotContains ?? []), ...(step.transformedNotContains ?? [])])
+      await hmrLifecycle?.waitForCompletion(hbuilderxAppTimeoutMs, ensureLaunchRunning)
+      if (initialHarmony) {
+        const evidence = await waitForHarmonyRuntimeEvidence({
+          deviceId: harmonyDeviceId,
+          directory: path.resolve(runtimeEvidenceRoot, step.name),
+          marker: step.markerText,
+          previousPid: initialHarmony.pid,
+          timeoutMs: hbuilderxAppTimeoutMs,
+          ensureRunning: () => {
+            ensureLaunchRunning()
+            hmrLifecycle?.assertNoFallback()
+          },
+        })
+        process.stdout.write(`${JSON.stringify({ step: step.name, runtimeEvidence: evidence })}\n`)
+      }
       if (item.platform === 'app-android' && step.runtime) {
         const screenshot = path.resolve(runtimeEvidenceRoot, `${step.name}.png`)
         const evidence = await waitForAndroidRuntimeEvidence({
@@ -780,7 +814,8 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
       else if (item.platform === 'app-android') {
         process.stdout.write(`[hbuilderx-app-hmr] ${item.name} step=${step.name} 未配置 Android 运行时探针，保留产物/HMR 断言\n`)
       }
-      process.stdout.write(`[hbuilderx-app-hmr] ${item.name} step=${step.name} passed\n`)
+      hmrLifecycle?.assertNoFallback()
+      process.stdout.write(`[hbuilderx-app-hmr] ${item.name} step=${step.name} 产物与传输检查通过\n`)
     }
     await assertAppOutputHasNoUnsupportedContent(item, hmrOutputRoot)
     expectNoContent(logs.join(''), item.logNotContains, `${item.name} HBuilderX 日志`)
@@ -788,8 +823,18 @@ export async function verifyAppHmrWithHBuilderX(item: AppCase) {
 
     await stopAppLaunch(child, closed)
     child = undefined
+    hmrLifecycle?.assertNoFallback()
+  }
+  catch (error) {
+    if (harmonyFailureEvidence) {
+      await captureHarmonyRuntimeEvidence(harmonyFailureEvidence).catch((captureError) => {
+        process.stderr.write(`Harmony 失败现场取证也失败：${captureError}\n`)
+      })
+    }
+    throw error
   }
   finally {
+    hmrLifecycle?.dispose()
     if (child) {
       const closed = new Promise<void>((resolve) => {
         child?.once('close', () => resolve())

--- a/e2e/issue-1144-alpha.test.ts
+++ b/e2e/issue-1144-alpha.test.ts
@@ -1,0 +1,18 @@
+import path from 'node:path'
+import { describe, it } from 'vitest'
+import { webCases } from './hbuilderx-local/cases'
+import { withIssue1144Setup } from './hbuilderx-local/issue-1144-source'
+import { verifyWebHmr } from './hbuilderx-local/runner'
+
+const run = process.env['E2E_ISSUE_1144_ALPHA'] === '1' ? describe : describe.skip
+
+run('issue #1144 HBuilderX alpha original setup', () => {
+  it('keeps the original setup lifecycle and pt consumer current across 16 saves and refreshes', async () => {
+    if (process.env['HBUILDERX_CHANNEL'] !== 'alpha') {
+      throw new Error('此回归必须显式使用 HBUILDERX_CHANNEL=alpha')
+    }
+    const item = webCases.find(item => item.name === 'issue-1144-uni-app-x-web')!
+    const projectRoot = path.resolve(__dirname, '..', item.projectDir)
+    await withIssue1144Setup(projectRoot, () => verifyWebHmr(item))
+  }, 360_000)
+})

--- a/e2e/issue-1144-runner.test.ts
+++ b/e2e/issue-1144-runner.test.ts
@@ -1,10 +1,34 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { expect, it } from 'vitest'
+import { withIssue1144Setup } from './hbuilderx-local/issue-1144-source'
 import { assertServerIdentity, sameSourceFile } from './hbuilderx-local/web/identity'
 import { rewriteHmrMarker } from './hbuilderx-local/web/source'
 import config from './vitest.e2e.config'
+
+it('alpha setup 运行失败后恢复 App 与页面的原始内容', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'issue-1144-setup-'))
+  const page = path.join(root, 'pages', 'index', 'index.uvue')
+  const app = path.join(root, 'App.uvue')
+  const original = '<template><view /></template><script lang="uts">export default {}</script><style>// author</style>'
+  try {
+    await mkdir(path.dirname(page), { recursive: true })
+    await writeFile(app, original)
+    await writeFile(page, original)
+    await expect(withIssue1144Setup(root, async () => {
+      expect(await readFile(page, 'utf8')).toContain('import PtProbe')
+      expect(await readFile(app, 'utf8')).toContain('onLaunch(')
+      expect(await readFile(page, 'utf8')).toContain('<style>// author</style>')
+      throw new Error('模拟运行失败')
+    })).rejects.toThrow('模拟运行失败')
+    expect(await readFile(app, 'utf8')).toBe(original)
+    expect(await readFile(page, 'utf8')).toBe(original)
+  }
+  finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
 
 it('E2E 默认不写入快照', () => {
   expect(config.test?.update).toBe('none')

--- a/e2e/issue-1144-static.test.ts
+++ b/e2e/issue-1144-static.test.ts
@@ -5,12 +5,12 @@ import { parseSync, traverse } from '@babel/core'
 import fg from 'fast-glob'
 import postcss from 'postcss'
 import { expect, it } from 'vitest'
+import { withIssue1144Setup } from './hbuilderx-local/issue-1144-source'
 import { runPnpm } from './hbuilderx-local/process'
 
 const filter = process.env['E2E_PROJECT_FILTER']
 
-it.skipIf(Boolean(filter && !new RegExp(filter).test('issue-1144-uni-app-x-web')))('issue #1144 production output keeps pt and important CSS connected', async () => {
-  const projectRoot = path.resolve(__dirname, '../demo/issue-1144-uni-app-x-web')
+async function verifyProduction(projectRoot: string) {
   await runPnpm(projectRoot, ['exec', 'cross-env', 'UNI_INPUT_DIR=.', 'uni', 'build'], 120_000)
   const outputRoot = path.join(projectRoot, 'dist/build/h5')
   const files = await fg('**/*.{js,css}', { cwd: outputRoot, absolute: true })
@@ -34,8 +34,13 @@ it.skipIf(Boolean(filter && !new RegExp(filter).test('issue-1144-uni-app-x-web')
         if (node.key.name === 'class' && node.value.type === 'StringLiteral' && node.value.value.includes('issue-1144-important-probe')) {
           classes.margin = node.value.value.split(/\s+/).find(value => value.startsWith('wtu-'))!
         }
-        if (node.key.name === 'pt' && node.value.type === 'ObjectExpression') {
-          for (const property of node.value.properties) {
+        // UTS setup 编译器用构造调用承载对象字面量；沿实际 pt 值读取相同的 root。
+        const value = node.value.type === 'NewExpression'
+          && node.value.callee.type === 'Identifier' && node.value.callee.name === 'UTSJSONObject'
+          ? node.value.arguments[0]
+          : node.value
+        if (node.key.name === 'pt' && value?.type === 'ObjectExpression') {
+          for (const property of value.properties) {
             if (property.type === 'ObjectProperty' && property.key.type === 'Identifier' && property.key.name === 'root' && property.value.type === 'StringLiteral') {
               classes.padding = property.value.value
             }
@@ -61,4 +66,14 @@ it.skipIf(Boolean(filter && !new RegExp(filter).test('issue-1144-uni-app-x-web')
   expect(evidence.margin).toContain('margin-top: 24px !important')
   expect(evidence.padding).toContain('padding: 0 !important')
   await expect(`${JSON.stringify(evidence, null, 2)}\n`).toMatchFileSnapshot('__snapshots__/issue-1144-web/important.json')
+}
+
+it.skipIf(Boolean(filter && !new RegExp(filter).test('issue-1144-uni-app-x-web'))).each(['options', 'setup'])('issue #1144 production output keeps %s pt and important CSS connected', async (script) => {
+  const projectRoot = path.resolve(__dirname, '../demo/issue-1144-uni-app-x-web')
+  if (script === 'setup') {
+    await withIssue1144Setup(projectRoot, () => verifyProduction(projectRoot))
+  }
+  else {
+    await verifyProduction(projectRoot)
+  }
 }, 150_000)

--- a/e2e/issue-1160-mini-static.test.ts
+++ b/e2e/issue-1160-mini-static.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises'
+import { readFile, rm } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
@@ -6,7 +6,8 @@ import fg from 'fast-glob'
 import { JSDOM } from 'jsdom'
 import postcss from 'postcss'
 import { expect, it } from 'vitest'
-import { runPnpm } from './hbuilderx-local/process'
+import { createHBuilderXProjectAlias } from '../scripts/hbuilderx-project-alias.mjs'
+import { createLocalHBuilderXRunner } from './hbuilderx-local/process'
 
 const project = 'uni-app-x-vdom-tailwindcss-v4'
 const filter = process.env['E2E_PROJECT_FILTER']
@@ -15,7 +16,21 @@ const selectorParser = createRequire(path.resolve(__dirname, '../packages/postcs
 
 it.skipIf(!enabled)('issue #1160 preserves component border defaults in HBuilderX mini output', async () => {
   const projectRoot = path.resolve(__dirname, '../demo', project)
-  await runPnpm(path.resolve(__dirname, '..'), ['exec', 'hbuilderx', 'launch', 'mp-weixin', '--project', projectRoot, '--compile', 'true'], 120_000)
+  const alias = await createHBuilderXProjectAlias(projectRoot)
+  const runner = await createLocalHBuilderXRunner(projectRoot)
+  try {
+    await runner.run({ args: ['project', 'open', '--path', alias.projectPath] })
+    await rm(path.join(projectRoot, 'unpackage', 'dist', 'dev', 'mp-weixin'), { recursive: true, force: true })
+    await runner.run({ args: ['launch', 'mp-weixin', '--project', alias.projectName, '--compile', 'true'], timeoutMs: 120_000 })
+    await verifyOutput(projectRoot)
+  }
+  finally {
+    await runner.run({ args: ['project', 'close', '--path', alias.projectPath], allowFailure: true }).catch(() => undefined)
+    await alias.cleanup()
+  }
+}, 150_000)
+
+async function verifyOutput(projectRoot: string) {
   const output = path.join(projectRoot, 'unpackage/dist/dev/mp-weixin')
   const files = await fg('**/*.wxml', { cwd: output, absolute: true })
   const evidence: Record<string, string[]> = {}
@@ -58,4 +73,4 @@ it.skipIf(!enabled)('issue #1160 preserves component border defaults in HBuilder
   expect(evidence['issue-1160-pair']).toContain('border-left-width:2px')
   expect(evidence['issue-1160-override']).toContain('border-top-width:0px')
   await expect(`${JSON.stringify(evidence, null, 2)}\n`).toMatchFileSnapshot('__snapshots__/issue-1160/mini-borders.json')
-}, 150_000)
+}

--- a/e2e/issue-1164-native-static.test.ts
+++ b/e2e/issue-1164-native-static.test.ts
@@ -1,0 +1,62 @@
+import { cp, mkdtemp, readFile, realpath, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { parseSync, traverse } from '@babel/core'
+import fg from 'fast-glob'
+import { expect, it } from 'vitest'
+import { createLocalHBuilderXRunner } from './hbuilderx-local/process'
+
+it.skipIf(process.env['E2E_ISSUE_1164_NATIVE'] !== '1')('原生 CSS 最小对照生成四组 Harmony 样式，未加载 Tailwind 插件', async () => {
+  const temporary = await realpath(await mkdtemp(path.join(tmpdir(), 'issue-1164-native-')))
+  const projectRoot = path.join(temporary, 'native-control')
+  const fixture = path.resolve(__dirname, 'fixtures/issue-1164-native')
+  await cp(fixture, projectRoot, { recursive: true })
+  await symlink(path.resolve(__dirname, '../demo/uni-app-x-vdom-tailwindcss-v4/node_modules'), path.join(projectRoot, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir')
+  const runner = await createLocalHBuilderXRunner(projectRoot)
+  try {
+    await runner.run({ args: ['project', 'open', '--path', projectRoot] })
+    await runner.run({ args: ['launch', 'app-harmony', '--project', projectRoot, '--compile', 'true'], timeoutMs: 180_000 })
+    const files = await fg('**/src/main/resources/resfile/**/www/assets/components/*.js', {
+      cwd: path.join(projectRoot, 'unpackage/dist/dev/app-harmony'),
+      absolute: true,
+      ignore: ['**/build/**'],
+    })
+    expect(files).toHaveLength(4)
+    const evidence: Record<string, unknown> = {}
+    for (const file of files.sort()) {
+      const source = await readFile(file, 'utf8')
+      expect(source).not.toMatch(/wtu-|@apply|tailwindcss/)
+      const inline: unknown[] = []
+      const scoped: unknown[] = []
+      traverse(parseSync(source, { configFile: false, babelrc: false })!, {
+        ObjectProperty(property) {
+          if (property.node.key.type === 'Identifier' && property.node.key.name === 'style') {
+            const value = property.get('value').evaluate()
+            expect(value.confident).toBe(true)
+            inline.push(value.value)
+          }
+        },
+        VariableDeclarator(variable) {
+          const init = variable.get('init')
+          if (variable.node.id.type === 'Identifier' && /^_style_\d+$/.test(variable.node.id.name) && init.isObjectExpression()) {
+            const value = init.evaluate()
+            expect(value.confident).toBe(true)
+            scoped.push(value.value)
+          }
+        },
+      })
+      expect(inline).toEqual([
+        { 'background-color': '#ff7a00', 'height': '100px', 'width': '100%' },
+        { color: '#ffffff' },
+        { 'background-color': '#f21903', 'height': '48px', 'width': '48px', 'border-radius': '9999px' },
+      ])
+      evidence[path.parse(file).name] = { inline, scoped }
+    }
+    await expect(`${JSON.stringify(evidence, null, 2)}\n`).toMatchFileSnapshot('__snapshots__/issue-1164/native-control.json')
+  }
+  finally {
+    await runner.run({ args: ['project', 'close', '--path', projectRoot], allowFailure: true }).catch(() => undefined)
+    await rm(temporary, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 })
+  }
+}, 240_000)

--- a/scripts/demo-visual-e2e-report/app.ts
+++ b/scripts/demo-visual-e2e-report/app.ts
@@ -18,6 +18,8 @@ import {
   resolveAdbCommand,
 } from '../../e2e/hbuilderx-local/android-runtime.ts'
 import { resolveAppHmrSteps } from '../../e2e/hbuilderx-local/cases.ts'
+import { captureHarmonyRuntimeEvidence, waitForHarmonyRuntimeEvidence } from '../../e2e/hbuilderx-local/harmony-runtime.ts'
+import { observeHmrStep } from '../../e2e/hbuilderx-local/hmr-lifecycle.ts'
 import {
   assertAndroidToolchain,
   assertHarmonyToolchain,
@@ -666,6 +668,8 @@ async function runAppCaseVariant(
   const sourceFile = path.resolve(projectRoot, item.sourceFile)
   let activeSourceFile = sourceFile
   let launch: ReturnType<typeof startAppLaunch> | undefined
+  let harmonyFailureEvidence: Parameters<typeof captureHarmonyRuntimeEvidence>[0] | undefined
+  let hmrLifecycle: ReturnType<typeof observeHmrStep> | undefined
   let projectAlias: Awaited<ReturnType<typeof createHBuilderXProjectAlias>> | undefined
   let beforeScreenshotEvidence: Record<string, unknown> | undefined
   let afterScreenshotEvidence: Record<string, unknown> | undefined
@@ -749,7 +753,19 @@ async function runAppCaseVariant(
       })
     }
 
-    const ensureHmrRunning = ensureInitialRunning
+    const initialHarmony = item.platform === 'app-harmony'
+      ? await waitForHarmonyRuntimeEvidence({
+          deviceId: resolveHarmonyScreenshotDeviceId(item),
+          directory: path.join(path.dirname(hmrBeforeScreenshot), 'runtime-initial'),
+          marker: item.markerText,
+          timeoutMs: appOutputTimeoutMs,
+          ensureRunning: ensureInitialRunning,
+        })
+      : undefined
+    const ensureHmrRunning = () => {
+      ensureInitialRunning()
+      hmrLifecycle?.assertNoFallback()
+    }
     const hmrSteps: VisualHmrStepResult[] = []
     let previousAfterScreenshot = hmrBeforeScreenshot
     let hmrOutputRoot = initialOutputRoot
@@ -758,6 +774,10 @@ async function runAppCaseVariant(
       const stepAfterScreenshot = resolveHmrStepScreenshotPath(context, name, platform, step.name, 'after', variant.key)
       await fs.mkdir(path.dirname(stepBeforeScreenshot), { recursive: true })
       await fs.copyFile(previousAfterScreenshot, stepBeforeScreenshot)
+      hmrLifecycle?.assertNoFallback()
+      hmrLifecycle?.dispose()
+      hmrLifecycle = item.platform === 'app-harmony' ? observeHmrStep(launch.child) : undefined
+      harmonyFailureEvidence = initialHarmony ? { deviceId: resolveHarmonyScreenshotDeviceId(item), directory: path.join(path.dirname(stepAfterScreenshot), `runtime-${step.name}`), marker: step.markerText } : undefined
       process.stdout.write(`[app-${platform}] ${name}${variant.key ? ` ${variant.key}` : ''}: write hmr marker ${step.name}\n`)
       await writeAppMarker(activeSourceFile, resolveAppMarkerAnchors(item), {
         className: step.markerClass,
@@ -780,6 +800,17 @@ async function runAppCaseVariant(
       await wait(Number(process.env['DEMO_VISUAL_APP_SCREENSHOT_DELAY_MS'] ?? 3000))
       process.stdout.write(`[app-${platform}] ${name}${variant.key ? ` ${variant.key}` : ''}: screenshot after ${step.name}\n`)
       const evidence = await waitForAppScreenshotReady(item, stepAfterScreenshot, toolEnv, `${item.name} HMR ${step.name} 后`, ensureHmrRunning, step.markerClass)
+      await hmrLifecycle?.waitForCompletion(appOutputTimeoutMs, ensureHmrRunning)
+      const harmonyRuntime = initialHarmony
+        ? await waitForHarmonyRuntimeEvidence({
+            deviceId: resolveHarmonyScreenshotDeviceId(item),
+            directory: path.join(path.dirname(stepAfterScreenshot), `runtime-${step.name}`),
+            marker: step.markerText,
+            previousPid: initialHarmony.pid,
+            timeoutMs: appOutputTimeoutMs,
+            ensureRunning: ensureHmrRunning,
+          })
+        : undefined
       const expectedMarkerColor = parseHexColorFromClass(step.markerClass)
       const beforeMarker = expectedMarkerColor
         ? await analyzeScreenshotColorPresence(stepBeforeScreenshot, expectedMarkerColor)
@@ -790,6 +821,7 @@ async function runAppCaseVariant(
       if (markerColorDelta != null && markerColorDelta <= 100) {
         throw new Error(`${item.name} HMR ${step.name} 目标背景色像素未明显增加：before=${beforeMarker?.matchingPixels} after=${evidence.marker?.matchingPixels}`)
       }
+      hmrLifecycle?.assertNoFallback()
       hmrSteps.push({
         afterScreenshot: stepAfterScreenshot,
         beforeScreenshot: stepBeforeScreenshot,
@@ -797,6 +829,7 @@ async function runAppCaseVariant(
         evidence: {
           ...evidence,
           markerColorDelta,
+          harmonyRuntime,
         },
         expectedBackgroundColor: step.markerClass.match(/bg-\[(#[0-9a-f]{6})\]/i)?.[1] ?? '',
         marker: step.markerText,
@@ -805,6 +838,7 @@ async function runAppCaseVariant(
       afterScreenshotEvidence = evidence
       previousAfterScreenshot = stepAfterScreenshot
     }
+    hmrLifecycle?.assertNoFallback()
     await fs.copyFile(previousAfterScreenshot, hmrAfterScreenshot)
     await fs.copyFile(hmrAfterScreenshot, screenshot)
     const forbiddenRuntimeLogs = findForbiddenRuntimeLogs(launch.logs.join(''), runtimeLogContract.notContains)
@@ -843,6 +877,11 @@ async function runAppCaseVariant(
     launch = undefined
   }
   catch (error) {
+    if (harmonyFailureEvidence) {
+      await captureHarmonyRuntimeEvidence(harmonyFailureEvidence).catch((captureError) => {
+        process.stderr.write(`Harmony 失败现场取证也失败：${captureError}\n`)
+      })
+    }
     const launchLog = launch?.logs.join('').trim()
     results.push({
       name,
@@ -859,6 +898,7 @@ async function runAppCaseVariant(
     })
   }
   finally {
+    hmrLifecycle?.dispose()
     await stopAppLaunch(launch)
     if (item.platform === 'app-android') {
       cleanupAndroidAppRuntime(shared?.toolEnv ?? {}, resolveAndroidScreenshotDeviceId(item))


### PR DESCRIPTION
# 问题与结果

Refs #1144
Refs #1164
Refs #1159
Refs #1160

本地 HBuilderX 5.25.2026082902-alpha 验证表明：#1144 当前产品实现已覆盖原始 setup 场景；Harmony 的“热更新完成”仍可能重启应用，旧 runner 还会把失败后的重新安装当作 HMR 成功。本 PR 补齐真实环境证据，并修正这些验收盲点。

| 场景 | 本次结果 |
| --- | --- |
| #1144 alpha | Options 与公开原始 setup 分别完成同服务 16 次保存 + 两次刷新，实际 pt.root 消费、class、CSS、computed style、marker 均一致 |
| #1164 Harmony | 首次四组样式正常；真实目录三轮增量均重启，无插件原生 CSS 对照同样重启，state=1 → state=0 |
| #1159 Taro 独立消费 | 发布版 5.5.1 / 当前打包依赖闭包，各 dev 与 prod，共四阶段通过 |
| #1160 / #1166 | H5、alpha 微信产物、webpack 圆角回归通过 |

# 实现与前后证据

- 保存公开 setup 脚本 fixture，失败后恢复 App/首页；生产读取器识别编译器的 `new UTSJSONObject({ root: ... })`，相同输出从读取失败变为通过，保持原语义基线。
- Harmony 在源文件写入前捕获本轮完整 stdout/stderr；失败、重装、迟到的 App Launch 均不能被成功通知覆盖。设备侧另行检查本轮 marker、布局、截图和 PID；失败现场也保留。
- 修订后的真实 runner 在初始 marker/截图通过后，检测到“热更新失败”并拒绝成功，失败现场目标 marker 尚未出现。它不再凭新编译产物或重装后画面报 HMR 通过。
- #1160 mini 旧测试未打开独立项目，首次得到 0/12 个探针；改用现有项目别名与固定 alpha runner、清除旧目标输出后重新编译，原断言 12/12 通过。
- 提交不加载任何 Tailwind 插件的原生 CSS 最小对照与 Harmony static 基线；中文复盘包含 PID 序列、App Launch 时序和复验命令，并明确替代旧记录的未验证结论。

详见 [中文根因与验证记录](https://github.com/sonofmagic/weapp-tailwindcss/blob/a668f7e35abff4584e00e3dd1b4e36b264c9a919/docs/engineering/lessons/uni-app-x-alpha-hmr.md) 与 [原生最小对照](https://github.com/sonofmagic/weapp-tailwindcss/blob/a668f7e35abff4584e00e3dd1b4e36b264c9a919/e2e/fixtures/issue-1164-native/README.md)。原始大日志、每轮截图和 Web CSS/JSON 保留在本地忽略的 `e2e/.artifacts/alpha-hmr`、`e2e/.artifacts/web-hmr`。

# 本地验证

- 冻结安装、受影响包构建；直接重建 postcss / 主包。
- core + postcss：4,158 通过，38 跳过；HBuilderX runner：19 通过。
- 运行器、Harmony 生命周期/渲染模式、视觉主题：37 通过。
- #1144 两种脚本 static、原生 Harmony 四组 static、#1160 mini 均限定项目更新基线，再以 `CI=1 --update=none` 复验；旧语义快照不变。
- 定向 lint、`agents:check`、`git diff --check` 通过；lint 对仓库默认忽略的文档/fixture 配置有提示。
- `pnpm typecheck` 有既有错误；额外用独立干净 HEAD worktree 对照 e2e tsc：基线与当前各 1,242 条诊断，按文件/错误码/消息比较无新增。

# Draft 的原因与边界

Harmony 保持运行状态的纯 HMR 尚未通过，不能把这五个 Issue 一概宣称为彻底修复。相同 alpha/compiler/device 上，无插件原生对照亦重启，说明剩余限制来自 HBuilderX/Harmony 增量运行链路。项目根符号链接还会触发 hvigor 的 ArkTS 模块身份错误；外部真实目录能消除失败后重装，但仍有增量重启。通用物理项目暂存方案须处理相邻配置依赖与 source/output 身份，尚未实现。

此次修改限于测试、运行器、fixture 与记录，没有公开包行为变更，因此无需 change intent。未扩展为 Windows/Linux 原生、Android/iOS 或微信设备运行时验收；未发布 npm、关闭 Issue 或等待远端 CI。
