### PR TITLE
fix(core): 修复嵌套 CSS 的 @source 扫描

### DIFF
--- a/docs/engineering/lessons/issue-1175-rollup-patch-coverage.md
+++ b/docs/engineering/lessons/issue-1175-rollup-patch-coverage.md
@@ -19,6 +19,8 @@ PR #1175 的 Ubuntu uview demo 在 replace 阶段通过后，add 阶段不再触
 
 扩展真实依赖链回归后，4.63.1 的文件状态去重及 CJS/ESM 构建期间失效测试均失败，4.63.0 通过。按 4.63.1 发布文件重新生成同等补丁，同时注册两个版本并同步锁文件。测试通过各 demo 的 Vite 解析 Rollup，避免只测试固定旧版本。
 
+构建期间失效用例在进入 transform 后立即发布下一版本，可能早于原生事件去重窗口结束。该用例使用真实 polling watcher 观察状态变化，以独立验证缓存生命周期；原生 watcher 的连续原子替换仍由 `rollup-watch.test.mjs` 验证。相同 polling 用例在未打补丁的 4.63.1 上仍然失败，在打补丁版本上通过。
+
 ## 验证
 
 - `pnpm exec vitest run -c scripts/ci/demo-matrix/vitest.config.mts scripts/ci/demo-matrix/rollup-invalidation.test.mjs scripts/ci/demo-matrix/rollup-watch.test.mjs --update=none`：修复前 4.63.1 三项失效回归失败；修复后两个版本的 14 项回归通过。

--- a/docs/engineering/lessons/issue-1175-rollup-patch-coverage.md
+++ b/docs/engineering/lessons/issue-1175-rollup-patch-coverage.md
@@ -1,0 +1,34 @@
+---
+status: verified
+issue: https://github.com/sonofmagic/weapp-tailwindcss/pull/1175
+baseline: b6026b5906cd564974d759581bb0ce9b7691c262
+regressions:
+  - scripts/ci/demo-matrix/rollup-invalidation.test.mjs
+  - scripts/ci/demo-matrix/rollup-watch.test.mjs
+---
+
+# Rollup 补丁需要覆盖实际解析到的版本
+
+## 症状
+
+PR #1175 的 Ubuntu uview demo 在 replace 阶段通过后，add 阶段不再触发编译。重复运行仍失败，其他 uni-app demo 通过。
+
+## 根因与纠正
+
+`uni-app-vite-tailwindcss-v4` 的 Vite 5 解析到已打补丁的 Rollup 4.63.0，`issue-uview-plus-cssentries` 的 Vite 7 解析到没有补丁的 4.63.1。升级依赖后，按精确版本注册的补丁不会自动继承。
+
+扩展真实依赖链回归后，4.63.1 的文件状态去重及 CJS/ESM 构建期间失效测试均失败，4.63.0 通过。按 4.63.1 发布文件重新生成同等补丁，同时注册两个版本并同步锁文件。测试通过各 demo 的 Vite 解析 Rollup，避免只测试固定旧版本。
+
+## 验证
+
+- `pnpm exec vitest run -c scripts/ci/demo-matrix/vitest.config.mts scripts/ci/demo-matrix/rollup-invalidation.test.mjs scripts/ci/demo-matrix/rollup-watch.test.mjs --update=none`：修复前 4.63.1 三项失效回归失败；修复后两个版本的 14 项回归通过。
+- `pnpm --filter weapp-tailwindcss... build`：通过，包含声明构建。
+- `pnpm exec node scripts/ci/demo-matrix/run.mjs issue-uview-plus-cssentries:mp-weixin issue-uview-plus-cssentries:mp-alipay`：本地两端生产构建、initial、replace、add、restore 均通过；生产产物与现有 static 基线一致，未改写基线。
+
+## 适用边界
+
+补丁限定为 Rollup 4.63.0 和 4.63.1，后续版本需重新验证。这里的本地验证为 macOS；Linux、Windows 的最终证据以 PR 当前提交的 CI 为准，不将 CLI 产物验收表述为设备验收。
+
+## 规则评估
+
+不新增 AGENTS 规则。用实际依赖链的可执行测试约束补丁覆盖，避免维护重复的版本清单。

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
@@ -12,6 +12,7 @@ import { normalizeConfigDirective } from '@/bundlers/shared/generator-css/config
 import { normalizeTailwindConfigDirectives, resolveCssEntrySource } from '@/bundlers/shared/generator-css/directives'
 import { normalizeEmptyTailwindCustomVariants } from '@/bundlers/shared/generator-css/user-css'
 import { resolveTailwindcssOptions } from '@/tailwindcss/runtime-options'
+import { parseSourceFileParam } from '@/tailwindcss/source-scan'
 import { filterTailwindV4CssSourceRoots } from '@/tailwindcss/v4/css-sources'
 import { omitUndefined } from '@/utils/object'
 import { parseCssImportSpecifier, quoteCssImportSpecifier } from './css-import'
@@ -159,6 +160,26 @@ function normalizeTailwindV4CssPackageImports(css: string, packageName: string |
   return changed ? root.toString() : css
 }
 
+function normalizeTailwindV4CssSourcePaths(css: string, base: string) {
+  let root: postcss.Root
+  try {
+    root = postcss.parse(css)
+  }
+  catch {
+    return css
+  }
+  let changed = false
+  root.walkAtRules('source', (rule) => {
+    const parsed = parseSourceFileParam(rule.params)
+    if (!parsed || path.isAbsolute(parsed.sourcePath)) {
+      return
+    }
+    rule.params = `${parsed.negated ? 'not ' : ''}${JSON.stringify(path.resolve(base, parsed.sourcePath))}`
+    changed = true
+  })
+  return changed ? root.toString() : css
+}
+
 function normalizeTailwindV4CssSources(
   cssSources: TailwindV4SourceOptions['cssSources'],
   packageName: string | undefined,
@@ -223,15 +244,15 @@ function normalizeTailwindV4CssEntrySources(
 
   const remainingCssEntries: string[] = []
   const cssSources: NonNullable<TailwindV4SourceOptions['cssSources']> = []
-  for (const cssEntry of cssEntries) {
-    const normalizedCssEntry = cssEntry.replace(/[?#].*$/, '')
-    const file = path.resolve(normalizedCssEntry)
-    if (!existsSync(file)) {
-      remainingCssEntries.push(normalizedCssEntry)
-      continue
+  const visited = new Set<string>()
+  const collectCssSource = (file: string) => {
+    const normalizedFile = path.resolve(file)
+    if (visited.has(normalizedFile) || !existsSync(normalizedFile)) {
+      return
     }
-    const base = path.dirname(file)
-    const rawCss = readFileSync(file, 'utf8')
+    visited.add(normalizedFile)
+    const base = path.dirname(normalizedFile)
+    const rawCss = readFileSync(normalizedFile, 'utf8')
     const entrySource = resolveCssEntrySource(rawCss, base, {
       removeConfig: false,
     })
@@ -241,15 +262,49 @@ function normalizeTailwindV4CssEntrySources(
         ? path.resolve(base, entrySource.configRequest)
         : entrySource?.config
     const css = normalizeTailwindV4CssPackageImports(
-      normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
+      normalizeTailwindV4CssSourcePaths(
+        normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
+        base,
+      ),
       packageName,
     )
     cssSources.push({
-      file,
+      file: normalizedFile,
       base,
       css,
-      dependencies: [file],
+      dependencies: [normalizedFile],
     })
+
+    let root: postcss.Root
+    try {
+      root = postcss.parse(rawCss)
+    }
+    catch {
+      return
+    }
+    root.walkAtRules('import', (rule) => {
+      const parsed = parseCssImportSpecifier(rule.params)
+      if (!parsed || !parsed.specifier.startsWith('.') || parsed.specifier.includes('\\')) {
+        return
+      }
+      const importedFile = path.resolve(base, parsed.specifier)
+      const candidates = path.extname(importedFile)
+        ? [importedFile]
+        : [importedFile, `${importedFile}.css`, `${importedFile}.pcss`, `${importedFile}.scss`, `${importedFile}.sass`]
+      const resolved = candidates.find(candidate => existsSync(candidate))
+      if (resolved) {
+        collectCssSource(resolved)
+      }
+    })
+  }
+  for (const cssEntry of cssEntries) {
+    const normalizedCssEntry = cssEntry.replace(/[?#].*$/, '')
+    const file = path.resolve(normalizedCssEntry)
+    if (!existsSync(file)) {
+      remainingCssEntries.push(normalizedCssEntry)
+      continue
+    }
+    collectCssSource(file)
   }
 
   return {

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
@@ -172,17 +172,17 @@ function normalizeTailwindV4CssSourceDirectives(css: string, base: string) {
   }
   let changed = false
   root.walkAtRules('source', (rule) => {
-    const match = rule.params.match(/^("([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)')(.*)$/)
+    const match = rule.params.match(/^(not\s+)?("([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)')(.*)$/)
     if (!match) {
       return
     }
-    const specifier = match[2] ?? match[3]
+    const specifier = match[3] ?? match[4]
     if (!specifier?.startsWith('.')) {
       return
     }
     const resolved = path.resolve(base, specifier)
     const quote = match[2] === undefined ? '\'' : '"'
-    rule.params = `${quote}${resolved}${quote}${match[4] ?? ''}`
+    rule.params = `${match[1] ?? ''}${quote}${resolved}${quote}${match[5] ?? ''}`
     changed = true
   })
   return changed ? root.toString() : css
@@ -253,7 +253,7 @@ function normalizeTailwindV4CssEntrySources(
   const remainingCssEntries: string[] = []
   const cssSources: NonNullable<TailwindV4SourceOptions['cssSources']> = []
   const visited = new Set<string>()
-  const collectCssSource = (file: string) => {
+  const collectCssSource = (file: string, nested = false) => {
     const normalizedFile = path.resolve(file)
     if (visited.has(normalizedFile) || !existsSync(normalizedFile)) {
       return
@@ -270,10 +270,12 @@ function normalizeTailwindV4CssEntrySources(
         ? path.resolve(base, entrySource.configRequest)
         : entrySource?.config
     const css = normalizeTailwindV4CssPackageImports(
-      normalizeTailwindV4CssSourceDirectives(
-        normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
-        base,
-      ),
+      nested
+        ? normalizeTailwindV4CssSourceDirectives(
+            normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
+            base,
+          )
+        : normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
       packageName,
     )
     cssSources.push({
@@ -301,7 +303,7 @@ function normalizeTailwindV4CssEntrySources(
         : [importedFile, `${importedFile}.css`, `${importedFile}.pcss`, `${importedFile}.scss`, `${importedFile}.sass`]
       const resolved = candidates.find(candidate => existsSync(candidate))
       if (resolved) {
-        collectCssSource(resolved)
+        collectCssSource(resolved, true)
       }
     })
   }

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
@@ -159,6 +159,35 @@ function normalizeTailwindV4CssPackageImports(css: string, packageName: string |
   return changed ? root.toString() : css
 }
 
+function normalizeTailwindV4CssSourceDirectives(css: string, base: string) {
+  if (!css.includes('@source')) {
+    return css
+  }
+  let root: postcss.Root
+  try {
+    root = postcss.parse(css)
+  }
+  catch {
+    return css
+  }
+  let changed = false
+  root.walkAtRules('source', (rule) => {
+    const match = rule.params.match(/^("([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)')(.*)$/)
+    if (!match) {
+      return
+    }
+    const specifier = match[2] ?? match[3]
+    if (!specifier?.startsWith('.')) {
+      return
+    }
+    const resolved = path.resolve(base, specifier)
+    const quote = match[2] === undefined ? '\'' : '"'
+    rule.params = `${quote}${resolved}${quote}${match[4] ?? ''}`
+    changed = true
+  })
+  return changed ? root.toString() : css
+}
+
 function normalizeTailwindV4CssSources(
   cssSources: TailwindV4SourceOptions['cssSources'],
   packageName: string | undefined,
@@ -241,7 +270,10 @@ function normalizeTailwindV4CssEntrySources(
         ? path.resolve(base, entrySource.configRequest)
         : entrySource?.config
     const css = normalizeTailwindV4CssPackageImports(
-      normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
+      normalizeTailwindV4CssSourceDirectives(
+        normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
+        base,
+      ),
       packageName,
     )
     cssSources.push({

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
@@ -12,7 +12,6 @@ import { normalizeConfigDirective } from '@/bundlers/shared/generator-css/config
 import { normalizeTailwindConfigDirectives, resolveCssEntrySource } from '@/bundlers/shared/generator-css/directives'
 import { normalizeEmptyTailwindCustomVariants } from '@/bundlers/shared/generator-css/user-css'
 import { resolveTailwindcssOptions } from '@/tailwindcss/runtime-options'
-import { parseSourceFileParam } from '@/tailwindcss/source-scan'
 import { filterTailwindV4CssSourceRoots } from '@/tailwindcss/v4/css-sources'
 import { omitUndefined } from '@/utils/object'
 import { parseCssImportSpecifier, quoteCssImportSpecifier } from './css-import'
@@ -160,26 +159,6 @@ function normalizeTailwindV4CssPackageImports(css: string, packageName: string |
   return changed ? root.toString() : css
 }
 
-function normalizeTailwindV4CssSourcePaths(css: string, base: string) {
-  let root: postcss.Root
-  try {
-    root = postcss.parse(css)
-  }
-  catch {
-    return css
-  }
-  let changed = false
-  root.walkAtRules('source', (rule) => {
-    const parsed = parseSourceFileParam(rule.params)
-    if (!parsed || path.isAbsolute(parsed.sourcePath)) {
-      return
-    }
-    rule.params = `${parsed.negated ? 'not ' : ''}${JSON.stringify(path.resolve(base, parsed.sourcePath))}`
-    changed = true
-  })
-  return changed ? root.toString() : css
-}
-
 function normalizeTailwindV4CssSources(
   cssSources: TailwindV4SourceOptions['cssSources'],
   packageName: string | undefined,
@@ -262,10 +241,7 @@ function normalizeTailwindV4CssEntrySources(
         ? path.resolve(base, entrySource.configRequest)
         : entrySource?.config
     const css = normalizeTailwindV4CssPackageImports(
-      normalizeTailwindV4CssSourcePaths(
-        normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
-        base,
-      ),
+      normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
       packageName,
     )
     cssSources.push({

--- a/packages/weapp-tailwindcss/test/ci/pnpm-command.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/pnpm-command.test.ts
@@ -24,4 +24,16 @@ describe('pnpm command', () => {
       shell: true,
     })
   })
+
+  it('falls back to the pnpm executable when npm_execpath is native', () => {
+    expect(createPnpmCommand(['exec', 'vite'], {
+      platform: 'linux',
+      execPath: '/usr/bin/node',
+      npmExecPath: '/opt/pnpm/pnpm',
+    })).toEqual({
+      command: 'pnpm',
+      args: ['exec', 'vite'],
+      shell: false,
+    })
+  })
 })

--- a/packages/weapp-tailwindcss/test/ci/workflows.test.ts
+++ b/packages/weapp-tailwindcss/test/ci/workflows.test.ts
@@ -474,7 +474,7 @@ describe('ci workflows', () => {
       catalogs?: Record<string, Record<string, string>>
       overrides?: Record<string, string>
     }
-    const lockfile = YAML.parse(readText('pnpm-lock.yaml')) as {
+    const lockfile = YAML.parseAllDocuments(readText('pnpm-lock.yaml'))[1]?.toJS() as {
       catalogs?: Record<string, Record<string, { specifier?: string, version?: string }>>
       importers?: Record<string, {
         dependencies?: Record<string, { specifier?: string, version?: string }>
@@ -804,7 +804,7 @@ describe('ci workflows', () => {
     expect(packageJson.scripts['pr:rc']).toBe('repo release pre enter rc')
     expect(packageJson.scripts['pr:next']).toBe('repo release pre enter next')
     expect(packageJson.scripts['pr:exit']).toBe('repo release pre exit')
-    expect(packageJson.devDependencies.repoctl).toBe('^5.4.7')
+    expect(packageJson.devDependencies.repoctl).toBe('^5.4.9')
     expect(packageJson.devDependencies['@changesets/cli']).toBeUndefined()
     expect(packageJson.devDependencies['@changesets/changelog-github']).toBeUndefined()
     expect(packageJson.devDependencies['@icebreakers/changelog-github']).toBeUndefined()

--- a/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
@@ -1,9 +1,12 @@
 import { postcss } from '@weapp-tailwindcss/postcss'
 import path from 'node:path'
 import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { createCompiler } from '@/core/compiler'
 import { resolveTailwindV4Source } from '@/generator'
+
+const require = createRequire(import.meta.url)
 
 const MINIMAL_THEME_CSS = `
 @theme default {
@@ -27,7 +30,7 @@ describe('createCompiler', () => {
     const tailwindCss = path.join(root, 'styles/tailwind.css')
     await mkdir(path.join(root, 'styles/pages'), { recursive: true })
     await mkdir(path.join(root, 'node_modules'), { recursive: true })
-    await symlink(path.resolve(process.cwd(), '../../node_modules/tailwindcss'), path.join(root, 'node_modules/tailwindcss'), 'dir')
+    await symlink(path.dirname(require.resolve('tailwindcss/package.json')), path.join(root, 'node_modules/tailwindcss'), 'dir')
     await writeFile(appCss, '@import "./styles/tailwind.css";')
     await writeFile(tailwindCss, [
       '@import "tailwindcss" source(none);',

--- a/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
@@ -1,4 +1,7 @@
 import { postcss } from '@weapp-tailwindcss/postcss'
+import path from 'node:path'
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { createCompiler } from '@/core/compiler'
 import { resolveTailwindV4Source } from '@/generator'
 
@@ -18,6 +21,39 @@ async function createSource() {
 }
 
 describe('createCompiler', () => {
+  it('scans @source directives from nested css entries', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-core-nested-source-'))
+    const appCss = path.join(root, 'app.css')
+    const tailwindCss = path.join(root, 'styles/tailwind.css')
+    await mkdir(path.join(root, 'styles/pages'), { recursive: true })
+    await mkdir(path.join(root, 'node_modules'), { recursive: true })
+    await symlink(path.resolve(process.cwd(), '../../node_modules/tailwindcss'), path.join(root, 'node_modules/tailwindcss'), 'dir')
+    await writeFile(appCss, '@import "./styles/tailwind.css";')
+    await writeFile(tailwindCss, [
+      '@import "tailwindcss" source(none);',
+      '@source "./pages/**/*.{wxml,ts}";',
+    ].join('\n'))
+    await writeFile(path.join(root, 'styles/pages/index.wxml'), '<view class="w-[37px] text-white" />')
+    await writeFile(path.join(root, 'outside.wxml'), '<view class="w-[99px]" />')
+
+    const compiler = createCompiler()
+    const generated = await compiler.generate({
+      id: 'nested-source',
+      sourceOptions: {
+        projectRoot: root,
+        cssEntries: [appCss],
+        packageName: 'tailwindcss',
+      },
+      target: 'web',
+      scanSources: true,
+    })
+    expect(generated.classSet.has('w-[37px]')).toBe(true)
+    expect(generated.classSet.has('text-white')).toBe(true)
+    expect(generated.classSet.has('w-[99px]')).toBe(false)
+    expect(generated.css).toContain('.w-\\[37px\\]')
+    await compiler.dispose()
+  })
+
   it('finalizes mini-program CSS by default and exposes explicit finalizers', async () => {
     const compiler = createCompiler()
     const weapp = compiler.createSnapshot({ classSet: [], id: 'root:weapp', target: 'weapp' })

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4-source-options.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4-source-options.test.ts
@@ -39,6 +39,31 @@ describe('tailwind v4 source options', () => {
     expect(packageJsonOptions?.cssSources?.[0]?.css).toContain('#tw')
   })
 
+  it('keeps nested css imports as independent source roots', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-nested-source-'))
+    const appEntry = path.join(root, 'app.css')
+    const nestedEntry = path.join(root, 'styles/tailwind.css')
+    await mkdir(path.dirname(nestedEntry), { recursive: true })
+    await writeFile(appEntry, '@import "./styles/tailwind.css";')
+    await writeFile(nestedEntry, [
+      '@import "tailwindcss" source(none);',
+      '@source "./pages/**/*.{wxml,ts}";',
+    ].join('\n'))
+
+    const options = normalizeTailwindV4SourceOptions({
+      projectRoot: root,
+      cssEntries: [appEntry],
+    })
+
+    expect(options?.cssSources).toHaveLength(2)
+    expect(options?.cssSources?.map(source => source.file)).toEqual([appEntry, nestedEntry])
+    expect(options?.cssSources?.[1]).toMatchObject({
+      base: path.dirname(nestedEntry),
+      dependencies: [nestedEntry],
+    })
+    expect(options?.cssSources?.[1]?.css).toContain(`@source ${JSON.stringify(path.join(path.dirname(nestedEntry), 'pages/**/*.{wxml,ts}'))}`)
+  })
+
   it('removes Vite request queries before treating css entries as file paths', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-query-entry-'))
     const cssEntry = path.join(root, 'src/app.css')

--- a/patches/rollup@4.63.1.patch
+++ b/patches/rollup@4.63.1.patch
@@ -1,0 +1,256 @@
+diff --git a/dist/es/shared/watch.js b/dist/es/shared/watch.js
+--- a/dist/es/shared/watch.js
++++ b/dist/es/shared/watch.js
+@@ -9251,8 +9251,15 @@
+ 	  }
+ 
+ 	  if (event === EV_CHANGE) {
+-	    const isThrottled = !this._throttle(EV_CHANGE, path, 50);
+-	    if (isThrottled) return this;
++	    // 只合并同一文件状态的重复通知，不丢弃窗口内的新版本。
++	    const previous = this._throttled.get(EV_CHANGE)?.get(path);
++	    const stats = val1;
++	    if (previous?.stats && stats && ['dev', 'ino', 'size', 'mtimeMs', 'ctimeMs'].some(key => previous.stats[key] !== stats[key])) {
++	      previous.clear();
++	    }
++	    const throttle = this._throttle(EV_CHANGE, path, 50);
++	    if (!throttle) return this;
++	    throttle.stats = stats;
+ 	  }
+ 
+ 	  if (opts.alwaysStat && val1 === undefined &&
+@@ -9617,50 +9624,43 @@
+ 
+ class FileWatcher {
+     constructor(task, chokidarOptions) {
+-        this.transformWatchers = new Map();
++        this.transformDependencies = new Set();
+         this.chokidarOptions = chokidarOptions;
+         this.task = task;
+-        this.watcher = this.createWatcher(null);
++        this.watcher = this.createWatcher();
+     }
+     close() {
+         this.watcher.close();
+-        for (const watcher of this.transformWatchers.values()) {
+-            watcher.close();
+-        }
+     }
+     unwatch(id) {
+         this.watcher.unwatch(id);
+-        const transformWatcher = this.transformWatchers.get(id);
+-        if (transformWatcher) {
+-            this.transformWatchers.delete(id);
+-            transformWatcher.close();
+-        }
++        this.transformDependencies.delete(id);
+     }
+     watch(id, isTransformDependency) {
+         if (isTransformDependency) {
+-            const watcher = this.transformWatchers.get(id) ?? this.createWatcher(id);
+-            watcher.add(id);
+-            this.transformWatchers.set(id, watcher);
++            this.transformDependencies.add(id);
+         }
+-        else {
+-            this.watcher.add(id);
+-        }
++        this.watcher.add(id);
+     }
+-    createWatcher(transformWatcherId) {
++    createWatcher() {
+         const task = this.task;
+         const isLinux = platform() === 'linux';
+         const isFreeBSD = platform() === 'freebsd';
+-        const isTransformDependency = transformWatcherId !== null;
+         const handleChange = (id, event) => {
+-            const changedId = transformWatcherId || id;
+             if (isLinux || isFreeBSD) {
+                 // unwatching and watching fixes an issue with chokidar where on certain systems,
+                 // a file that was unlinked and immediately recreated would create a change event
+                 // but then no longer any further events
+-                watcher.unwatch(changedId);
+-                watcher.add(changedId);
++                watcher.unwatch(id);
++                watcher.add(id);
+             }
+-            task.invalidate(changedId, { event, isTransformDependency });
++            task.invalidate(id, { event, isTransformDependency: this.transformDependencies.has(id) });
++            for (const dependency of this.transformDependencies) {
++                const relative = path.relative(dependency, id);
++                if (relative && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) {
++                    task.invalidate(dependency, { event, isTransformDependency: true });
++                }
++            }
+         };
+         const watcher = chokidar
+             .watch([], this.chokidarOptions)
+@@ -9785,6 +9785,7 @@
+         this.watchFiles = [];
+         this.closed = false;
+         this.invalidated = true;
++        this.invalidatedTransformDependencies = new Set();
+         this.watched = new Set();
+         this.watcher = watcher;
+         this.options = options;
+@@ -9810,6 +9811,7 @@
+     invalidate(id, details) {
+         this.invalidated = true;
+         if (details.isTransformDependency) {
++            this.invalidatedTransformDependencies.add(id);
+             for (const module of this.cache.modules) {
+                 if (!module.transformDependencies.includes(id))
+                     continue;
+@@ -9824,6 +9826,8 @@
+         if (!this.invalidated)
+             return;
+         this.invalidated = false;
++        // 新一轮消费现有缓存；本轮构建期间到达的失效必须保留给下一轮。
++        this.invalidatedTransformDependencies.clear();
+         const options = {
+             ...this.options,
+             cache: this.cache
+@@ -9879,6 +9883,12 @@
+         this.watched = new Set();
+         this.watchFiles = result.watchFiles;
+         this.cache = result.cache;
++        // 新缓存不能覆盖构建期间对旧缓存标记的失效。
++        for (const module of this.cache.modules) {
++            if (module.transformDependencies.some(id => this.invalidatedTransformDependencies.has(id))) {
++                module.originalCode = null;
++            }
++        }
+         for (const id of this.watchFiles) {
+             this.watchFile(id);
+         }
+diff --git a/dist/shared/watch.js b/dist/shared/watch.js
+--- a/dist/shared/watch.js
++++ b/dist/shared/watch.js
+@@ -30,50 +30,43 @@
+ 
+ class FileWatcher {
+     constructor(task, chokidarOptions) {
+-        this.transformWatchers = new Map();
++        this.transformDependencies = new Set();
+         this.chokidarOptions = chokidarOptions;
+         this.task = task;
+-        this.watcher = this.createWatcher(null);
++        this.watcher = this.createWatcher();
+     }
+     close() {
+         this.watcher.close();
+-        for (const watcher of this.transformWatchers.values()) {
+-            watcher.close();
+-        }
+     }
+     unwatch(id) {
+         this.watcher.unwatch(id);
+-        const transformWatcher = this.transformWatchers.get(id);
+-        if (transformWatcher) {
+-            this.transformWatchers.delete(id);
+-            transformWatcher.close();
+-        }
++        this.transformDependencies.delete(id);
+     }
+     watch(id, isTransformDependency) {
+         if (isTransformDependency) {
+-            const watcher = this.transformWatchers.get(id) ?? this.createWatcher(id);
+-            watcher.add(id);
+-            this.transformWatchers.set(id, watcher);
+-        }
+-        else {
+-            this.watcher.add(id);
+-        }
+-    }
+-    createWatcher(transformWatcherId) {
++            this.transformDependencies.add(id);
++        }
++        this.watcher.add(id);
++    }
++    createWatcher() {
+         const task = this.task;
+         const isLinux = node_os.platform() === 'linux';
+         const isFreeBSD = node_os.platform() === 'freebsd';
+-        const isTransformDependency = transformWatcherId !== null;
+         const handleChange = (id, event) => {
+-            const changedId = transformWatcherId || id;
+             if (isLinux || isFreeBSD) {
+                 // unwatching and watching fixes an issue with chokidar where on certain systems,
+                 // a file that was unlinked and immediately recreated would create a change event
+                 // but then no longer any further events
+-                watcher.unwatch(changedId);
+-                watcher.add(changedId);
+-            }
+-            task.invalidate(changedId, { event, isTransformDependency });
++                watcher.unwatch(id);
++                watcher.add(id);
++            }
++            task.invalidate(id, { event, isTransformDependency: this.transformDependencies.has(id) });
++            for (const dependency of this.transformDependencies) {
++                const relative = path.relative(dependency, id);
++                if (relative && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) {
++                    task.invalidate(dependency, { event, isTransformDependency: true });
++                }
++            }
+         };
+         const watcher = index.chokidar
+             .watch([], this.chokidarOptions)
+@@ -198,6 +191,7 @@
+         this.watchFiles = [];
+         this.closed = false;
+         this.invalidated = true;
++        this.invalidatedTransformDependencies = new Set();
+         this.watched = new Set();
+         this.watcher = watcher;
+         this.options = options;
+@@ -223,6 +217,7 @@
+     invalidate(id, details) {
+         this.invalidated = true;
+         if (details.isTransformDependency) {
++            this.invalidatedTransformDependencies.add(id);
+             for (const module of this.cache.modules) {
+                 if (!module.transformDependencies.includes(id))
+                     continue;
+@@ -237,6 +232,8 @@
+         if (!this.invalidated)
+             return;
+         this.invalidated = false;
++        // 新一轮消费现有缓存；本轮构建期间到达的失效必须保留给下一轮。
++        this.invalidatedTransformDependencies.clear();
+         const options = {
+             ...this.options,
+             cache: this.cache
+@@ -292,6 +289,12 @@
+         this.watched = new Set();
+         this.watchFiles = result.watchFiles;
+         this.cache = result.cache;
++        // 新缓存不能覆盖构建期间对旧缓存标记的失效。
++        for (const module of this.cache.modules) {
++            if (module.transformDependencies.some(id => this.invalidatedTransformDependencies.has(id))) {
++                module.originalCode = null;
++            }
++        }
+         for (const id of this.watchFiles) {
+             this.watchFile(id);
+         }
+diff --git a/dist/shared/index.js b/dist/shared/index.js
+--- a/dist/shared/index.js
++++ b/dist/shared/index.js
+@@ -9247,8 +9247,15 @@
+ 	  }
+ 
+ 	  if (event === EV_CHANGE) {
+-	    const isThrottled = !this._throttle(EV_CHANGE, path, 50);
+-	    if (isThrottled) return this;
++	    // 只合并同一文件状态的重复通知，不丢弃窗口内的新版本。
++	    const previous = this._throttled.get(EV_CHANGE)?.get(path);
++	    const stats = val1;
++	    if (previous?.stats && stats && ['dev', 'ino', 'size', 'mtimeMs', 'ctimeMs'].some(key => previous.stats[key] !== stats[key])) {
++	      previous.clear();
++	    }
++	    const throttle = this._throttle(EV_CHANGE, path, 50);
++	    if (!throttle) return this;
++	    throttle.stats = stats;
+ 	  }
+ 
+ 	  if (opts.alwaysStat && val1 === undefined &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2261,7 +2261,7 @@ importers:
         version: 19.2.18
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(ccdc1689092fcdca83ffff6634d15c82))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       cross-env:
         specifier: catalog:crossEnv
         version: 10.1.0
@@ -3857,7 +3857,7 @@ importers:
     dependencies:
       nuxt:
         specifier: 4.5.2
-        version: 4.5.2(eea432f0be145ee388fe177e665862c9)
+        version: 4.5.2(38695c2cde4556c72b82606b67e79188)
       vue:
         specifier: catalog:vue3
         version: 3.5.42(typescript@6.0.3)
@@ -5209,7 +5209,7 @@ importers:
         version: 4.7.0(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(35e9ddb42b304e587abd6a4670c1785d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(a8d039a7e1017f75aa1d22926a3c1c2f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       postcss:
         specifier: catalog:postcss85
         version: 8.5.28
@@ -5294,7 +5294,7 @@ importers:
         version: 1.18.8
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(ccdc1689092fcdca83ffff6634d15c82))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       postcss:
         specifier: catalog:postcss85
         version: 8.5.28
@@ -5379,7 +5379,7 @@ importers:
         version: link:../../packages/weapp-tailwindcss
       weapp-vite:
         specifier: catalog:weappVite
-        version: 7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0)
+        version: 7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0)
 
   tools/weapp-tailwindcss-scripts:
     dependencies:
@@ -44430,7 +44430,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
 
-  '@mapbox/node-pre-gyp@2.0.3(encoding@0.1.13)(supports-color@10.2.2)':
+  '@mapbox/node-pre-gyp@2.0.3(supports-color@10.2.2)':
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
@@ -44581,15 +44581,15 @@ snapshots:
       '@module-federation/runtime': 0.22.0
       '@module-federation/sdk': 0.22.0
 
-  '@mpxjs/api-proxy@2.11.1(22c834dfb2e03f4fa653631ac408a8a2)':
+  '@mpxjs/api-proxy@2.11.1(@mpxjs/core@2.11.1)(@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(debug@4.4.3(supports-color@10.2.2))(react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(supports-color@10.2.2)':
     dependencies:
       '@mpxjs/utils': 2.11.0(@mpxjs/core@2.11.1)
       axios: 1.17.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      '@react-native-community/netinfo': 11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      react-native-device-info: 14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      '@react-native-community/netinfo': 11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      react-native-device-info: 14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
     transitivePeerDependencies:
       - '@mpxjs/core'
       - debug
@@ -44615,6 +44615,28 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
+  '@mpxjs/core@2.11.1(04010f44a3c2e4cf6d2ae724da488df6)':
+    dependencies:
+      '@mpxjs/api-proxy': 2.11.1(@mpxjs/core@2.11.1)(@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(debug@4.4.3(supports-color@10.2.2))(react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(supports-color@10.2.2)
+      '@mpxjs/perf': 2.11.1
+      '@mpxjs/store': 2.11.0(@mpxjs/core@2.11.1)
+      '@mpxjs/utils': 2.11.0(@mpxjs/core@2.11.1)
+      lodash: 4.18.1
+      miniprogram-api-typings: 3.12.3
+    optionalDependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/native-stack': 6.11.0(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react: 19.2.8
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native-gesture-handler: 2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-webview: 13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      vue: 2.7.16
+      vue-demi: 0.14.10(vue@2.7.16)
+      vue-i18n: 8.28.2(vue@2.7.16)
+      vue-i18n-bridge: 9.14.1(vue@2.7.16)
+
   '@mpxjs/core@2.11.1(0d78c100d46990f06d04da85b4577888)':
     dependencies:
       '@mpxjs/api-proxy': 2.11.1(b1a47d05f4be82069e05926a20b17bdf)
@@ -44632,28 +44654,6 @@ snapshots:
       react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react-native-webview: 13.6.4(react-native@0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      vue: 2.7.16
-      vue-demi: 0.14.10(vue@2.7.16)
-      vue-i18n: 8.28.2(vue@2.7.16)
-      vue-i18n-bridge: 9.14.1(vue@2.7.16)
-
-  '@mpxjs/core@2.11.1(4d802bec98f8ef7b3f03cc7276b0d512)':
-    dependencies:
-      '@mpxjs/api-proxy': 2.11.1(22c834dfb2e03f4fa653631ac408a8a2)
-      '@mpxjs/perf': 2.11.1
-      '@mpxjs/store': 2.11.0(@mpxjs/core@2.11.1)
-      '@mpxjs/utils': 2.11.0(@mpxjs/core@2.11.1)
-      lodash: 4.18.1
-      miniprogram-api-typings: 3.12.3
-    optionalDependencies:
-      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      '@react-navigation/native-stack': 6.11.0(d9bd4077107d9abc80758ed7c8a94b14)
-      react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-      react-native-gesture-handler: 2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-webview: 13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       vue: 2.7.16
       vue-demi: 0.14.10(vue@2.7.16)
       vue-i18n: 8.28.2(vue@2.7.16)
@@ -45635,7 +45635,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.2(7381fefd0087dd48fe01f9b88282477b)':
+  '@nuxt/nitro-server@4.5.2(20324ea341303b0a68d31ebea693cd22)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
@@ -45652,9 +45652,9 @@ snapshots:
       impound: 1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(encoding@0.1.13)(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       nostics: 1.2.0
-      nuxt: 4.5.2(eea432f0be145ee388fe177e665862c9)
+      nuxt: 4.5.2(38695c2cde4556c72b82606b67e79188)
       nypm: 0.6.9
       ohash: 2.0.12
       pathe: 2.0.3
@@ -45741,7 +45741,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(eea432f0be145ee388fe177e665862c9))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1))(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(38695c2cde4556c72b82606b67e79188))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1))(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
@@ -45759,7 +45759,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(eea432f0be145ee388fe177e665862c9)
+      nuxt: 4.5.2(38695c2cde4556c72b82606b67e79188)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.3
@@ -47445,10 +47445,10 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  '@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
+  '@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   '@react-native-camera-roll/camera-roll@7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))':
     dependencies:
@@ -47647,9 +47647,9 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  '@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
+  '@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
     dependencies:
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   '@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)':
     dependencies:
@@ -48107,23 +48107,6 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@react-native/community-cli-plugin@0.81.6(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@react-native/dev-middleware': 0.81.6(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-      invariant: 2.2.4
-      metro: 0.83.7(supports-color@10.2.2)
-      metro-config: 0.83.7(supports-color@10.2.2)
-      metro-core: 0.83.7
-      semver: 7.8.5
-    optionalDependencies:
-      '@react-native-community/cli': 12.3.7(encoding@0.1.13)(supports-color@10.2.2)
-      '@react-native/metro-config': 0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@react-native/debugger-frontend@0.73.3': {}
 
   '@react-native/debugger-frontend@0.81.5': {}
@@ -48312,12 +48295,12 @@ snapshots:
       '@types/react': 19.2.18
     optional: true
 
-  '@react-native/virtualized-lists@0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
+  '@react-native/virtualized-lists@0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optionalDependencies:
       '@types/react': 19.2.18
 
@@ -48387,12 +48370,12 @@ snapshots:
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
     optional: true
 
-  '@react-navigation/elements@1.3.31(c51dd0a9611efc80988e6af404f461d2)':
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
-      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
 
   ? '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)'
   : dependencies:
@@ -48414,14 +48397,14 @@ snapshots:
       warn-once: 0.1.1
     optional: true
 
-  '@react-navigation/native-stack@6.11.0(d9bd4077107d9abc80758ed7c8a94b14)':
+  '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
-      '@react-navigation/elements': 1.3.31(c51dd0a9611efc80988e6af404f461d2)
-      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       warn-once: 0.1.1
 
   '@react-navigation/native-stack@6.11.0(e47cc7b09d58094ab558bc33d5cb4482)':
@@ -48464,14 +48447,14 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  '@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
+  '@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
       '@react-navigation/core': 6.4.17(react@19.2.8)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.18
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   '@react-navigation/routers@6.1.9':
     dependencies:
@@ -50502,10 +50485,10 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components-rn@4.2.1(538c449ad6437b95e6db13f31eec1c5b)':
+  '@tarojs/components-rn@4.2.1(7794d815aacbe440aaf39102e7ac9e8a)':
     dependencies:
       '@ant-design/react-native': 5.0.0(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
       expo-av: 13.10.6(expo@54.0.37)
@@ -50536,10 +50519,10 @@ snapshots:
       - webpack-dev-server
     optional: true
 
-  '@tarojs/components-rn@4.2.1(7794d815aacbe440aaf39102e7ac9e8a)':
+  '@tarojs/components-rn@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(expo-av@13.10.6(expo@54.0.37))(expo-camera@14.1.3(expo@54.0.37))(expo@54.0.37)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(rollup@4.63.1)(supports-color@10.2.2)(typescript@6.0.3)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@ant-design/react-native': 5.0.0(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
       expo-av: 13.10.6(expo@54.0.37)
@@ -51417,9 +51400,47 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@tarojs/runtime-rn@4.2.1(256c9aa8529969b1fae0cdbe6f63c477)':
+  '@tarojs/runtime-rn@4.2.1(1de65e4262541daadaebb2dac610f43e)':
     dependencies:
-      '@tarojs/components-rn': 4.2.1(538c449ad6437b95e6db13f31eec1c5b)
+      '@tarojs/components-rn': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(expo-av@13.10.6(expo@54.0.37))(expo-camera@14.1.3(expo@54.0.37))(expo@54.0.37)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(rollup@4.63.1)(supports-color@10.2.2)(typescript@6.0.3)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@tarojs/shared': 4.2.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-root-siblings: 5.0.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/helper'
+      - '@types/react'
+      - expo
+      - expo-av
+      - expo-camera
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+    optional: true
+
+  '@tarojs/runtime-rn@4.2.1(23dbf78a7bb74f66973c83225463c127)':
+    dependencies:
+      '@tarojs/components-rn': 4.2.1(7794d815aacbe440aaf39102e7ac9e8a)
       '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/shared': 4.2.1
       react: 18.3.1
@@ -51804,7 +51825,7 @@ snapshots:
       - webpack-dev-server
     optional: true
 
-  '@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa)':
+  '@tarojs/taro-rn@4.2.1(a8d039a7e1017f75aa1d22926a3c1c2f)':
     dependencies:
       '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
@@ -51812,7 +51833,63 @@ snapshots:
       '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@tarojs/runtime-rn': 4.2.1(256c9aa8529969b1fae0cdbe6f63c477)
+      '@tarojs/runtime-rn': 4.2.1(23dbf78a7bb74f66973c83225463c127)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 5.0.0
+      expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
+      expo-av: 13.10.6(expo@54.0.37)
+      expo-barcode-scanner: 12.9.3(expo@54.0.37)
+      expo-brightness: 11.8.0(expo@54.0.37)
+      expo-camera: 14.1.3(expo@54.0.37)
+      expo-file-system: 16.0.9(expo@54.0.37)
+      expo-image-picker: 14.7.1(expo@54.0.37)
+      expo-keep-awake: 12.8.2(expo@54.0.37)
+      expo-location: 16.5.5(expo@54.0.37)
+      expo-sensors: 12.9.1(expo@54.0.37)
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      react-native-root-siblings: 5.0.1
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/components'
+      - '@tarojs/helper'
+      - '@tarojs/shared'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+    optional: true
+
+  '@tarojs/taro-rn@4.2.1(ccdc1689092fcdca83ffff6634d15c82)':
+    dependencies:
+      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@tarojs/runtime-rn': 4.2.1(1de65e4262541daadaebb2dac610f43e)
       '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       base64-js: 1.5.1
       deprecated-react-native-prop-types: 5.0.0
@@ -53401,9 +53478,9 @@ snapshots:
 
   '@vercel/detect-agent@1.2.5': {}
 
-  '@vercel/nft@1.11.0(encoding@0.1.13)(rollup@4.63.1)(supports-color@10.2.2)':
+  '@vercel/nft@1.11.0(rollup@4.63.1)(supports-color@10.2.2)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)(supports-color@10.2.2)
+      '@mapbox/node-pre-gyp': 2.0.3(supports-color@10.2.2)
       '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
       acorn: 8.18.0
       acorn-import-attributes: 1.9.5(acorn@8.18.0)
@@ -56113,7 +56190,7 @@ snapshots:
       - metro-react-native-babel-preset
       - supports-color
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(a8d039a7e1017f75aa1d22926a3c1c2f))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56132,7 +56209,36 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa)
+      '@tarojs/taro-rn': 4.2.1(a8d039a7e1017f75aa1d22926a3c1c2f)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-typescript'
+      - '@react-native/babel-preset'
+      - '@swc/helpers'
+      - metro-react-native-babel-preset
+      - supports-color
+
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(ccdc1689092fcdca83ffff6634d15c82))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
+      '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-transform-imports-api: 1.0.0
+      babel-plugin-transform-solid-jsx: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
+      core-js: 3.50.0
+    optionalDependencies:
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@tarojs/taro-rn': 4.2.1(ccdc1689092fcdca83ffff6634d15c82)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -66835,7 +66941,7 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(encoding@0.1.13)(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  nitropack@2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.63.1)
@@ -66845,7 +66951,7 @@ snapshots:
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.63.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.63.1)
       '@rollup/plugin-terser': 1.0.0(rollup@4.63.1)
-      '@vercel/nft': 1.11.0(encoding@0.1.13)(rollup@4.63.1)(supports-color@10.2.2)
+      '@vercel/nft': 1.11.0(rollup@4.63.1)(supports-color@10.2.2)
       archiver: 7.0.1
       c12: 3.3.4(magicast@0.5.4)
       chokidar: 5.0.0
@@ -67201,16 +67307,16 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nuxt@4.5.2(eea432f0be145ee388fe177e665862c9):
+  nuxt@4.5.2(38695c2cde4556c72b82606b67e79188):
     dependencies:
       '@dxup/nuxt': 0.5.10(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(@parcel/watcher@2.6.0)(cac@6.7.14)(commander@15.0.0)(magicast@0.5.4)(supports-color@10.2.2)
       '@nuxt/devtools': 3.4.2(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(supports-color@10.2.2)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
-      '@nuxt/nitro-server': 4.5.2(7381fefd0087dd48fe01f9b88282477b)
+      '@nuxt/nitro-server': 4.5.2(20324ea341303b0a68d31ebea693cd22)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))
-      '@nuxt/vite-builder': 4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(eea432f0be145ee388fe177e665862c9))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1))(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(38695c2cde4556c72b82606b67e79188))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1))(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)
       '@unhead/vue': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
       '@vue/shared': 3.5.42
       chokidar: 5.0.0
@@ -67689,6 +67795,12 @@ snapshots:
   oxc-walker@1.1.1(@oxc-project/types@0.148.0)(oxc-parser@0.148.0)(rolldown@1.2.7):
     optionalDependencies:
       '@oxc-project/types': 0.148.0
+      oxc-parser: 0.148.0
+      rolldown: 1.2.7
+
+  oxc-walker@1.1.1(@oxc-project/types@0.149.0)(oxc-parser@0.148.0)(rolldown@1.2.7):
+    optionalDependencies:
+      '@oxc-project/types': 0.149.0
       oxc-parser: 0.148.0
       rolldown: 1.2.7
 
@@ -70099,9 +70211,9 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)):
+  react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)):
     dependencies:
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1):
     dependencies:
@@ -70124,7 +70236,7 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-gesture-handler@2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-gesture-handler@2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
@@ -70132,7 +70244,7 @@ snapshots:
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native-image-pan-zoom@2.1.12(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1):
     dependencies:
@@ -70216,10 +70328,10 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1):
     dependencies:
@@ -70236,11 +70348,11 @@ snapshots:
       warn-once: 0.1.1
     optional: true
 
-  react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-freeze: 1.0.4(react@19.2.8)
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
       warn-once: 0.1.1
 
   react-native-svg-transformer@1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
@@ -70331,12 +70443,12 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-webview@13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-webview@13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       escape-string-regexp: 2.0.0
       invariant: 2.2.4
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2):
     dependencies:
@@ -70579,16 +70691,16 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2):
+  react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.6
       '@react-native/codegen': 0.81.6(@babel/core@8.0.1)
-      '@react-native/community-cli-plugin': 0.81.6(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
+      '@react-native/community-cli-plugin': 0.81.6(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
       '@react-native/gradle-plugin': 0.81.6
       '@react-native/js-polyfills': 0.81.6
       '@react-native/normalize-colors': 0.81.6
-      '@react-native/virtualized-lists': 0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-native/virtualized-lists': 0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -75718,6 +75830,44 @@ snapshots:
       - tailwindcss
       - tsx
 
+  weapp-tailwindcss@5.5.1(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(jiti@2.7.0)(rolldown@1.2.7)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.13)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@tailwindcss-mangle/engine': 0.2.0(tailwindcss@4.3.3)
+      '@vue/compiler-dom': 3.5.42
+      '@weapp-core/escape': 8.0.0
+      '@weapp-tailwindcss/logger': 2.0.3
+      '@weapp-tailwindcss/postcss': 3.3.2(jiti@2.7.0)(tailwindcss@4.3.3)(tsx@4.23.13)(yaml@2.9.0)
+      '@weapp-tailwindcss/reset': 0.1.4(tailwindcss@4.3.3)
+      '@weapp-tailwindcss/shared': 2.0.3
+      comment-json: 5.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      htmlparser2: 12.0.0
+      lightningcss: 1.33.0
+      local-pkg: 1.2.1
+      lru-cache: 11.5.2
+      magic-string: 1.2.3
+      micromatch: 4.0.8
+      oxc-parser: 0.148.0
+      oxc-walker: 1.1.1(@oxc-project/types@0.149.0)(oxc-parser@0.148.0)(rolldown@1.2.7)
+      semver: 7.8.5
+      tailwindcss-config: 2.0.4
+      weapp-style-injector: 1.0.4
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mpxjs/webpack-plugin': 2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@oxc-project/types'
+      - jiti
+      - rolldown
+      - supports-color
+      - tailwindcss
+      - tsx
+
   weapp-vite@7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0):
     dependencies:
       '@babel/preset-env': 8.0.2(@babel/core@8.0.1)
@@ -75767,6 +75917,87 @@ snapshots:
       vue-tsc: 3.3.11(typescript@6.0.3)
       weapp-ide-cli: 6.1.2(@types/node@26.5.0)
       weapp-tailwindcss: 5.5.1(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(jiti@2.7.0)(rolldown@1.2.7)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.13)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)
+    optionalDependencies:
+      '@swc/core': 1.16.1(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@mpxjs/webpack-plugin'
+      - '@oxc-project/types'
+      - '@swc/helpers'
+      - '@types/node'
+      - '@typescript/native-preview'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - eslint
+      - hono
+      - jiti
+      - less
+      - miniprogram-api-typings
+      - oxc-resolver
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - tailwindcss
+      - terser
+      - tsx
+      - utf-8-validate
+      - vitest
+      - yaml
+
+  weapp-vite@7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0):
+    dependencies:
+      '@babel/preset-env': 8.0.2(@babel/core@8.0.1)
+      '@babel/preset-typescript': 8.0.1(@babel/core@8.0.1)
+      '@jridgewell/remapping': 2.3.5
+      '@vercel/detect-agent': 1.2.5
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
+      '@vue/language-core': 3.3.11
+      '@weapp-core/constants': 0.2.1
+      '@weapp-core/init': 6.0.17
+      '@weapp-core/logger': 3.1.1
+      '@weapp-core/schematics': 6.2.2
+      '@weapp-core/shared': 3.2.1
+      '@weapp-vite/ast': 7.0.4(rolldown@1.2.7)
+      '@weapp-vite/eslint': 0.2.3(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@weapp-vite/i18n': 0.2.1(miniprogram-api-typings@5.2.3)
+      '@weapp-vite/mcp': 1.5.1(@types/node@26.5.0)(hono@4.13.0)
+      '@weapp-vite/miniprogram-automator': 1.2.16(@types/node@26.5.0)
+      '@weapp-vite/volar': 2.1.6
+      '@weapp-vite/web': 1.4.21(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)
+      '@wevu/api': 0.3.0(vitest@5.0.0)
+      '@wevu/web-apis': 1.2.40(vitest@5.0.0)
+      cac: 7.0.0
+      chokidar: 5.0.0
+      comment-json: 5.0.0
+      fdir: 6.5.0(picomatch@4.0.7)
+      htmlparser2: 12.0.0
+      local-pkg: 1.2.1
+      lru-cache: 11.5.2
+      magic-string: 1.2.3
+      merge: 2.1.1
+      obug: 2.1.4
+      p-queue: 9.3.3
+      package-manager-detector: 1.8.0
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      postcss: 8.5.28
+      rolldown: 1.2.7
+      rolldown-plugin-dts: 0.28.5(@volar/typescript@2.4.28(typescript@6.0.3))(oxc-resolver@11.21.2)(rolldown@1.2.7)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))
+      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1)
+      semver: 7.8.5
+      typescript: 6.0.3
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      vite-plugin-performance: 2.0.1
+      vite-tsconfig-paths: 6.1.1(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      vue: 3.5.42(typescript@6.0.3)
+      vue-tsc: 3.3.11(typescript@6.0.3)
+      weapp-ide-cli: 6.1.2(@types/node@26.5.0)
+      weapp-tailwindcss: 5.5.1(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(jiti@2.7.0)(rolldown@1.2.7)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.13)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)
     optionalDependencies:
       '@swc/core': 1.16.1(@swc/helpers@0.5.23)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -727,6 +727,7 @@ pnpmfileChecksum: sha256-VIhHxkE3DlYGW4jpmh5YBZoirXpyRMuq7rJOkofCfW8=
 
 patchedDependencies:
   rollup@4.63.0: 4f732dcaad5986ffbe82caa0236c5ece50738873705cb399aa2f0a4dd15ed375
+  rollup@4.63.1: c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0
 
 importers:
 
@@ -1100,7 +1101,7 @@ importers:
         version: 6.1.3
       rollup:
         specifier: ^4.63.0
-        version: 4.63.1
+        version: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       sass:
         specifier: catalog:sass195
         version: 1.104.0
@@ -1175,7 +1176,7 @@ importers:
         version: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-plugin-inspect:
         specifier: catalog:vitePluginInspect
-        version: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       vite4:
         specifier: npm:vite@^4.5.14
         version: vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)
@@ -1300,7 +1301,7 @@ importers:
         version: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-plugin-inspect:
         specifier: catalog:vitePluginInspect
-        version: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       vue-echarts:
         specifier: ^8.3.0
         version: 8.3.0(echarts@6.1.0)(vue@3.5.42(typescript@6.0.3))
@@ -1521,23 +1522,23 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
     devDependencies:
       '@dcloudio/uni-uts-v1':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(rollup@4.63.1)(supports-color@10.2.2)
+        version: 3.0.0-alpha-5020220260725001(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       cross-env:
         specifier: catalog:crossEnv
         version: 10.1.0
@@ -1567,10 +1568,10 @@ importers:
         version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(2c7805a693769637d0f17e0b56b3652b)
+        version: 4.2.1(7dd9358174ce14aa2b23b2e46486bfdd)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -1585,10 +1586,10 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(5ba80bafdec30d5ac92719095d442bf8)
       '@tarojs/plugin-platform-harmony-hybrid':
         specifier: catalog:taro4
-        version: 4.2.1(5bdd325bb5364fb8fe68569d8d9c52ec)
+        version: 4.2.1(d177d30b0db4daee41a111b1d0978313)
       '@tarojs/plugin-platform-jd':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -1609,22 +1610,22 @@ importers:
         version: 4.2.1(react@18.3.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(27cb4f84af186dbc951e2cefc1d9c35f)
+        version: 4.2.1(62d80ffb910fdcbee3ef18e909016fa5)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(1da657eeb07dd0ca13856389960c4091)
+        version: 4.2.1(d183b15501574718df48af50655c2fae)
       expo:
         specifier: catalog:expo50
         version: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
@@ -1709,13 +1710,13 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.1(fcff09d2ad0e5273de5a015f3fd0571d)
+        version: 4.2.1(612ed2af818e08f79339a0be479f2c83)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.1(56162062d9d5fbfa4b06c5618fc9331c)
+        version: 4.2.1(3cf8487eff69a72e4b91cf12d9b58b4c)
       '@tarojs/vite-runner':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
+        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@types/react':
         specifier: catalog:react18
         version: 19.2.18
@@ -1736,7 +1737,7 @@ importers:
         version: 1.0.0
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       core-js:
         specifier: ^3.50.0
         version: 3.50.0
@@ -1790,16 +1791,16 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-alipay':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       uview-plus:
         specifier: catalog:uviewPlus
         version: 3.8.120
@@ -1812,13 +1813,13 @@ importers:
         version: 3.4.31
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-stacktracey':
         specifier: 3.0.0-5000720260410001
         version: 3.0.0-5000720260410001
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@iconify-json/mdi':
         specifier: catalog:iconifyJson
         version: 1.2.3
@@ -2099,7 +2100,7 @@ importers:
         version: 7.29.7
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -2108,7 +2109,7 @@ importers:
         version: 4.2.1(@pmmmwh/react-refresh-webpack-plugin@0.6.3(@types/webpack@5.28.5(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3))(react-refresh@0.14.2)(type-fest@5.9.0)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)))(react@18.3.1)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(webpack@5.105.4)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(5ba80bafdec30d5ac92719095d442bf8)
       '@tarojs/plugin-platform-weapp':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -2117,7 +2118,7 @@ importers:
         version: 4.2.1(react@18.3.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
@@ -2126,7 +2127,7 @@ importers:
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -2154,7 +2155,7 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/vite-runner':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
+        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@types/node':
         specifier: catalog:typesNode2410
         version: 26.5.0
@@ -2166,7 +2167,7 @@ importers:
         version: 4.7.0(supports-color@10.2.2)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(35e9ddb42b304e587abd6a4670c1785d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(94183b8aa15bb12d2f67e255951d0483))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       cross-env:
         specifier: catalog:crossEnv
         version: 10.1.0
@@ -2190,7 +2191,7 @@ importers:
         version: 7.29.7
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -2199,7 +2200,7 @@ importers:
         version: 4.2.1(@pmmmwh/react-refresh-webpack-plugin@0.6.3(@types/webpack@5.28.5(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.21.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3))(react-refresh@0.18.0)(type-fest@5.9.0)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)))(react@18.3.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(648ab1bb16a74dc45f10df309ae97fe4)
       '@tarojs/plugin-platform-weapp':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -2208,7 +2209,7 @@ importers:
         version: 4.2.1(react@18.3.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
@@ -2217,7 +2218,7 @@ importers:
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -2260,7 +2261,7 @@ importers:
         version: 19.2.18
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(c0a92e4bab5da598264e0c017d407e00))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       cross-env:
         specifier: catalog:crossEnv
         version: 10.1.0
@@ -2287,19 +2288,19 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue':
         specifier: 3.0.0-5000320260312001
         version: 3.0.0-5000320260312001
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
@@ -2309,10 +2310,10 @@ importers:
         version: 3.4.31
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@iconify-json/mdi':
         specifier: catalog:iconifyJson
         version: 1.2.3
@@ -2360,10 +2361,10 @@ importers:
         version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(b804624545cb105e79c0e0480282cac5)
+        version: 4.2.1(8095221785d4ff017a2edc5d5918b022)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -2378,7 +2379,7 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(648ab1bb16a74dc45f10df309ae97fe4)
       '@tarojs/plugin-platform-tt':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -2390,22 +2391,22 @@ importers:
         version: 4.2.1(react@18.3.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(34e1a581c5d4fe27af0c97068f310a76)
+        version: 4.2.1(1e9a597af4b436f8aafd83165305b1fd)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(085699df9dd20ac452327c67c904a072)
+        version: 4.2.1(cbb84af26c141d75c2b8f7138f1b90fa)
       expo:
         specifier: catalog:expo50
         version: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
@@ -2469,10 +2470,10 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.1(71131a4387a7ada6d0de339db9ba5848)
+        version: 4.2.1(dc915ff486f034318f8fc16a63f43157)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.1(5387e117e79f4faa8c4be336eab7c420)
+        version: 4.2.1(4e69551906908d89ed056164957f0abd)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)(webpack@5.105.4)
@@ -2487,7 +2488,7 @@ importers:
         version: 19.2.18
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       postcss:
         specifier: catalog:postcss85
         version: 8.5.28
@@ -2517,28 +2518,28 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-app-plus':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-alipay':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-toutiao':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue':
         specifier: 3.0.0-5000320260312001
         version: 3.0.0-5000320260312001
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
@@ -2548,10 +2549,10 @@ importers:
         version: 3.4.31
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@iconify-json/mdi':
         specifier: catalog:iconifyJson
         version: 1.2.3
@@ -2605,10 +2606,10 @@ importers:
         version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(2c7805a693769637d0f17e0b56b3652b)
+        version: 4.2.1(7dd9358174ce14aa2b23b2e46486bfdd)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -2623,10 +2624,10 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(5ba80bafdec30d5ac92719095d442bf8)
       '@tarojs/plugin-platform-harmony-hybrid':
         specifier: catalog:taro4
-        version: 4.2.1(5bdd325bb5364fb8fe68569d8d9c52ec)
+        version: 4.2.1(d177d30b0db4daee41a111b1d0978313)
       '@tarojs/plugin-platform-jd':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -2647,22 +2648,22 @@ importers:
         version: 4.2.1(react@18.3.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(27cb4f84af186dbc951e2cefc1d9c35f)
+        version: 4.2.1(62d80ffb910fdcbee3ef18e909016fa5)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(1da657eeb07dd0ca13856389960c4091)
+        version: 4.2.1(d183b15501574718df48af50655c2fae)
       expo:
         specifier: catalog:expo50
         version: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
@@ -2747,13 +2748,13 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.1(fcff09d2ad0e5273de5a015f3fd0571d)
+        version: 4.2.1(612ed2af818e08f79339a0be479f2c83)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.1(56162062d9d5fbfa4b06c5618fc9331c)
+        version: 4.2.1(3cf8487eff69a72e4b91cf12d9b58b4c)
       '@tarojs/vite-runner':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
+        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@types/react':
         specifier: catalog:react18
         version: 19.2.18
@@ -2774,7 +2775,7 @@ importers:
         version: 1.0.0
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       core-js:
         specifier: ^3.50.0
         version: 3.50.0
@@ -2840,10 +2841,10 @@ importers:
         version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(2c7805a693769637d0f17e0b56b3652b)
+        version: 4.2.1(7dd9358174ce14aa2b23b2e46486bfdd)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -2858,10 +2859,10 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(5ba80bafdec30d5ac92719095d442bf8)
       '@tarojs/plugin-platform-harmony-hybrid':
         specifier: catalog:taro4
-        version: 4.2.1(5bdd325bb5364fb8fe68569d8d9c52ec)
+        version: 4.2.1(d177d30b0db4daee41a111b1d0978313)
       '@tarojs/plugin-platform-jd':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -2879,22 +2880,22 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(27cb4f84af186dbc951e2cefc1d9c35f)
+        version: 4.2.1(62d80ffb910fdcbee3ef18e909016fa5)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(1da657eeb07dd0ca13856389960c4091)
+        version: 4.2.1(d183b15501574718df48af50655c2fae)
       expo:
         specifier: catalog:expo50
         version: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
@@ -2982,13 +2983,13 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.1(ce7f44a63b1b8f76b38ca8ef20df15d9)
+        version: 4.2.1(64ca070a9122359a1506e79e5c443a64)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.1(56162062d9d5fbfa4b06c5618fc9331c)
+        version: 4.2.1(3cf8487eff69a72e4b91cf12d9b58b4c)
       '@tarojs/vite-runner':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
+        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@types/react':
         specifier: catalog:react18
         version: 19.2.18
@@ -3018,7 +3019,7 @@ importers:
         version: 1.0.0
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       core-js:
         specifier: ^3.50.0
         version: 3.50.0
@@ -3078,10 +3079,10 @@ importers:
         version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(b804624545cb105e79c0e0480282cac5)
+        version: 4.2.1(8095221785d4ff017a2edc5d5918b022)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -3096,10 +3097,10 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(648ab1bb16a74dc45f10df309ae97fe4)
       '@tarojs/plugin-platform-harmony-hybrid':
         specifier: catalog:taro4
-        version: 4.2.1(0ff94c6e9328a6e43945fca696c824c5)
+        version: 4.2.1(d5d33781a80ae15397b02f9be5fd883f)
       '@tarojs/plugin-platform-jd':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -3120,22 +3121,22 @@ importers:
         version: 4.2.1(react@18.3.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(34e1a581c5d4fe27af0c97068f310a76)
+        version: 4.2.1(1e9a597af4b436f8aafd83165305b1fd)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(085699df9dd20ac452327c67c904a072)
+        version: 4.2.1(cbb84af26c141d75c2b8f7138f1b90fa)
       expo:
         specifier: catalog:expo50
         version: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
@@ -3202,10 +3203,10 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.1(71131a4387a7ada6d0de339db9ba5848)
+        version: 4.2.1(dc915ff486f034318f8fc16a63f43157)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.1(5387e117e79f4faa8c4be336eab7c420)
+        version: 4.2.1(4e69551906908d89ed056164957f0abd)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)(webpack@5.105.4)
@@ -3229,7 +3230,7 @@ importers:
         version: link:../../packages-runtime/variants
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       eslint:
         specifier: catalog:eslint10
         version: 10.10.0(jiti@2.7.0)(supports-color@10.2.2)
@@ -3292,10 +3293,10 @@ importers:
         version: 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/components-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(b804624545cb105e79c0e0480282cac5)
+        version: 4.2.1(8095221785d4ff017a2edc5d5918b022)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -3310,10 +3311,10 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(648ab1bb16a74dc45f10df309ae97fe4)
       '@tarojs/plugin-platform-harmony-hybrid':
         specifier: catalog:taro4
-        version: 4.2.1(0ff94c6e9328a6e43945fca696c824c5)
+        version: 4.2.1(d5d33781a80ae15397b02f9be5fd883f)
       '@tarojs/plugin-platform-jd':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -3331,22 +3332,22 @@ importers:
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
       '@tarojs/router':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+        version: 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/runtime-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(34e1a581c5d4fe27af0c97068f310a76)
+        version: 4.2.1(1e9a597af4b436f8aafd83165305b1fd)
       '@tarojs/shared':
         specifier: catalog:taro4
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/taro-rn':
         specifier: catalog:taro4rn
-        version: 4.2.1(085699df9dd20ac452327c67c904a072)
+        version: 4.2.1(cbb84af26c141d75c2b8f7138f1b90fa)
       expo:
         specifier: catalog:expo50
         version: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
@@ -3413,10 +3414,10 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/rn-runner':
         specifier: catalog:taro4rn
-        version: 4.2.1(bcfbac0ffbc4d61f514d1c3790a58b63)
+        version: 4.2.1(024e6177bafd7814f4512b88be8344bd)
       '@tarojs/rn-supporter':
         specifier: catalog:taro4rn
-        version: 4.2.1(5387e117e79f4faa8c4be336eab7c420)
+        version: 4.2.1(4e69551906908d89ed056164957f0abd)
       '@tarojs/taro-loader':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)(webpack@5.105.4)
@@ -3452,7 +3453,7 @@ importers:
         version: link:../../packages-runtime/variants
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       eslint:
         specifier: catalog:eslint10
         version: 10.10.0(jiti@2.7.0)(supports-color@10.2.2)
@@ -3503,55 +3504,55 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-app-harmony':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-app-plus':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-alipay':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-baidu':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-harmony':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-jd':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-kuaishou':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-lark':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-qq':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-toutiao':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue':
         specifier: 3.0.0-5000320260312001
         version: 3.0.0-5000320260312001
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-xhs':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-quickapp-webview':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       tailwindcss-core-plugins-extractor:
         specifier: workspace:*
         version: link:../../packages/tailwindcss-core-plugins-extractor
@@ -3567,16 +3568,16 @@ importers:
         version: 3.4.31
       '@dcloudio/uni-automator':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(jest-environment-node@27.5.1)(jest@27.0.4(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(jest-environment-node@27.5.1)(jest@27.0.4(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-stacktracey':
         specifier: 3.0.0-5010520260709002
         version: 3.0.0-5010520260709002
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-5010520260709002
-        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@egoist/tailwindcss-icons':
         specifier: catalog:egoistTailwindcssIcons
         version: 1.9.2(tailwindcss@4.3.3)
@@ -3636,19 +3637,19 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-app-plus':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
@@ -3658,7 +3659,7 @@ importers:
         version: 3.4.31
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue':
         specifier: 3.0.0-5000320260312001
         version: 3.0.0-5000320260312001
@@ -3667,7 +3668,7 @@ importers:
         version: 3.0.0-5000720260410001
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@iconify-json/mdi':
         specifier: catalog:iconifyJson
         version: 1.2.3
@@ -3700,13 +3701,13 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
@@ -3716,10 +3717,10 @@ importers:
         version: 1.2.0
       '@dcloudio/uni-uts-v1':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(rollup@4.63.1)(supports-color@10.2.2)
+        version: 3.0.0-alpha-5020220260725001(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@iconify-json/mdi':
         specifier: catalog:iconifyJson
         version: 1.2.3
@@ -3755,13 +3756,13 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
@@ -3771,10 +3772,10 @@ importers:
         version: 1.2.0
       '@dcloudio/uni-uts-v1':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(rollup@4.63.1)(supports-color@10.2.2)
+        version: 3.0.0-alpha-5020220260725001(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-alpha-5020220260725001
-        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@iconify-json/mdi':
         specifier: catalog:iconifyJson
         version: 1.2.3
@@ -3850,13 +3851,13 @@ importers:
         version: link:../../packages/weapp-tailwindcss
       weapp-vite:
         specifier: catalog:weappVite
-        version: 7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0)
+        version: 7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0)
 
   demo/web/nuxt-vite-tailwindcss-v4:
     dependencies:
       nuxt:
         specifier: 4.5.2
-        version: 4.5.2(eea432f0be145ee388fe177e665862c9)
+        version: 4.5.2(4f93883d3d0f3f89f0c35d187057e72e)
       vue:
         specifier: catalog:vue3
         version: 3.5.42(typescript@6.0.3)
@@ -4466,7 +4467,7 @@ importers:
         version: 10.6.0(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(supports-color@10.2.2)(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: catalog:storybook
-        version: 10.6.0(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 10.6.0(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:tailwindcss4
         version: 4.3.3(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
@@ -4496,7 +4497,7 @@ importers:
         version: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: catalog:buildUtilities
-        version: 4.5.4(@types/node@26.5.0)(rollup@4.63.1)(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 4.5.4(@types/node@26.5.0)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
 
   packages-runtime/variants:
     dependencies:
@@ -5147,7 +5148,7 @@ importers:
         version: 7.29.7
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -5156,7 +5157,7 @@ importers:
         version: 4.2.1(@pmmmwh/react-refresh-webpack-plugin@0.6.3(@types/webpack@5.28.5(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3))(react-refresh@0.14.2)(type-fest@5.9.0)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)))(react@18.3.1)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(webpack@5.105.4)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(5ba80bafdec30d5ac92719095d442bf8)
       '@tarojs/plugin-platform-weapp':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -5171,7 +5172,7 @@ importers:
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -5190,7 +5191,7 @@ importers:
         version: 4.2.1(@swc/helpers@0.5.23)(@types/node@26.5.0)(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tarojs/vite-runner':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
+        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@types/node':
         specifier: catalog:typesNode2410
         version: 26.5.0
@@ -5205,7 +5206,7 @@ importers:
         version: 4.7.0(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(35e9ddb42b304e587abd6a4670c1785d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(84cc1a49136a536920638c449c2cac59))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       postcss:
         specifier: catalog:postcss85
         version: 8.5.28
@@ -5232,7 +5233,7 @@ importers:
         version: 7.29.7
       '@tarojs/components':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper':
         specifier: catalog:taro4
         version: 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -5241,7 +5242,7 @@ importers:
         version: 4.2.1(@pmmmwh/react-refresh-webpack-plugin@0.6.3(@types/webpack@5.28.5(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3))(react-refresh@0.18.0)(type-fest@5.9.0)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)))(react@18.3.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       '@tarojs/plugin-platform-h5':
         specifier: catalog:taro4
-        version: 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(648ab1bb16a74dc45f10df309ae97fe4)
       '@tarojs/plugin-platform-weapp':
         specifier: catalog:taro4
         version: 4.2.1(@tarojs/service@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)
@@ -5256,7 +5257,7 @@ importers:
         version: 4.2.1
       '@tarojs/taro':
         specifier: catalog:taro4
-        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+        version: 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       react:
         specifier: catalog:react18
         version: 18.3.1
@@ -5290,7 +5291,7 @@ importers:
         version: 1.18.8
       babel-preset-taro:
         specifier: catalog:taro4
-        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+        version: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(c0a92e4bab5da598264e0c017d407e00))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       postcss:
         specifier: catalog:postcss85
         version: 8.5.28
@@ -5317,16 +5318,16 @@ importers:
     dependencies:
       '@dcloudio/uni-app':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-components':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-weixin':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       vue:
         specifier: ^3.5.41
         version: 3.5.42(typescript@6.0.3)
@@ -5336,10 +5337,10 @@ importers:
         version: 3.4.31
       '@dcloudio/uni-cli-shared':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/vite-plugin-uni':
         specifier: 3.0.0-5000720260410001
-        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+        version: 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@vue/runtime-core':
         specifier: ^3.5.41
         version: 3.5.42
@@ -5375,7 +5376,7 @@ importers:
         version: link:../../packages/weapp-tailwindcss
       weapp-vite:
         specifier: catalog:weappVite
-        version: 7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0)
+        version: 7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0)
 
   tools/weapp-tailwindcss-scripts:
     dependencies:
@@ -38593,10 +38594,10 @@ snapshots:
 
   '@dcloudio/types@3.4.31': {}
 
-  '@dcloudio/uni-app-harmony@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-harmony@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-app-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app-uts': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       debug: 4.3.7(supports-color@10.2.2)
       fs-extra: 10.1.0
       licia: 1.41.1
@@ -38611,10 +38612,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-plus@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-app-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app-uts': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-app-vue': 3.0.0-5000720260410001
       debug: 4.3.7(supports-color@10.2.2)
       fs-extra: 10.1.0
@@ -38630,10 +38631,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-plus@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-plus@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-app-uts': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-app-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app-uts': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-app-vue': 3.0.0-5010520260709002
       debug: 4.3.7(supports-color@10.2.2)
       fs-extra: 10.1.0
@@ -38649,18 +38650,18 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-uts@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-uts@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-console': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-console': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
       '@dcloudio/uni-nvue-styler': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -38684,12 +38685,12 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-uts@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-uts@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-console': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-console': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
       '@dcloudio/uni-nvue-styler': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
@@ -38719,13 +38720,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-vite@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
       '@dcloudio/uni-nvue-styler': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -38742,9 +38743,9 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app-vite@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app-vite@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
       '@dcloudio/uni-nvue-styler': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
@@ -38771,16 +38772,16 @@ snapshots:
 
   '@dcloudio/uni-app-x@0.7.114': {}
 
-  '@dcloudio/uni-app@3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app@3.0.0-5000720260410001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@dcloudio/types': 3.4.31
-      '@dcloudio/uni-cloud': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-components': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-console': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cloud': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-components': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-console': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
-      '@dcloudio/uni-push': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-push': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
-      '@dcloudio/uni-stat': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-stat': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -38791,16 +38792,16 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-app@3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app@3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@dcloudio/types': 3.4.31
-      '@dcloudio/uni-cloud': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-components': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-console': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cloud': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-components': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-console': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
-      '@dcloudio/uni-push': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-push': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
-      '@dcloudio/uni-stat': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-stat': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -38812,16 +38813,16 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-app@3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-app@3.0.0-alpha-5020220260725001(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@dcloudio/types': 3.4.31
-      '@dcloudio/uni-cloud': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-components': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-console': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cloud': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-components': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-console': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-alpha-5020220260725001
-      '@dcloudio/uni-push': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-push': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-alpha-5020220260725001
-      '@dcloudio/uni-stat': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-stat': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -38833,9 +38834,9 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-automator@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(jest-environment-node@27.5.1)(jest@27.0.4(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-automator@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(jest-environment-node@27.5.1)(jest@27.0.4(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       address: 1.2.2
       cross-env: 7.0.3
       debug: 4.3.7(supports-color@10.2.2)
@@ -38860,7 +38861,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-cli-shared@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
@@ -38873,7 +38874,7 @@ snapshots:
       '@intlify/core-base': 9.1.9
       '@intlify/shared': 9.1.9
       '@intlify/vue-devtools': 9.1.9
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -38911,7 +38912,7 @@ snapshots:
       tapable: 2.3.3
       tinycolor2: 1.6.0
       unimport: 4.1.1
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       xregexp: 5.1.2
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -38922,7 +38923,7 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-cli-shared@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
@@ -38973,7 +38974,7 @@ snapshots:
       tapable: 2.3.3
       tinycolor2: 1.6.0
       unimport: 4.1.1
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       xregexp: 5.1.2
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -38984,7 +38985,7 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cli-shared@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-cli-shared@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.7
@@ -38997,7 +38998,7 @@ snapshots:
       '@intlify/core-base': 9.1.9
       '@intlify/shared': 9.1.9
       '@intlify/vue-devtools': 9.1.9
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -39035,7 +39036,7 @@ snapshots:
       tapable: 2.3.3
       tinycolor2: 1.6.0
       unimport: 4.1.1
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       xregexp: 5.1.2
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39046,9 +39047,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-cloud@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@vue/shared': 3.4.21
@@ -39062,9 +39063,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-cloud@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
@@ -39078,9 +39079,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-cloud@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-cloud@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-alpha-5020220260725001
       '@dcloudio/uni-shared': 3.0.0-alpha-5020220260725001
       '@vue/shared': 3.4.21
@@ -39094,10 +39095,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-components@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-components@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-h5': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cloud': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-h5': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39108,10 +39109,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-components@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-components@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-h5': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cloud': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-h5': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39123,10 +39124,10 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-components@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-components@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cloud': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-h5': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cloud': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-h5': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-alpha-5020220260725001
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39138,9 +39139,9 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-console@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-console@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39151,9 +39152,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-console@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-console@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39164,9 +39165,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-console@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-console@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39177,11 +39178,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-h5-vite@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/server-renderer': 3.4.21(vue@3.5.42(typescript@6.0.3))
@@ -39199,9 +39200,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-h5-vite@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@rollup/pluginutils': 5.1.0(rollup@4.14.3)
       '@vitejs/plugin-basic-ssl': 1.2.0(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))
@@ -39223,11 +39224,11 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-h5-vite@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-h5-vite@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-alpha-5020220260725001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vitejs/plugin-basic-ssl': 1.2.0(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
@@ -39268,9 +39269,9 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-h5@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-h5-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5-vue': 3.0.0-5000720260410001(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
@@ -39291,9 +39292,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-h5@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-h5-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5-vue': 3.0.0-5010520260709002(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
@@ -39315,9 +39316,9 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-h5@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-h5@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-h5-vite': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-h5-vite': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-h5-vue': 3.0.0-alpha-5020220260725001(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-alpha-5020220260725001
       '@dcloudio/uni-shared': 3.0.0-alpha-5020220260725001
@@ -39345,11 +39346,11 @@ snapshots:
 
   '@dcloudio/uni-i18n@3.0.0-alpha-5020220260725001': {}
 
-  '@dcloudio/uni-mp-alipay@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-alipay@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@vue/compiler-core': 3.4.21
@@ -39363,11 +39364,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-alipay@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-alipay@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-core': 3.4.21
@@ -39381,14 +39382,14 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-baidu@3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-baidu@3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-app': 3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-app': 3.0.0-5010520260709002(@dcloudio/types@3.4.31)(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
-      '@dcloudio/uni-mp-weixin': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-weixin': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -39411,12 +39412,12 @@ snapshots:
       - vite
       - vue
 
-  '@dcloudio/uni-mp-compiler@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-compiler@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/generator': 7.25.6
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
@@ -39431,12 +39432,12 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-compiler@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-compiler@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/generator': 7.25.6
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-core': 3.4.21
       '@vue/compiler-dom': 3.4.21
@@ -39451,13 +39452,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-harmony@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-harmony@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-toutiao': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-toutiao': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
-      '@dcloudio/uni-quickapp-webview': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-quickapp-webview': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
     transitivePeerDependencies:
@@ -39469,11 +39470,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-jd@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-jd@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
@@ -39486,13 +39487,13 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-kuaishou@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-kuaishou@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
-      '@dcloudio/uni-mp-weixin': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-weixin': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-core': 3.4.21
       '@vue/shared': 3.4.21
@@ -39508,12 +39509,12 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-lark@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-lark@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-toutiao': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-toutiao': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-core': 3.4.21
@@ -39527,11 +39528,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-qq@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-qq@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
@@ -39545,11 +39546,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-toutiao@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-toutiao@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@vue/compiler-core': 3.4.21
@@ -39563,11 +39564,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-toutiao@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-toutiao@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-core': 3.4.21
@@ -39581,11 +39582,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-vite@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-vite@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5000720260410001
-      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@vue/compiler-dom': 3.4.21
@@ -39601,11 +39602,11 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-mp-vite@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-vite@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-i18n': 3.0.0-5010520260709002
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/compiler-dom': 3.4.21
@@ -39636,11 +39637,11 @@ snapshots:
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
 
-  '@dcloudio/uni-mp-weixin@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-weixin@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       '@vue/shared': 3.4.21
@@ -39661,11 +39662,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-weixin@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-weixin@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(debug@4.4.3(supports-color@10.2.2))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
@@ -39686,11 +39687,11 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@dcloudio/uni-mp-xhs@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-mp-xhs@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-compiler': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
@@ -39724,9 +39725,9 @@ snapshots:
       postcss: 8.5.6
       tinycolor2: 1.6.0
 
-  '@dcloudio/uni-push@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-push@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -39736,9 +39737,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-push@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-push@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -39748,9 +39749,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-push@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-push@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@vueuse/core'
@@ -39760,10 +39761,10 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-quickapp-webview@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-quickapp-webview@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
-      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-mp-vite': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-mp-vue': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@vue/shared': 3.4.21
@@ -39796,9 +39797,9 @@ snapshots:
 
   '@dcloudio/uni-stacktracey@3.0.0-5010520260709002': {}
 
-  '@dcloudio/uni-stat@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-stat@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
       debug: 4.3.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -39810,9 +39811,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-stat@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-stat@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       debug: 4.3.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -39824,9 +39825,9 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-stat@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/uni-stat@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-shared': 3.0.0-alpha-5020220260725001
       debug: 4.3.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -39838,12 +39839,12 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/uni-uts-v1@3.0.0-alpha-5020220260725001(rollup@4.63.1)(supports-color@10.2.2)':
+  '@dcloudio/uni-uts-v1@3.0.0-alpha-5020220260725001(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.24.7
       '@dcloudio/uni-app-x': 0.7.114
       '@dcloudio/uts': 3.0.0-alpha-5020220260725001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vue/shared': 3.4.21
       adm-zip: 0.5.16
       android-versions: 1.9.0
@@ -39891,15 +39892,15 @@ snapshots:
       '@dcloudio/uts-win32-ia32-msvc': 3.0.0-alpha-5020220260725001
       '@dcloudio/uts-win32-x64-msvc': 3.0.0-alpha-5020220260725001
 
-  '@dcloudio/vite-plugin-uni@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/vite-plugin-uni@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.25.2(supports-color@10.2.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2(supports-color@10.2.2))
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.25.2(supports-color@10.2.2))(supports-color@10.2.2)
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-nvue-styler': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vitejs/plugin-legacy': 5.3.2(supports-color@10.2.2)(terser@5.51.0)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@vitejs/plugin-vue': 5.2.4(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
@@ -39918,7 +39919,7 @@ snapshots:
       magic-string: 0.30.11
       picocolors: 1.1.0
       terser: 5.51.0
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       vite: 5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39929,15 +39930,15 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/vite-plugin-uni@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.25.2(supports-color@10.2.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2(supports-color@10.2.2))
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.25.2(supports-color@10.2.2))(supports-color@10.2.2)
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-nvue-styler': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vitejs/plugin-legacy': 5.3.2(supports-color@10.2.2)(terser@5.51.0)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
@@ -39956,7 +39957,7 @@ snapshots:
       magic-string: 0.30.11
       picocolors: 1.1.0
       terser: 5.51.0
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       vite: 5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -39967,15 +39968,15 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/vite-plugin-uni@3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.25.2(supports-color@10.2.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2(supports-color@10.2.2))
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.25.2(supports-color@10.2.2))(supports-color@10.2.2)
-      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5000720260410001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-nvue-styler': 3.0.0-5000720260410001
       '@dcloudio/uni-shared': 3.0.0-5000720260410001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vitejs/plugin-legacy': 5.3.2(supports-color@10.2.2)(terser@5.51.0)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))
       '@vitejs/plugin-vue': 5.2.4(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
@@ -39994,7 +39995,7 @@ snapshots:
       magic-string: 0.30.11
       picocolors: 1.1.0
       terser: 5.51.0
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)(tsx@4.23.13)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -40005,12 +40006,12 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/vite-plugin-uni@3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vite@5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.25.2(supports-color@10.2.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2(supports-color@10.2.2))
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.25.2(supports-color@10.2.2))(supports-color@10.2.2)
-      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-5010520260709002(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.14.3)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-nvue-styler': 3.0.0-5010520260709002
       '@dcloudio/uni-shared': 3.0.0-5010520260709002
       '@rollup/pluginutils': 5.1.0(rollup@4.14.3)
@@ -40032,7 +40033,7 @@ snapshots:
       magic-string: 0.30.11
       picocolors: 1.1.0
       terser: 5.51.0
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       vite: 5.2.8(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.0)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -40043,16 +40044,16 @@ snapshots:
       - ts-node
       - vue
 
-  '@dcloudio/vite-plugin-uni@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
+  '@dcloudio/vite-plugin-uni@3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.25.2(supports-color@10.2.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2(supports-color@10.2.2))
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.25.2(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/types': 7.25.6
-      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
+      '@dcloudio/uni-cli-shared': 3.0.0-alpha-5020220260725001(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))
       '@dcloudio/uni-nvue-styler': 3.0.0-alpha-5020220260725001
       '@dcloudio/uni-shared': 3.0.0-alpha-5020220260725001
-      '@rollup/pluginutils': 5.1.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@vitejs/plugin-legacy': 5.3.2(supports-color@10.2.2)(terser@5.51.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))
       '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(supports-color@10.2.2)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))(vue@3.5.42(typescript@6.0.3))
@@ -40073,7 +40074,7 @@ snapshots:
       picocolors: 1.1.0
       source-map-js: 1.2.1
       terser: 5.51.2
-      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
+      unplugin-auto-import: 19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3)))
       vite: 5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -41112,17 +41113,17 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
-  '@dxup/nuxt@0.5.10(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)':
+  '@dxup/nuxt@0.5.10(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       '@vue/compiler-dom': 3.5.42
       chokidar: 5.0.0
       knitwork: 1.3.0
       magic-string: 1.2.3
       pathe: 2.0.3
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -44443,7 +44444,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
 
-  '@mapbox/node-pre-gyp@2.0.3(encoding@0.1.13)(supports-color@10.2.2)':
+  '@mapbox/node-pre-gyp@2.0.3(supports-color@10.2.2)':
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
@@ -44594,15 +44595,15 @@ snapshots:
       '@module-federation/runtime': 0.22.0
       '@module-federation/sdk': 0.22.0
 
-  '@mpxjs/api-proxy@2.11.1(22c834dfb2e03f4fa653631ac408a8a2)':
+  '@mpxjs/api-proxy@2.11.1(@mpxjs/core@2.11.1)(@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(debug@4.4.3(supports-color@10.2.2))(react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(supports-color@10.2.2)':
     dependencies:
       '@mpxjs/utils': 2.11.0(@mpxjs/core@2.11.1)
       axios: 1.17.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      '@react-native-community/netinfo': 11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      react-native-device-info: 14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      '@react-native-community/netinfo': 11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      react-native-device-info: 14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
     transitivePeerDependencies:
       - '@mpxjs/core'
       - debug
@@ -44628,6 +44629,28 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
+  '@mpxjs/core@2.11.1(04010f44a3c2e4cf6d2ae724da488df6)':
+    dependencies:
+      '@mpxjs/api-proxy': 2.11.1(@mpxjs/core@2.11.1)(@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(debug@4.4.3(supports-color@10.2.2))(react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(supports-color@10.2.2)
+      '@mpxjs/perf': 2.11.1
+      '@mpxjs/store': 2.11.0(@mpxjs/core@2.11.1)
+      '@mpxjs/utils': 2.11.0(@mpxjs/core@2.11.1)
+      lodash: 4.18.1
+      miniprogram-api-typings: 3.12.3
+    optionalDependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/native-stack': 6.11.0(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react: 19.2.8
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native-gesture-handler: 2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-webview: 13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      vue: 2.7.16
+      vue-demi: 0.14.10(vue@2.7.16)
+      vue-i18n: 8.28.2(vue@2.7.16)
+      vue-i18n-bridge: 9.14.1(vue@2.7.16)
+
   '@mpxjs/core@2.11.1(0d78c100d46990f06d04da85b4577888)':
     dependencies:
       '@mpxjs/api-proxy': 2.11.1(b1a47d05f4be82069e05926a20b17bdf)
@@ -44645,28 +44668,6 @@ snapshots:
       react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react-native-webview: 13.6.4(react-native@0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      vue: 2.7.16
-      vue-demi: 0.14.10(vue@2.7.16)
-      vue-i18n: 8.28.2(vue@2.7.16)
-      vue-i18n-bridge: 9.14.1(vue@2.7.16)
-
-  '@mpxjs/core@2.11.1(4d802bec98f8ef7b3f03cc7276b0d512)':
-    dependencies:
-      '@mpxjs/api-proxy': 2.11.1(22c834dfb2e03f4fa653631ac408a8a2)
-      '@mpxjs/perf': 2.11.1
-      '@mpxjs/store': 2.11.0(@mpxjs/core@2.11.1)
-      '@mpxjs/utils': 2.11.0(@mpxjs/core@2.11.1)
-      lodash: 4.18.1
-      miniprogram-api-typings: 3.12.3
-    optionalDependencies:
-      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      '@react-navigation/native-stack': 6.11.0(d9bd4077107d9abc80758ed7c8a94b14)
-      react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-      react-native-gesture-handler: 2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-webview: 13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       vue: 2.7.16
       vue-demi: 0.14.10(vue@2.7.16)
       vue-i18n: 8.28.2(vue@2.7.16)
@@ -45499,9 +45500,9 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.4.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@3.4.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       execa: 8.0.1
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -45522,11 +45523,11 @@ snapshots:
       pkg-types: 2.3.3
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.2(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(supports-color@10.2.2)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))':
+  '@nuxt/devtools@3.4.2(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(supports-color@10.2.2)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.4.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.4.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.2
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       '@vue/devtools-core': 8.2.1(vue@3.5.42(typescript@6.0.3))
       '@vue/devtools-kit': 8.2.1
       birpc: 4.2.0
@@ -45554,7 +45555,7 @@ snapshots:
       tinyglobby: 0.2.17
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
-      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.5.0(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       which: 6.0.1
       ws: 8.21.3
@@ -45587,7 +45588,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))':
+  '@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))':
     dependencies:
       c12: 3.3.4(magicast@0.5.4)
       consola: 3.4.2
@@ -45607,7 +45608,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       untyped: 2.0.0
       verkit: 0.3.2
     transitivePeerDependencies:
@@ -45618,7 +45619,7 @@ snapshots:
       - unplugin
     optional: true
 
-  '@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))':
+  '@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))':
     dependencies:
       c12: 3.3.4(magicast@0.5.4)
       consola: 3.4.2
@@ -45638,7 +45639,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       untyped: 2.0.0
       verkit: 0.3.2
     transitivePeerDependencies:
@@ -45648,11 +45649,11 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.2(7381fefd0087dd48fe01f9b88282477b)':
+  '@nuxt/nitro-server@4.5.2(4233bbbb327a90f49fa44d298cdd5a65)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
-      '@unhead/vue': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@unhead/vue': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
       '@vue/shared': 3.5.42
       consola: 3.4.2
       defu: 6.1.7
@@ -45662,19 +45663,19 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.1
       h3: 1.15.11
-      impound: 1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      impound: 1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(encoding@0.1.13)(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       nostics: 1.2.0
-      nuxt: 4.5.2(eea432f0be145ee388fe177e665862c9)
+      nuxt: 4.5.2(4f93883d3d0f3f89f0c35d187057e72e)
       nypm: 0.6.9
       ohash: 2.0.12
       pathe: 2.0.3
       rou3: 0.9.2
       std-env: 4.2.0
       ufo: 1.6.4
-      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
       vue: 3.5.42(typescript@6.0.3)
       vue-bundle-renderer: 2.3.2
@@ -45682,7 +45683,7 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/plugin-syntax-typescript': 8.0.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -45745,18 +45746,18 @@ snapshots:
       pkg-types: 2.3.3
       std-env: 4.2.0
 
-  '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))':
+  '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))':
     dependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       citty: 0.2.2
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(eea432f0be145ee388fe177e665862c9))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1))(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)':
-    dependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+  ? '@nuxt/vite-builder@4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(4f93883d3d0f3f89f0c35d187057e72e))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)))(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)'
+  : dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.6(supports-color@10.2.2)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       autoprefixer: 10.5.5(postcss@8.5.28)
@@ -45772,7 +45773,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(eea432f0be145ee388fe177e665862c9)
+      nuxt: 4.5.2(4f93883d3d0f3f89f0c35d187057e72e)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.3
@@ -45782,7 +45783,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-plugin-checker: 0.14.5(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(meow@14.1.0)(optionator@0.9.4)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))
@@ -45792,7 +45793,7 @@ snapshots:
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/plugin-syntax-jsx': 8.0.1(@babel/core@7.29.7(supports-color@10.2.2))
       rolldown: 1.2.7
-      rollup-plugin-visualizer: 7.1.1(rolldown@1.2.7)(rollup@4.63.1)
+      rollup-plugin-visualizer: 7.1.1(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@farmfe/core'
@@ -47458,10 +47459,10 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  '@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
+  '@react-native-async-storage/async-storage@1.21.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   '@react-native-camera-roll/camera-roll@7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))':
     dependencies:
@@ -47660,9 +47661,9 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  '@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
+  '@react-native-community/netinfo@11.1.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))':
     dependencies:
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   '@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)':
     dependencies:
@@ -48120,23 +48121,6 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@react-native/community-cli-plugin@0.81.6(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@react-native/dev-middleware': 0.81.6(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-      invariant: 2.2.4
-      metro: 0.83.7(supports-color@10.2.2)
-      metro-config: 0.83.7(supports-color@10.2.2)
-      metro-core: 0.83.7
-      semver: 7.8.5
-    optionalDependencies:
-      '@react-native-community/cli': 12.3.7(encoding@0.1.13)(supports-color@10.2.2)
-      '@react-native/metro-config': 0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@react-native/debugger-frontend@0.73.3': {}
 
   '@react-native/debugger-frontend@0.81.5': {}
@@ -48325,12 +48309,12 @@ snapshots:
       '@types/react': 19.2.18
     optional: true
 
-  '@react-native/virtualized-lists@0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
+  '@react-native/virtualized-lists@0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optionalDependencies:
       '@types/react': 19.2.18
 
@@ -48400,12 +48384,12 @@ snapshots:
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
     optional: true
 
-  '@react-navigation/elements@1.3.31(c51dd0a9611efc80988e6af404f461d2)':
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
-      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
 
   ? '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)'
   : dependencies:
@@ -48427,14 +48411,14 @@ snapshots:
       warn-once: 0.1.1
     optional: true
 
-  '@react-navigation/native-stack@6.11.0(d9bd4077107d9abc80758ed7c8a94b14)':
+  '@react-navigation/native-stack@6.11.0(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
-      '@react-navigation/elements': 1.3.31(c51dd0a9611efc80988e6af404f461d2)
-      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8))(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-navigation/native': 6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
-      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
-      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native-safe-area-context: 4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      react-native-screens: 3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       warn-once: 0.1.1
 
   '@react-navigation/native-stack@6.11.0(e47cc7b09d58094ab558bc33d5cb4482)':
@@ -48477,14 +48461,14 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  '@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
+  '@react-navigation/native@6.1.18(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)':
     dependencies:
       '@react-navigation/core': 6.4.17(react@19.2.8)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.18
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   '@react-navigation/routers@6.1.9':
     dependencies:
@@ -48965,35 +48949,35 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-alias@6.0.0(rollup@4.63.1)':
+  '@rollup/plugin-alias@6.0.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)':
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-commonjs@25.0.8(rollup@4.63.1)':
+  '@rollup/plugin-commonjs@25.0.8(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-commonjs@29.0.3(rollup@4.63.1)':
+  '@rollup/plugin-commonjs@29.0.3(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.7)
@@ -49001,71 +48985,71 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.7
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-inject@5.0.5(rollup@4.63.1)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       estree-walker: 2.0.2
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-json@6.1.0(rollup@4.63.1)':
+  '@rollup/plugin-json@6.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@4.63.1)':
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.12
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.63.1)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.12
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-replace@5.0.7(rollup@4.63.1)':
+  '@rollup/plugin-replace@5.0.7(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-replace@6.0.3(rollup@4.63.1)':
+  '@rollup/plugin-replace@6.0.3(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-terser@0.4.4(rollup@4.63.1)':
+  '@rollup/plugin-terser@0.4.4(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.51.2
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/plugin-terser@1.0.0(rollup@4.63.1)':
+  '@rollup/plugin-terser@1.0.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
       serialize-javascript: 7.1.1
       smob: 1.6.2
       terser: 5.51.2
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
   '@rollup/pluginutils@5.1.0(rollup@4.14.3)':
     dependencies:
@@ -49075,21 +49059,21 @@ snapshots:
     optionalDependencies:
       rollup: 4.14.3
 
-  '@rollup/pluginutils@5.1.0(rollup@4.63.1)':
+  '@rollup/pluginutils@5.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 2.3.2
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
-  '@rollup/pluginutils@5.4.0(rollup@4.63.1)':
+  '@rollup/pluginutils@5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.7
     optionalDependencies:
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
   '@rollup/rollup-android-arm-eabi@4.14.3':
     optional: true
@@ -49921,10 +49905,10 @@ snapshots:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.5(@types/react@19.2.18)
 
-  '@storybook/react-vite@10.6.0(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1)(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
+  '@storybook/react-vite@10.6.0(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@storybook/builder-vite': 10.6.0(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       '@storybook/react': 10.6.0(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.6.0(@types/react@19.2.18)(prettier@3.9.6)(react@18.3.1))(supports-color@10.2.2)(typescript@6.0.3)
       empathic: 2.0.1
@@ -50432,12 +50416,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@tarojs/components-react@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/components-react@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       classnames: 2.5.1
       identity-obj-proxy: 3.0.0
       react: 18.3.1
@@ -50455,12 +50439,12 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components-react@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/components-react@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       classnames: 2.5.1
       identity-obj-proxy: 3.0.0
       react: 18.3.1
@@ -50478,12 +50462,12 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components-rn@4.2.1(2c7805a693769637d0f17e0b56b3652b)':
+  '@tarojs/components-rn@4.2.1(7dd9358174ce14aa2b23b2e46486bfdd)':
     dependencies:
       '@ant-design/react-native': 5.0.0(b3433b3814c4b586571147aa50e03471)
       '@react-native-community/slider': 4.4.2
       '@react-native-picker/picker': 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/router-rn': 4.2.1(f4ee3e2183a8700254bd0fa426607c69)
       expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
       expo-av: 13.10.6(expo@50.0.21)
@@ -50515,80 +50499,12 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components-rn@4.2.1(538c449ad6437b95e6db13f31eec1c5b)':
-    dependencies:
-      '@ant-design/react-native': 5.0.0(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
-      expo-av: 13.10.6(expo@54.0.37)
-      expo-camera: 14.1.3(expo@54.0.37)
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
-      react-native-maps: 1.3.2(react-native-web@0.21.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - '@react-native-community/cameraroll'
-      - '@react-native-community/segmented-control'
-      - '@tarojs/helper'
-      - '@types/react'
-      - html-webpack-plugin
-      - postcss
-      - react-native-gesture-handler
-      - react-native-safe-area-context
-      - react-native-screens
-      - react-native-web
-      - rollup
-      - supports-color
-      - typescript
-      - vue
-      - webpack
-      - webpack-chain
-      - webpack-dev-server
-    optional: true
-
-  '@tarojs/components-rn@4.2.1(7794d815aacbe440aaf39102e7ac9e8a)':
-    dependencies:
-      '@ant-design/react-native': 5.0.0(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
-      expo-av: 13.10.6(expo@54.0.37)
-      expo-camera: 14.1.3(expo@54.0.37)
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
-      react-native-maps: 1.3.2(react-native-web@0.21.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - '@react-native-community/cameraroll'
-      - '@react-native-community/segmented-control'
-      - '@tarojs/helper'
-      - '@types/react'
-      - html-webpack-plugin
-      - postcss
-      - react-native-gesture-handler
-      - react-native-safe-area-context
-      - react-native-screens
-      - react-native-web
-      - rollup
-      - supports-color
-      - typescript
-      - vue
-      - webpack
-      - webpack-chain
-      - webpack-dev-server
-    optional: true
-
-  '@tarojs/components-rn@4.2.1(b804624545cb105e79c0e0480282cac5)':
+  '@tarojs/components-rn@4.2.1(8095221785d4ff017a2edc5d5918b022)':
     dependencies:
       '@ant-design/react-native': 5.0.0(b3433b3814c4b586571147aa50e03471)
       '@react-native-community/slider': 4.4.2
       '@react-native-picker/picker': 2.6.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/router-rn': 4.2.1(f4ee3e2183a8700254bd0fa426607c69)
       expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
       expo-av: 13.10.6(expo@50.0.21)
@@ -50620,12 +50536,80 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/components-rn@4.2.1(88bcf821003cf0192dba77b709d9ae08)':
+    dependencies:
+      '@ant-design/react-native': 5.0.0(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
+      expo-av: 13.10.6(expo@54.0.37)
+      expo-camera: 14.1.3(expo@54.0.37)
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-maps: 1.3.2(react-native-web@0.21.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@tarojs/helper'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-web
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+    optional: true
+
+  '@tarojs/components-rn@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(expo-av@13.10.6(expo@54.0.37))(expo-camera@14.1.3(expo@54.0.37))(expo@54.0.37)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(typescript@6.0.3)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+    dependencies:
+      '@ant-design/react-native': 5.0.0(@react-native-community/cameraroll@4.1.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(@react-native-community/segmented-control@2.2.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
+      expo-av: 13.10.6(expo@54.0.37)
+      expo-camera: 14.1.3(expo@54.0.37)
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-maps: 1.3.2(react-native-web@0.21.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      react-native-webview: 13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@tarojs/helper'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-web
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+    optional: true
+
+  '@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@stencil/core': 2.22.3
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       classnames: 2.5.1
       hammerjs: 2.0.8
       hls.js: 1.6.15
@@ -50644,12 +50628,12 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@stencil/core': 2.22.3
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       classnames: 2.5.1
       hammerjs: 2.0.8
       hls.js: 1.6.15
@@ -50897,16 +50881,16 @@ snapshots:
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
 
-  '@tarojs/plugin-platform-h5@4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/plugin-platform-h5@4.2.1(5ba80bafdec30d5ac92719095d442bf8)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/runtime': 4.2.1
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro-h5': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/taro-h5': 4.2.1(907d5832c268f2734a50dfc59429c49a)
       babel-plugin-transform-taroapi: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
       change-case: 4.1.2
       lodash-es: 4.17.21
@@ -50926,16 +50910,16 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/plugin-platform-h5@4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/plugin-platform-h5@4.2.1(648ab1bb16a74dc45f10df309ae97fe4)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/runtime': 4.2.1
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro-h5': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/taro-h5': 4.2.1(f34d8cdf97f881ef22ee67df104951ae)
       babel-plugin-transform-taroapi: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
       change-case: 4.1.2
       lodash-es: 4.17.21
@@ -50955,18 +50939,18 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/plugin-platform-harmony-hybrid@4.2.1(0ff94c6e9328a6e43945fca696c824c5)':
+  '@tarojs/plugin-platform-harmony-hybrid@4.2.1(d177d30b0db4daee41a111b1d0978313)':
     dependencies:
       '@tarojs/api': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
-      '@tarojs/plugin-platform-h5': 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/plugin-platform-h5': 4.2.1(5ba80bafdec30d5ac92719095d442bf8)
+      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime': 4.2.1
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro-h5': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/taro-h5': 4.2.1(907d5832c268f2734a50dfc59429c49a)
       axios: 1.17.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       babel-plugin-transform-taroapi: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
       base64-js: 1.5.1
@@ -50992,18 +50976,18 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/plugin-platform-harmony-hybrid@4.2.1(5bdd325bb5364fb8fe68569d8d9c52ec)':
+  '@tarojs/plugin-platform-harmony-hybrid@4.2.1(d5d33781a80ae15397b02f9be5fd883f)':
     dependencies:
       '@tarojs/api': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components-react': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(solid-js@1.9.10)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
-      '@tarojs/plugin-platform-h5': 4.2.1(@swc/helpers@0.5.23)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react@18.3.1)(rollup@4.63.1)(solid-js@1.9.10)(supports-color@10.2.2)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/plugin-platform-h5': 4.2.1(648ab1bb16a74dc45f10df309ae97fe4)
+      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime': 4.2.1
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro-h5': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/taro-h5': 4.2.1(f34d8cdf97f881ef22ee67df104951ae)
       axios: 1.17.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       babel-plugin-transform-taroapi: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
       base64-js: 1.5.1
@@ -51062,20 +51046,20 @@ snapshots:
       react: 18.3.1
       react-reconciler: 0.29.0(react@18.3.1)
 
-  '@tarojs/rn-runner@4.2.1(71131a4387a7ada6d0de339db9ba5848)':
+  '@tarojs/rn-runner@4.2.1(024e6177bafd7814f4512b88be8344bd)':
     dependencies:
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.63.1)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-json': 6.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/rn-style-transformer': 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(encoding@0.1.13)(postcss@8.5.28)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/rn-supporter': 4.2.1(5387e117e79f4faa8c4be336eab7c420)
+      '@tarojs/rn-supporter': 4.2.1(4e69551906908d89ed056164957f0abd)
       '@tarojs/rn-transformer': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
-      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
       fs-extra: 11.4.0
       lodash: 4.18.1
@@ -51106,20 +51090,20 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-runner@4.2.1(bcfbac0ffbc4d61f514d1c3790a58b63)':
+  '@tarojs/rn-runner@4.2.1(612ed2af818e08f79339a0be479f2c83)':
     dependencies:
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.63.1)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-json': 6.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/rn-style-transformer': 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(encoding@0.1.13)(postcss@8.5.28)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/rn-supporter': 4.2.1(5387e117e79f4faa8c4be336eab7c420)
+      '@tarojs/rn-supporter': 4.2.1(3cf8487eff69a72e4b91cf12d9b58b4c)
       '@tarojs/rn-transformer': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
-      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
       fs-extra: 11.4.0
       lodash: 4.18.1
@@ -51150,20 +51134,20 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-runner@4.2.1(ce7f44a63b1b8f76b38ca8ef20df15d9)':
+  '@tarojs/rn-runner@4.2.1(64ca070a9122359a1506e79e5c443a64)':
     dependencies:
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.63.1)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-json': 6.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/rn-style-transformer': 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(encoding@0.1.13)(postcss@8.5.28)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/rn-supporter': 4.2.1(56162062d9d5fbfa4b06c5618fc9331c)
+      '@tarojs/rn-supporter': 4.2.1(3cf8487eff69a72e4b91cf12d9b58b4c)
       '@tarojs/rn-transformer': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
-      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
+      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2)
       expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
       fs-extra: 11.4.0
       lodash: 4.18.1
@@ -51194,20 +51178,20 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-runner@4.2.1(fcff09d2ad0e5273de5a015f3fd0571d)':
+  '@tarojs/rn-runner@4.2.1(dc915ff486f034318f8fc16a63f43157)':
     dependencies:
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.63.1)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-json': 6.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-replace': 5.0.7(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/rn-style-transformer': 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(encoding@0.1.13)(postcss@8.5.28)(supports-color@10.2.2)(typescript@6.0.3)
-      '@tarojs/rn-supporter': 4.2.1(56162062d9d5fbfa4b06c5618fc9331c)
+      '@tarojs/rn-supporter': 4.2.1(4e69551906908d89ed056164957f0abd)
       '@tarojs/rn-transformer': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
-      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
+      babel-preset-taro: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2)
       expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
       fs-extra: 11.4.0
       lodash: 4.18.1
@@ -51265,7 +51249,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@tarojs/rn-supporter@4.2.1(5387e117e79f4faa8c4be336eab7c420)':
+  '@tarojs/rn-supporter@4.2.1(3cf8487eff69a72e4b91cf12d9b58b4c)':
     dependencies:
       '@react-native-community/cli-config': 12.3.7(encoding@0.1.13)
       '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
@@ -51275,7 +51259,7 @@ snapshots:
       '@tarojs/rn-transformer': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       babel-plugin-global-define: 1.0.3
       babel-plugin-jsx-attributes-array-to-object: 0.3.0
       babel-plugin-transform-react-jsx-to-rn-stylesheet: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
@@ -51309,7 +51293,7 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/rn-supporter@4.2.1(56162062d9d5fbfa4b06c5618fc9331c)':
+  '@tarojs/rn-supporter@4.2.1(4e69551906908d89ed056164957f0abd)':
     dependencies:
       '@react-native-community/cli-config': 12.3.7(encoding@0.1.13)
       '@react-native-community/cli-tools': 12.3.7(encoding@0.1.13)
@@ -51319,7 +51303,7 @@ snapshots:
       '@tarojs/rn-transformer': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/service': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       babel-plugin-global-define: 1.0.3
       babel-plugin-jsx-attributes-array-to-object: 0.3.0
       babel-plugin-transform-react-jsx-to-rn-stylesheet: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
@@ -51397,11 +51381,11 @@ snapshots:
       react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
     optional: true
 
-  '@tarojs/router@4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))':
+  '@tarojs/router@4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))':
     dependencies:
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       dingtalk-jsapi: 2.15.6
       history: 5.3.0
       mobile-detect: 1.4.5
@@ -51409,11 +51393,11 @@ snapshots:
       tslib: 2.8.1
       universal-router: 9.2.1
 
-  '@tarojs/router@4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))':
+  '@tarojs/router@4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))':
     dependencies:
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       dingtalk-jsapi: 2.15.6
       history: 5.3.0
       mobile-detect: 1.4.5
@@ -51430,9 +51414,46 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@tarojs/runtime-rn@4.2.1(256c9aa8529969b1fae0cdbe6f63c477)':
+  '@tarojs/runtime-rn@4.2.1(1e9a597af4b436f8aafd83165305b1fd)':
     dependencies:
-      '@tarojs/components-rn': 4.2.1(538c449ad6437b95e6db13f31eec1c5b)
+      '@tarojs/components-rn': 4.2.1(8095221785d4ff017a2edc5d5918b022)
+      '@tarojs/router-rn': 4.2.1(f4ee3e2183a8700254bd0fa426607c69)
+      '@tarojs/shared': 4.2.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-root-siblings: 5.0.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/helper'
+      - '@types/react'
+      - expo
+      - expo-av
+      - expo-camera
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/runtime-rn@4.2.1(559222e1bf3809b7947a717dbcbd8008)':
+    dependencies:
+      '@tarojs/components-rn': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(expo-av@13.10.6(expo@54.0.37))(expo-camera@14.1.3(expo@54.0.37))(expo@54.0.37)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(typescript@6.0.3)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/shared': 4.2.1
       react: 18.3.1
@@ -51468,9 +51489,47 @@ snapshots:
       - webpack-dev-server
     optional: true
 
-  '@tarojs/runtime-rn@4.2.1(27cb4f84af186dbc951e2cefc1d9c35f)':
+  '@tarojs/runtime-rn@4.2.1(597e9e60182ef2e3cdb67555fb258a75)':
     dependencies:
-      '@tarojs/components-rn': 4.2.1(2c7805a693769637d0f17e0b56b3652b)
+      '@tarojs/components-rn': 4.2.1(88bcf821003cf0192dba77b709d9ae08)
+      '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@tarojs/shared': 4.2.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-root-siblings: 5.0.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/helper'
+      - '@types/react'
+      - expo
+      - expo-av
+      - expo-camera
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-safe-area-context
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+    optional: true
+
+  '@tarojs/runtime-rn@4.2.1(62d80ffb910fdcbee3ef18e909016fa5)':
+    dependencies:
+      '@tarojs/components-rn': 4.2.1(7dd9358174ce14aa2b23b2e46486bfdd)
       '@tarojs/router-rn': 4.2.1(f4ee3e2183a8700254bd0fa426607c69)
       '@tarojs/shared': 4.2.1
       react: 18.3.1
@@ -51505,46 +51564,9 @@ snapshots:
       - webpack-chain
       - webpack-dev-server
 
-  '@tarojs/runtime-rn@4.2.1(34e1a581c5d4fe27af0c97068f310a76)':
+  '@tarojs/runtime-rn@4.2.1(66e80141915823d503e28feb65e2e7a1)':
     dependencies:
-      '@tarojs/components-rn': 4.2.1(b804624545cb105e79c0e0480282cac5)
-      '@tarojs/router-rn': 4.2.1(f4ee3e2183a8700254bd0fa426607c69)
-      '@tarojs/shared': 4.2.1
-      react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
-      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      react-native-root-siblings: 5.0.1
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - '@react-native-community/cameraroll'
-      - '@react-native-community/segmented-control'
-      - '@react-native-community/slider'
-      - '@react-native-picker/picker'
-      - '@tarojs/helper'
-      - '@types/react'
-      - expo
-      - expo-av
-      - expo-camera
-      - html-webpack-plugin
-      - postcss
-      - react-native-gesture-handler
-      - react-native-pager-view
-      - react-native-safe-area-context
-      - react-native-screens
-      - react-native-svg
-      - react-native-web
-      - react-native-webview
-      - rollup
-      - supports-color
-      - typescript
-      - vue
-      - webpack
-      - webpack-chain
-      - webpack-dev-server
-
-  '@tarojs/runtime-rn@4.2.1(38be1c6312e14d2466d3f4eb8211cf56)':
-    dependencies:
-      '@tarojs/components-rn': 4.2.1(7794d815aacbe440aaf39102e7ac9e8a)
+      '@tarojs/components-rn': 4.2.1(88bcf821003cf0192dba77b709d9ae08)
       '@tarojs/router-rn': 4.2.1(react-native-safe-area-context@4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@tarojs/shared': 4.2.1
       react: 18.3.1
@@ -51602,11 +51624,11 @@ snapshots:
 
   '@tarojs/shared@4.2.1': {}
 
-  '@tarojs/taro-h5@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))':
+  '@tarojs/taro-h5@4.2.1(907d5832c268f2734a50dfc59429c49a)':
     dependencies:
       '@tarojs/api': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
       abortcontroller-polyfill: 1.7.8
@@ -51622,11 +51644,11 @@ snapshots:
     transitivePeerDependencies:
       - '@tarojs/taro'
 
-  '@tarojs/taro-h5@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))':
+  '@tarojs/taro-h5@4.2.1(f34d8cdf97f881ef22ee67df104951ae)':
     dependencies:
       '@tarojs/api': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/router': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)(@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
       abortcontroller-polyfill: 1.7.8
@@ -51651,117 +51673,7 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072)':
-    dependencies:
-      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@tarojs/runtime-rn': 4.2.1(34e1a581c5d4fe27af0c97068f310a76)
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      base64-js: 1.5.1
-      deprecated-react-native-prop-types: 5.0.0
-      expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
-      expo-av: 13.10.6(expo@50.0.21)
-      expo-barcode-scanner: 12.9.3(expo@50.0.21)
-      expo-brightness: 11.8.0(expo@50.0.21)
-      expo-camera: 14.1.3(expo@50.0.21)
-      expo-file-system: 16.0.9(expo@50.0.21)
-      expo-image-picker: 14.7.1(expo@50.0.21)
-      expo-keep-awake: 12.8.2(expo@50.0.21)
-      expo-location: 16.5.5(expo@50.0.21)
-      expo-sensors: 12.9.1(expo@50.0.21)
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
-      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      react-native-root-siblings: 5.0.1
-      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - '@react-native-community/cameraroll'
-      - '@react-native-community/segmented-control'
-      - '@react-native-community/slider'
-      - '@react-native-picker/picker'
-      - '@tarojs/components'
-      - '@tarojs/helper'
-      - '@tarojs/shared'
-      - '@types/react'
-      - html-webpack-plugin
-      - postcss
-      - react-native-gesture-handler
-      - react-native-pager-view
-      - react-native-screens
-      - react-native-svg
-      - react-native-web
-      - react-native-webview
-      - rollup
-      - supports-color
-      - typescript
-      - vue
-      - webpack
-      - webpack-chain
-      - webpack-dev-server
-
-  '@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091)':
-    dependencies:
-      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@tarojs/runtime-rn': 4.2.1(27cb4f84af186dbc951e2cefc1d9c35f)
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
-      base64-js: 1.5.1
-      deprecated-react-native-prop-types: 5.0.0
-      expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
-      expo-av: 13.10.6(expo@50.0.21)
-      expo-barcode-scanner: 12.9.3(expo@50.0.21)
-      expo-brightness: 11.8.0(expo@50.0.21)
-      expo-camera: 14.1.3(expo@50.0.21)
-      expo-file-system: 16.0.9(expo@50.0.21)
-      expo-image-picker: 14.7.1(expo@50.0.21)
-      expo-keep-awake: 12.8.2(expo@50.0.21)
-      expo-location: 16.5.5(expo@50.0.21)
-      expo-sensors: 12.9.1(expo@50.0.21)
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
-      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-      react-native-root-siblings: 5.0.1
-      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - '@react-native-community/cameraroll'
-      - '@react-native-community/segmented-control'
-      - '@react-native-community/slider'
-      - '@react-native-picker/picker'
-      - '@tarojs/components'
-      - '@tarojs/helper'
-      - '@tarojs/shared'
-      - '@types/react'
-      - html-webpack-plugin
-      - postcss
-      - react-native-gesture-handler
-      - react-native-pager-view
-      - react-native-screens
-      - react-native-svg
-      - react-native-web
-      - react-native-webview
-      - rollup
-      - supports-color
-      - typescript
-      - vue
-      - webpack
-      - webpack-chain
-      - webpack-dev-server
-
-  '@tarojs/taro-rn@4.2.1(35e9ddb42b304e587abd6a4670c1785d)':
+  '@tarojs/taro-rn@4.2.1(84cc1a49136a536920638c449c2cac59)':
     dependencies:
       '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
@@ -51769,8 +51681,8 @@ snapshots:
       '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@tarojs/runtime-rn': 4.2.1(38be1c6312e14d2466d3f4eb8211cf56)
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/runtime-rn': 4.2.1(597e9e60182ef2e3cdb67555fb258a75)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       base64-js: 1.5.1
       deprecated-react-native-prop-types: 5.0.0
       expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
@@ -51817,7 +51729,7 @@ snapshots:
       - webpack-dev-server
     optional: true
 
-  '@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa)':
+  '@tarojs/taro-rn@4.2.1(94183b8aa15bb12d2f67e255951d0483)':
     dependencies:
       '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
@@ -51825,8 +51737,8 @@ snapshots:
       '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
       '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
-      '@tarojs/runtime-rn': 4.2.1(256c9aa8529969b1fae0cdbe6f63c477)
-      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/runtime-rn': 4.2.1(66e80141915823d503e28feb65e2e7a1)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       base64-js: 1.5.1
       deprecated-react-native-prop-types: 5.0.0
       expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
@@ -51873,10 +51785,176 @@ snapshots:
       - webpack-dev-server
     optional: true
 
-  '@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/taro-rn@4.2.1(c0a92e4bab5da598264e0c017d407e00)':
+    dependencies:
+      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@tarojs/runtime-rn': 4.2.1(559222e1bf3809b7947a717dbcbd8008)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 5.0.0
+      expo: 54.0.37(@babel/core@7.29.7(supports-color@10.2.2))(@expo/metro-runtime@6.1.2)(graphql@15.8.0)(react-native-webview@13.6.4(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)(typescript@6.0.3)
+      expo-av: 13.10.6(expo@54.0.37)
+      expo-barcode-scanner: 12.9.3(expo@54.0.37)
+      expo-brightness: 11.8.0(expo@54.0.37)
+      expo-camera: 14.1.3(expo@54.0.37)
+      expo-file-system: 16.0.9(expo@54.0.37)
+      expo-image-picker: 14.7.1(expo@54.0.37)
+      expo-keep-awake: 12.8.2(expo@54.0.37)
+      expo-location: 16.5.5(expo@54.0.37)
+      expo-sensors: 12.9.1(expo@54.0.37)
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      react-native-root-siblings: 5.0.1
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/components'
+      - '@tarojs/helper'
+      - '@tarojs/shared'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+    optional: true
+
+  '@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa)':
+    dependencies:
+      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@tarojs/runtime-rn': 4.2.1(1e9a597af4b436f8aafd83165305b1fd)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 5.0.0
+      expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
+      expo-av: 13.10.6(expo@50.0.21)
+      expo-barcode-scanner: 12.9.3(expo@50.0.21)
+      expo-brightness: 11.8.0(expo@50.0.21)
+      expo-camera: 14.1.3(expo@50.0.21)
+      expo-file-system: 16.0.9(expo@50.0.21)
+      expo-image-picker: 14.7.1(expo@50.0.21)
+      expo-keep-awake: 12.8.2(expo@50.0.21)
+      expo-location: 16.5.5(expo@50.0.21)
+      expo-sensors: 12.9.1(expo@50.0.21)
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      react-native-root-siblings: 5.0.1
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/components'
+      - '@tarojs/helper'
+      - '@tarojs/shared'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae)':
+    dependencies:
+      '@bam.tech/react-native-image-resizer': 3.0.11(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 1.21.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-camera-roll/camera-roll': 7.10.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@react-native-clipboard/clipboard': 1.16.3(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/geolocation': 3.4.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      '@react-native-community/netinfo': 11.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      '@tarojs/runtime-rn': 4.2.1(62d80ffb910fdcbee3ef18e909016fa5)
+      '@tarojs/taro': 4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      base64-js: 1.5.1
+      deprecated-react-native-prop-types: 5.0.0
+      expo: 50.0.21(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(bluebird@3.7.2)(encoding@0.1.13)(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
+      expo-av: 13.10.6(expo@50.0.21)
+      expo-barcode-scanner: 12.9.3(expo@50.0.21)
+      expo-brightness: 11.8.0(expo@50.0.21)
+      expo-camera: 14.1.3(expo@50.0.21)
+      expo-file-system: 16.0.9(expo@50.0.21)
+      expo-image-picker: 14.7.1(expo@50.0.21)
+      expo-keep-awake: 12.8.2(expo@50.0.21)
+      expo-location: 16.5.5(expo@50.0.21)
+      expo-sensors: 12.9.1(expo@50.0.21)
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-native: 0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2)
+      react-native-device-info: 14.1.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))
+      react-native-image-zoom-viewer: 3.0.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+      react-native-root-siblings: 5.0.1
+      react-native-safe-area-context: 4.8.2(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@react-native-community/cameraroll'
+      - '@react-native-community/segmented-control'
+      - '@react-native-community/slider'
+      - '@react-native-picker/picker'
+      - '@tarojs/components'
+      - '@tarojs/helper'
+      - '@tarojs/shared'
+      - '@types/react'
+      - html-webpack-plugin
+      - postcss
+      - react-native-gesture-handler
+      - react-native-pager-view
+      - react-native-screens
+      - react-native-svg
+      - react-native-web
+      - react-native-webview
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+      - webpack
+      - webpack-chain
+      - webpack-dev-server
+
+  '@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@tarojs/api': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
@@ -51885,16 +51963,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
       html-webpack-plugin: 5.6.8(@rspack/core@1.7.11(@swc/helpers@0.5.23))(webpack@5.105.4)
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       vue: 3.5.42(typescript@6.0.3)
       webpack: 5.105.4(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.21.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3)
       webpack-chain: 6.5.1
       webpack-dev-server: 4.15.2(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(webpack-cli@7.2.3)(webpack@5.105.4)
 
-  '@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
+  '@tarojs/taro@4.2.1(@tarojs/components@4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4))(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@tarojs/shared@4.2.1)(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)':
     dependencies:
       '@tarojs/api': 4.2.1(@tarojs/runtime@4.2.1)(@tarojs/shared@4.2.1)
-      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1)(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
+      '@tarojs/components': 4.2.1(@tarojs/helper@4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2))(@types/react@19.2.18)(html-webpack-plugin@5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4))(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vue@3.5.42(typescript@6.0.3))(webpack-chain@6.5.1)(webpack-dev-server@4.15.2)(webpack@5.105.4)
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/runtime': 4.2.1
       '@tarojs/shared': 4.2.1
@@ -51903,20 +51981,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
       html-webpack-plugin: 5.6.8(@rspack/core@2.2.2(@swc/helpers@0.5.23))(webpack@5.105.4)
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       vue: 3.5.42(typescript@6.0.3)
       webpack: 5.105.4(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3)
       webpack-chain: 6.5.1
       webpack-dev-server: 4.15.2(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(webpack-cli@7.2.3)(webpack@5.105.4)
 
-  '@tarojs/vite-runner@4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))':
+  '@tarojs/vite-runner@4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@4.5.14(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.63.1)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.63.1)
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-terser': 0.4.4(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/parse-css-to-stylesheet': 0.0.69
       '@tarojs/runner-utils': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -51957,14 +52035,14 @@ snapshots:
       - tsx
       - typescript
 
-  '@tarojs/vite-runner@4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1)(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))':
+  '@tarojs/vite-runner@4.2.1(@swc/helpers@0.5.23)(@tarojs/runtime@4.2.1)(@types/babel__core@7.20.5)(jiti@2.7.0)(postcss@8.5.28)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vite@5.4.21(@types/node@26.5.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1)(supports-color@10.2.2)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.63.1)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.63.1)
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-terser': 0.4.4(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
       '@tarojs/parse-css-to-stylesheet': 0.0.69
       '@tarojs/runner-utils': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
@@ -53285,12 +53363,12 @@ snapshots:
 
   '@ungap/structured-clone@1.4.0': {}
 
-  '@unhead/bundler@3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(unhead@3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)':
+  '@unhead/bundler@3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(unhead@3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)':
     dependencies:
       magic-string: 1.2.3
       oxc-walker: 1.1.1(@oxc-project/types@0.149.0)(oxc-parser@0.149.0)(rolldown@1.2.7)
-      unhead: 3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unhead: 3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
     optionalDependencies:
       esbuild: 0.28.2
       lightningcss: 1.33.0
@@ -53306,12 +53384,12 @@ snapshots:
       - rollup
       - unloader
 
-  '@unhead/vue@3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)':
+  '@unhead/vue@3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)':
     dependencies:
-      '@unhead/bundler': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(unhead@3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      '@unhead/bundler': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(unhead@3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       hookable: 6.1.1
-      unhead: 3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unhead: 3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       vue: 3.5.42(typescript@6.0.3)
     optionalDependencies:
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
@@ -53414,10 +53492,10 @@ snapshots:
 
   '@vercel/detect-agent@1.2.5': {}
 
-  '@vercel/nft@1.11.0(encoding@0.1.13)(rollup@4.63.1)(supports-color@10.2.2)':
+  '@vercel/nft@1.11.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3(encoding@0.1.13)(supports-color@10.2.2)
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@mapbox/node-pre-gyp': 2.0.3(supports-color@10.2.2)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       acorn: 8.18.0
       acorn-import-attributes: 1.9.5(acorn@8.18.0)
       async-sema: 3.1.1
@@ -54640,7 +54718,7 @@ snapshots:
     dependencies:
       '@weapp-core/schematics': 6.2.2
 
-  '@weapp-vite/web@1.4.21(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)':
+  '@weapp-vite/web@1.4.21(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0)':
     dependencies:
       '@babel/parser': 8.0.4
       '@babel/traverse': 8.0.4
@@ -54656,8 +54734,8 @@ snapshots:
       postcss: 8.5.28
       postcss-selector-parser: 7.1.6
       rolldown: 1.2.7
-      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1)
-      wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)
+      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0)
     transitivePeerDependencies:
       - '@babel/core'
       - miniprogram-api-typings
@@ -54749,7 +54827,7 @@ snapshots:
     optionalDependencies:
       vitest: 5.0.0(@types/node@26.5.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(jsdom@29.1.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
 
-  '@wevu/compiler@7.0.4(@babel/core@8.0.1)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)':
+  '@wevu/compiler@7.0.4(@babel/core@8.0.1)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)':
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@vue/babel-plugin-jsx': 3.0.0(@babel/core@8.0.1)
@@ -54765,7 +54843,7 @@ snapshots:
       pathe: 2.0.3
       postcss: 8.5.28
       postcss-selector-parser: 7.1.6
-      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1)
+      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       vue: 3.5.42(typescript@6.0.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -55981,7 +56059,7 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@8.0.1)
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(84cc1a49136a536920638c449c2cac59))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56000,7 +56078,7 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(085699df9dd20ac452327c67c904a072)
+      '@tarojs/taro-rn': 4.2.1(84cc1a49136a536920638c449c2cac59)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.14.2
     transitivePeerDependencies:
@@ -56010,7 +56088,7 @@ snapshots:
       - metro-react-native-babel-preset
       - supports-color
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(085699df9dd20ac452327c67c904a072))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(94183b8aa15bb12d2f67e255951d0483))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56029,7 +56107,36 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(085699df9dd20ac452327c67c904a072)
+      '@tarojs/taro-rn': 4.2.1(94183b8aa15bb12d2f67e255951d0483)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-typescript'
+      - '@react-native/babel-preset'
+      - '@swc/helpers'
+      - metro-react-native-babel-preset
+      - supports-color
+
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(c0a92e4bab5da598264e0c017d407e00))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/runtime': 7.29.7
+      '@babel/runtime-corejs3': 7.29.7
+      '@rnx-kit/babel-preset-metro-react-native': 1.1.8(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/runtime@7.29.7)(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
+      '@tarojs/helper': 4.2.1(@swc/helpers@0.5.23)(supports-color@10.2.2)
+      babel-plugin-dynamic-import-node: 2.3.3
+      babel-plugin-transform-imports-api: 1.0.0
+      babel-plugin-transform-solid-jsx: 4.2.1(@babel/core@7.29.7(supports-color@10.2.2))
+      core-js: 3.50.0
+    optionalDependencies:
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@tarojs/taro-rn': 4.2.1(c0a92e4bab5da598264e0c017d407e00)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -56039,7 +56146,7 @@ snapshots:
       - metro-react-native-babel-preset
       - supports-color
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56058,7 +56165,7 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(1da657eeb07dd0ca13856389960c4091)
+      '@tarojs/taro-rn': 4.2.1(cbb84af26c141d75c2b8f7138f1b90fa)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.14.2
     transitivePeerDependencies:
@@ -56068,7 +56175,7 @@ snapshots:
       - metro-react-native-babel-preset
       - supports-color
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(1da657eeb07dd0ca13856389960c4091))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(cbb84af26c141d75c2b8f7138f1b90fa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56087,7 +56194,7 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(1da657eeb07dd0ca13856389960c4091)
+      '@tarojs/taro-rn': 4.2.1(cbb84af26c141d75c2b8f7138f1b90fa)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -56097,7 +56204,7 @@ snapshots:
       - metro-react-native-babel-preset
       - supports-color
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(35e9ddb42b304e587abd6a4670c1785d))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.14.2)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56116,7 +56223,7 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(35e9ddb42b304e587abd6a4670c1785d)
+      '@tarojs/taro-rn': 4.2.1(d183b15501574718df48af50655c2fae)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.14.2
     transitivePeerDependencies:
@@ -56126,7 +56233,7 @@ snapshots:
       - metro-react-native-babel-preset
       - supports-color
 
-  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
+  babel-preset-taro@4.2.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@react-native/babel-preset@0.81.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@swc/helpers@0.5.23)(@tarojs/taro-rn@4.2.1(d183b15501574718df48af50655c2fae))(@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(metro-react-native-babel-preset@0.77.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-refresh@0.18.0)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -56145,7 +56252,7 @@ snapshots:
       core-js: 3.50.0
     optionalDependencies:
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@tarojs/taro-rn': 4.2.1(965eb9836ad3c4d32d1129f6c85ed2aa)
+      '@tarojs/taro-rn': 4.2.1(d183b15501574718df48af50655c2fae)
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       react-refresh: 0.18.0
     transitivePeerDependencies:
@@ -62867,12 +62974,12 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
-  impound@1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  impound@1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       es-module-lexer: 2.3.2
       pathe: 2.0.3
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       unplugin-utils: 0.3.2
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -66848,17 +66955,17 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(encoding@0.1.13)(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  nitropack@2.13.4(@parcel/watcher@2.6.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(oxc-parser@0.149.0)(rolldown@1.2.7)(srvx@0.11.22)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(rollup@4.63.1)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.63.1)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.63.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.63.1)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.63.1)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.63.1)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.63.1)
-      '@vercel/nft': 1.11.0(encoding@0.1.13)(rollup@4.63.1)(supports-color@10.2.2)
+      '@rollup/plugin-alias': 6.0.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-commonjs': 29.0.3(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-inject': 5.0.5(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-json': 6.1.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-replace': 6.0.3(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@rollup/plugin-terser': 1.0.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      '@vercel/nft': 1.11.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)
       archiver: 7.0.1
       c12: 3.3.4(magicast@0.5.4)
       chokidar: 5.0.0
@@ -66900,8 +67007,8 @@ snapshots:
       pkg-types: 2.3.3
       pretty-bytes: 7.1.2
       radix3: 1.1.2
-      rollup: 4.63.1
-      rollup-plugin-visualizer: 7.1.1(rolldown@1.2.7)(rollup@4.63.1)
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
+      rollup-plugin-visualizer: 7.1.1(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       scule: 1.3.0
       semver: 7.8.5
       serve-placeholder: 2.0.2
@@ -66913,7 +67020,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unimport: 6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       unplugin-utils: 0.3.2
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
@@ -67214,17 +67321,17 @@ snapshots:
 
   number-is-nan@1.0.1: {}
 
-  nuxt@4.5.2(eea432f0be145ee388fe177e665862c9):
+  nuxt@4.5.2(4f93883d3d0f3f89f0c35d187057e72e):
     dependencies:
-      '@dxup/nuxt': 0.5.10(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      '@dxup/nuxt': 0.5.10(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(@parcel/watcher@2.6.0)(cac@6.7.14)(commander@15.0.0)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.2(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(supports-color@10.2.2)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
-      '@nuxt/nitro-server': 4.5.2(7381fefd0087dd48fe01f9b88282477b)
+      '@nuxt/devtools': 3.4.2(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(supports-color@10.2.2)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/nitro-server': 4.5.2(4233bbbb327a90f49fa44d298cdd5a65)
       '@nuxt/schema': 4.5.2
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))
-      '@nuxt/vite-builder': 4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(eea432f0be145ee388fe177e665862c9))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1))(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)
-      '@unhead/vue': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))
+      '@nuxt/vite-builder': 4.5.2(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@8.0.1(@babel/core@7.29.7(supports-color@10.2.2)))(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(less@4.6.6)(magic-string@1.2.3)(magicast@0.5.4)(meow@14.1.0)(nuxt@4.5.2(4f93883d3d0f3f89f0c35d187057e72e))(optionator@0.9.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)))(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(sass-embedded@1.104.0)(sass@1.104.0)(stylelint@17.15.0(supports-color@10.2.2)(typescript@6.0.3))(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(terser@5.51.2)(tsx@4.23.13)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)(yaml@2.9.0)
+      '@unhead/vue': 3.4.0(@oxc-project/types@0.149.0)(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
       '@vue/shared': 3.5.42
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -67238,7 +67345,7 @@ snapshots:
       fnv1a-64: 0.1.2
       hookable: 6.1.1
       ignore: 7.0.7
-      impound: 1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      impound: 1.2.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -67265,17 +67372,17 @@ snapshots:
       ufo: 1.6.4
       ultrahtml: 1.7.0
       uncrypto: 0.1.3
-      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      unctx: 3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       undici: 8.10.2
-      unhead: 3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
-      unimport: 6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unhead: 3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unimport: 6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       unrouting: 0.2.3
       untyped: 2.0.0
       verkit: 0.3.2
       vue: 3.5.42(typescript@6.0.3)
       vue-component-type-helpers: 3.3.11
-      vue-router: 5.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
+      vue-router: 5.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4)
     optionalDependencies:
       '@parcel/watcher': 2.6.0
       '@types/node': 26.5.0
@@ -67702,6 +67809,12 @@ snapshots:
   oxc-walker@1.1.1(@oxc-project/types@0.148.0)(oxc-parser@0.148.0)(rolldown@1.2.7):
     optionalDependencies:
       '@oxc-project/types': 0.148.0
+      oxc-parser: 0.148.0
+      rolldown: 1.2.7
+
+  oxc-walker@1.1.1(@oxc-project/types@0.149.0)(oxc-parser@0.148.0)(rolldown@1.2.7):
+    optionalDependencies:
+      '@oxc-project/types': 0.149.0
       oxc-parser: 0.148.0
       rolldown: 1.2.7
 
@@ -70130,9 +70243,9 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)):
+  react-native-device-info@14.1.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)):
     dependencies:
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native-gesture-handler@2.14.1(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1):
     dependencies:
@@ -70155,7 +70268,7 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-gesture-handler@2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-gesture-handler@2.14.1(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
@@ -70163,7 +70276,7 @@ snapshots:
       lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native-image-pan-zoom@2.1.12(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1):
     dependencies:
@@ -70247,10 +70360,10 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-safe-area-context@4.8.2(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native-screens@3.29.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1):
     dependencies:
@@ -70267,11 +70380,11 @@ snapshots:
       warn-once: 0.1.1
     optional: true
 
-  react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-screens@3.29.0(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-freeze: 1.0.4(react@19.2.8)
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
       warn-once: 0.1.1
 
   react-native-svg-transformer@1.5.3(react-native-svg@14.1.0(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(react@18.3.1))(react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
@@ -70362,12 +70475,12 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
     optional: true
 
-  react-native-webview@13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
+  react-native-webview@13.6.4(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8):
     dependencies:
       escape-string-regexp: 2.0.0
       invariant: 2.2.4
       react: 19.2.8
-      react-native: 0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
+      react-native: 0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
 
   react-native@0.73.11(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(encoding@0.1.13)(react@18.3.1)(supports-color@10.2.2):
     dependencies:
@@ -70610,16 +70723,16 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2):
+  react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.6
       '@react-native/codegen': 0.81.6(@babel/core@8.0.1)
-      '@react-native/community-cli-plugin': 0.81.6(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
+      '@react-native/community-cli-plugin': 0.81.6(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@7.29.7(supports-color@10.2.2))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
       '@react-native/gradle-plugin': 0.81.6
       '@react-native/js-polyfills': 0.81.6
       '@react-native/normalize-colors': 0.81.6
-      '@react-native/virtualized-lists': 0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@react-native-community/cli@12.3.7(encoding@0.1.13)(supports-color@10.2.2))(@react-native/metro-config@0.73.5(@babel/core@8.0.1)(@babel/preset-env@7.29.7(@babel/core@8.0.1)(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
+      '@react-native/virtualized-lists': 0.81.6(@types/react@19.2.18)(react-native@0.81.6(@babel/core@8.0.1)(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2))(react@19.2.8)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -71387,9 +71500,9 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-require@2.0.28(rolldown@1.2.7)(rollup@4.63.1):
+  rolldown-require@2.0.28(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)):
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       get-tsconfig: 4.14.3
       rolldown: 1.2.7
     transitivePeerDependencies:
@@ -71449,7 +71562,7 @@ snapshots:
       rollup: 2.75.6
       rollup-pluginutils: 2.8.2
 
-  rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1):
+  rollup-plugin-visualizer@7.1.1(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.7
@@ -71457,7 +71570,7 @@ snapshots:
       yargs: 18.1.0
     optionalDependencies:
       rolldown: 1.2.7
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -71525,7 +71638,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.63.0
       fsevents: 2.3.3
 
-  rollup@4.63.1:
+  rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0):
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
@@ -74236,20 +74349,20 @@ snapshots:
       magic-string: 0.30.21
       unplugin: 2.3.11
 
-  unctx@3.0.1(magic-string@1.2.3)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)):
+  unctx@3.0.1(magic-string@1.2.3)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)):
     optionalDependencies:
       magic-string: 1.2.3
       oxc-parser: 0.148.0
       rolldown: 1.2.7
-      unplugin: 3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
     optional: true
 
-  unctx@3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)):
+  unctx@3.0.1(magic-string@1.2.3)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)):
     optionalDependencies:
       magic-string: 1.2.3
       oxc-parser: 0.149.0
       rolldown: 1.2.7
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
 
   undertaker-registry@2.0.0: {}
 
@@ -74282,10 +74395,10 @@ snapshots:
     dependencies:
       string.fromcodepoint: 0.2.1
 
-  unhead@3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  unhead@3.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       hookable: 6.1.1
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
     optionalDependencies:
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -74359,7 +74472,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.2.5
 
-  unimport@6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  unimport@6.4.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(oxc-parser@0.149.0)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       acorn: 8.18.0
       escape-string-regexp: 5.0.0
@@ -74373,7 +74486,7 @@ snapshots:
       scule: 1.3.0
       strip-literal: 4.0.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       unplugin-utils: 0.3.2
     optionalDependencies:
       oxc-parser: 0.149.0
@@ -74479,7 +74592,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-auto-import@19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3))):
+  unplugin-auto-import@19.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(@vueuse/core@14.2.1(vue@3.5.42(typescript@6.0.3))):
     dependencies:
       local-pkg: 1.2.1
       magic-string: 0.30.21
@@ -74488,7 +74601,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.2.5
     optionalDependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
       '@vueuse/core': 14.2.1(vue@3.5.42(typescript@6.0.3))
 
   unplugin-utils@0.2.5:
@@ -74538,7 +74651,7 @@ snapshots:
       picomatch: 4.0.7
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.7
@@ -74547,12 +74660,12 @@ snapshots:
       '@rspack/core': 2.2.2(@swc/helpers@0.5.23)
       esbuild: 0.28.2
       rolldown: 1.2.7
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3)
     optional: true
 
-  unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.7
@@ -74561,11 +74674,11 @@ snapshots:
       '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       esbuild: 0.28.2
       rolldown: 1.2.7
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3)
 
-  unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
+  unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.7
@@ -74574,7 +74687,7 @@ snapshots:
       '@rspack/core': 2.2.3(@swc/helpers@0.5.23)
       esbuild: 0.28.2
       rolldown: 1.2.7
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.16.2(@swc/helpers@0.5.23))(clean-css@5.3.3)(cssnano@8.0.10(postcss@8.5.28))(csso@5.0.5)(esbuild@0.28.2)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.28)(uglify-js@3.19.3)(webpack-cli@7.2.3)
 
@@ -74979,10 +75092,10 @@ snapshots:
       typescript: 6.0.3
       vue-tsc: 3.3.11(typescript@6.0.3)
 
-  vite-plugin-dts@4.5.4(@types/node@26.5.0)(rollup@4.63.1)(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+  vite-plugin-dts@4.5.4(@types/node@26.5.0)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(supports-color@10.2.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@26.5.0)
-      '@rollup/pluginutils': 5.4.0(rollup@4.63.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       '@volar/typescript': 2.4.28(typescript@6.0.3)
       '@vue/language-core': 2.2.0(typescript@6.0.3)
       compare-versions: 6.1.1
@@ -74998,7 +75111,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+  vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
       ansis: 4.3.0
       error-stack-parser-es: 1.0.5
@@ -75011,9 +75124,9 @@ snapshots:
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-dev-rpc: 2.0.0(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
     optionalDependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.148.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.2(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
 
-  vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+  vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
       ansis: 4.3.0
       error-stack-parser-es: 1.0.5
@@ -75026,7 +75139,7 @@ snapshots:
       vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
       vite-dev-rpc: 2.0.0(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
     optionalDependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.149.0)(rolldown@1.2.7)(unplugin@3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4))
 
   vite-plugin-performance@2.0.1: {}
 
@@ -75112,7 +75225,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.28
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
     optionalDependencies:
       '@types/node': 26.5.0
       fsevents: 2.3.3
@@ -75129,7 +75242,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.7)
       picomatch: 4.0.7
       postcss: 8.5.28
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.5.0
@@ -75171,7 +75284,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.28
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 26.5.0
@@ -75192,7 +75305,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.28
-      rollup: 4.63.1
+      rollup: 4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 26.5.0
@@ -75575,7 +75688,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.42(typescript@6.0.3)
 
-  vue-router@5.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4):
+  vue-router@5.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(@vue/compiler-sfc@3.5.42)(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))(webpack@5.105.4):
     dependencies:
       '@vue-macros/common': 3.1.4(vue@3.5.42(typescript@6.0.3))
       '@vue/devtools-api': 8.2.1
@@ -75591,7 +75704,7 @@ snapshots:
       picomatch: 4.0.7
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1)(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin: 3.3.0(@rspack/core@2.2.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(less@4.6.6)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(webpack@5.105.4)
       unplugin-utils: 0.3.2
       vue: 3.5.42(typescript@6.0.3)
     optionalDependencies:
@@ -75749,7 +75862,45 @@ snapshots:
       - tailwindcss
       - tsx
 
-  weapp-vite@7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0):
+  weapp-tailwindcss@5.5.1(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(jiti@2.7.0)(rolldown@1.2.7)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.13)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@tailwindcss-mangle/engine': 0.2.0(tailwindcss@4.3.3)
+      '@vue/compiler-dom': 3.5.42
+      '@weapp-core/escape': 8.0.0
+      '@weapp-tailwindcss/logger': 2.0.3
+      '@weapp-tailwindcss/postcss': 3.3.2(jiti@2.7.0)(tailwindcss@4.3.3)(tsx@4.23.13)(yaml@2.9.0)
+      '@weapp-tailwindcss/reset': 0.1.4(tailwindcss@4.3.3)
+      '@weapp-tailwindcss/shared': 2.0.3
+      comment-json: 5.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      fast-glob: 3.3.3
+      htmlparser2: 12.0.0
+      lightningcss: 1.33.0
+      local-pkg: 1.2.1
+      lru-cache: 11.5.2
+      magic-string: 1.2.3
+      micromatch: 4.0.8
+      oxc-parser: 0.148.0
+      oxc-walker: 1.1.1(@oxc-project/types@0.149.0)(oxc-parser@0.148.0)(rolldown@1.2.7)
+      semver: 7.8.5
+      tailwindcss-config: 2.0.4
+      weapp-style-injector: 1.0.4
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mpxjs/webpack-plugin': 2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@oxc-project/types'
+      - jiti
+      - rolldown
+      - supports-color
+      - tailwindcss
+      - tsx
+
+  weapp-vite@7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0):
     dependencies:
       '@babel/preset-env': 8.0.2(@babel/core@8.0.1)
       '@babel/preset-typescript': 8.0.1(@babel/core@8.0.1)
@@ -75768,7 +75919,7 @@ snapshots:
       '@weapp-vite/mcp': 1.5.1(@types/node@26.5.0)(hono@4.13.0)
       '@weapp-vite/miniprogram-automator': 1.2.16(@types/node@26.5.0)
       '@weapp-vite/volar': 2.1.6
-      '@weapp-vite/web': 1.4.21(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)
+      '@weapp-vite/web': 1.4.21(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0)
       '@wevu/api': 0.3.0(vitest@5.0.0)
       '@wevu/web-apis': 1.2.40(vitest@5.0.0)
       cac: 7.0.0
@@ -75788,7 +75939,7 @@ snapshots:
       postcss: 8.5.28
       rolldown: 1.2.7
       rolldown-plugin-dts: 0.28.5(@volar/typescript@2.4.28(typescript@6.0.3))(oxc-resolver@11.21.2)(rolldown@1.2.7)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))
-      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1)
+      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
       semver: 7.8.5
       typescript: 6.0.3
       vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
@@ -75798,7 +75949,88 @@ snapshots:
       vue-tsc: 3.3.11(typescript@6.0.3)
       weapp-ide-cli: 6.1.2(@types/node@26.5.0)
       weapp-tailwindcss: 5.5.1(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.148.0)(jiti@2.7.0)(rolldown@1.2.7)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.13)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
-      wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0)
+      wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0)
+    optionalDependencies:
+      '@swc/core': 1.16.1(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@mpxjs/webpack-plugin'
+      - '@oxc-project/types'
+      - '@swc/helpers'
+      - '@types/node'
+      - '@typescript/native-preview'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - eslint
+      - hono
+      - jiti
+      - less
+      - miniprogram-api-typings
+      - oxc-resolver
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - tailwindcss
+      - terser
+      - tsx
+      - utf-8-validate
+      - vitest
+      - yaml
+
+  weapp-vite@7.0.4(@babel/core@8.0.1)(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(@swc/helpers@0.5.23)(@types/node@26.5.0)(esbuild@0.28.2)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(hono@4.13.0)(jiti@2.7.0)(less@4.6.6)(miniprogram-api-typings@5.2.3)(oxc-resolver@11.21.2)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.3.3)(terser@5.51.2)(tsx@4.23.13)(vitest@5.0.0)(yaml@2.9.0):
+    dependencies:
+      '@babel/preset-env': 8.0.2(@babel/core@8.0.1)
+      '@babel/preset-typescript': 8.0.1(@babel/core@8.0.1)
+      '@jridgewell/remapping': 2.3.5
+      '@vercel/detect-agent': 1.2.5
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
+      '@vue/language-core': 3.3.11
+      '@weapp-core/constants': 0.2.1
+      '@weapp-core/init': 6.0.17
+      '@weapp-core/logger': 3.1.1
+      '@weapp-core/schematics': 6.2.2
+      '@weapp-core/shared': 3.2.1
+      '@weapp-vite/ast': 7.0.4(rolldown@1.2.7)
+      '@weapp-vite/eslint': 0.2.3(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@weapp-vite/i18n': 0.2.1(miniprogram-api-typings@5.2.3)
+      '@weapp-vite/mcp': 1.5.1(@types/node@26.5.0)(hono@4.13.0)
+      '@weapp-vite/miniprogram-automator': 1.2.16(@types/node@26.5.0)
+      '@weapp-vite/volar': 2.1.6
+      '@weapp-vite/web': 1.4.21(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0)
+      '@wevu/api': 0.3.0(vitest@5.0.0)
+      '@wevu/web-apis': 1.2.40(vitest@5.0.0)
+      cac: 7.0.0
+      chokidar: 5.0.0
+      comment-json: 5.0.0
+      fdir: 6.5.0(picomatch@4.0.7)
+      htmlparser2: 12.0.0
+      local-pkg: 1.2.1
+      lru-cache: 11.5.2
+      magic-string: 1.2.3
+      merge: 2.1.1
+      obug: 2.1.4
+      p-queue: 9.3.3
+      package-manager-detector: 1.8.0
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      postcss: 8.5.28
+      rolldown: 1.2.7
+      rolldown-plugin-dts: 0.28.5(@volar/typescript@2.4.28(typescript@6.0.3))(oxc-resolver@11.21.2)(rolldown@1.2.7)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))
+      rolldown-require: 2.0.28(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))
+      semver: 7.8.5
+      typescript: 6.0.3
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      vite-plugin-performance: 2.0.1
+      vite-tsconfig-paths: 6.1.1(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      vue: 3.5.42(typescript@6.0.3)
+      vue-tsc: 3.3.11(typescript@6.0.3)
+      weapp-ide-cli: 6.1.2(@types/node@26.5.0)
+      weapp-tailwindcss: 5.5.1(@mpxjs/webpack-plugin@2.11.1(@mpxjs/core@2.11.1)(supports-color@10.2.2)(vue@2.7.16)(webpack@5.105.4))(@oxc-project/types@0.149.0)(jiti@2.7.0)(rolldown@1.2.7)(supports-color@10.2.2)(tailwindcss@4.3.3)(tsx@4.23.13)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.6)(sass-embedded@1.104.0)(sass@1.104.0)(stylus@0.63.0(supports-color@10.2.2))(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      wevu: 7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0)
     optionalDependencies:
       '@swc/core': 1.16.1(@swc/helpers@0.5.23)
     transitivePeerDependencies:
@@ -76637,12 +76869,12 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
-  wevu@7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)(vitest@5.0.0):
+  wevu@7.0.4(@babel/core@8.0.1)(miniprogram-api-typings@5.2.3)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)(vitest@5.0.0):
     dependencies:
       '@weapp-core/constants': 0.2.1
       '@weapp-core/shared': 3.2.1
       '@wevu/api': 0.3.0(vitest@5.0.0)
-      '@wevu/compiler': 7.0.4(@babel/core@8.0.1)(rolldown@1.2.7)(rollup@4.63.1)(typescript@6.0.3)
+      '@wevu/compiler': 7.0.4(@babel/core@8.0.1)(rolldown@1.2.7)(rollup@4.63.1(patch_hash=c8c92d871ccf0418d1ba8b1f11a3371b706a1787f102194edb01d655e1ae84e0))(typescript@6.0.3)
       '@wevu/web-apis': 1.2.40(vitest@5.0.0)
       miniprogram-api-typings: 5.2.3
       vue: 3.5.42(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4764,7 +4764,7 @@ importers:
         specifier: ^4.9.0
         version: 4.9.0
       postcss-calc:
-        specifier: link:../postcss-calc
+        specifier: link:packages/postcss-calc
         version: link:../postcss-calc
       postcss-custom-properties:
         specifier: ^15.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -390,3 +390,4 @@ catalogs:
 
 patchedDependencies:
   rollup@4.63.0: patches/rollup@4.63.0.patch
+  rollup@4.63.1: patches/rollup@4.63.1.patch

--- a/scripts/ci/demo-matrix/gate.mjs
+++ b/scripts/ci/demo-matrix/gate.mjs
@@ -13,7 +13,7 @@ export function verifyReports(reports, expectedMatrix, sha) {
   const actual = new Set()
   for (const report of reports) {
     assert.equal(report.sha, sha, 'Report belongs to a different commit')
-    assert.equal(report.pnpm, '11.25.0')
+    assert.equal(report.pnpm, '12.3.4')
     const node = Number(report.node.match(/^v(\d+)/)?.[1])
     assert.deepEqual(report.results.map(result => result.id).sort(), [...report.expected].sort())
     for (const result of report.results) {

--- a/scripts/ci/demo-matrix/matrix.test.mjs
+++ b/scripts/ci/demo-matrix/matrix.test.mjs
@@ -80,7 +80,7 @@ describe('portable demo matrix', () => {
       for (const [index, job] of matrix().include.entries()) {
         const report = {
           sha: head,
-          pnpm: '11.25.0',
+          pnpm: '12.3.4',
           node: `v${job.node}.0.0`,
           os: platforms[job.os],
           expected: job.cases,
@@ -113,7 +113,7 @@ describe('portable demo matrix', () => {
   it('fails closed for absent, skipped, duplicate, stale or incomplete evidence', () => {
     const id = cases[0].id
     const expected = { include: [{ os: 'windows-latest', node: 24, cases: [id] }] }
-    const passed = { sha: 'head', pnpm: '11.25.0', node: 'v24.19.0', os: 'win32', expected: [id], results: [{ id, coverage: 'utilities', status: 'passed', rounds: Object.fromEntries(['production', 'initial', 'replace', 'add', 'restore'].map(round => [round, {}])) }] }
+    const passed = { sha: 'head', pnpm: '12.3.4', node: 'v24.19.0', os: 'win32', expected: [id], results: [{ id, coverage: 'utilities', status: 'passed', rounds: Object.fromEntries(['production', 'initial', 'replace', 'add', 'restore'].map(round => [round, {}])) }] }
     expect(verifyReports([passed], expected, 'head')).toBe(1)
     expect(() => verifyReports([], expected, 'head')).toThrow()
     expect(() => verifyReports([passed, passed], expected, 'head')).toThrow('Duplicate')
@@ -130,7 +130,7 @@ describe('portable demo matrix', () => {
     expect(coverage(hybrid)).toBe('webview-build')
     expect(requiredPhases(hybrid)).toEqual(['production'])
     expect(requiredPhases(cases.find(item => item.target === 'h5'))).toContain('refresh')
-    const report = { sha: 'head', pnpm: '11.25.0', node: 'v24.19.0', os: 'win32', expected: [native.id], results: [{ id: native.id, coverage: 'native-build', status: 'passed', rounds: { production: { javascript: true } } }] }
+    const report = { sha: 'head', pnpm: '12.3.4', node: 'v24.19.0', os: 'win32', expected: [native.id], results: [{ id: native.id, coverage: 'native-build', status: 'passed', rounds: { production: { javascript: true } } }] }
     const expected = { include: [{ os: 'windows-latest', node: 24, cases: [native.id] }] }
     expect(verifyReports([report], expected, 'head')).toBe(1)
     expect(() => verifyReports([{ ...report, results: [{ ...report.results[0], coverage: 'utilities' }] }], expected, 'head')).toThrow('Incorrect coverage')

--- a/scripts/ci/demo-matrix/rollup-invalidation.test.mjs
+++ b/scripts/ci/demo-matrix/rollup-invalidation.test.mjs
@@ -57,7 +57,12 @@ describe.each(['uni-app-vite-tailwindcss-v4', 'issue-uview-plus-cssentries'])('%
       watcher = rollup.watch({
         input: entry,
         output: { file: output, format: 'es' },
-        watch: { onInvalidate(id) { invalidated.push(id) } },
+        watch: {
+        // 该用例验证构建期间的缓存失效；polling 保证两轮状态都能跨过原生事件去重窗口。
+        // 原子替换后的原生监听连续性由 rollup-watch.test.mjs 独立覆盖。
+          chokidar: { usePolling: true, interval: 10 },
+          onInvalidate(id) { invalidated.push(id) },
+        },
         plugins: [{
           name: 'inflight-transform-dependency',
           resolveId(id) { return id === 'virtual:derived' ? id : null },

--- a/scripts/ci/demo-matrix/rollup-invalidation.test.mjs
+++ b/scripts/ci/demo-matrix/rollup-invalidation.test.mjs
@@ -3,97 +3,99 @@ import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { repo } from './catalog.mjs'
 import { replaceSourceFile } from './source-file.mjs'
 
-const demoRequire = createRequire(path.join(repo, 'demo/uni-app-vite-tailwindcss-v4/package.json'))
-const viteRequire = createRequire(demoRequire.resolve('vite/package.json'))
-const rollupDist = path.dirname(viteRequire.resolve('rollup'))
+describe.each(['uni-app-vite-tailwindcss-v4', 'issue-uview-plus-cssentries'])('%s Rollup', (demo) => {
+  const demoRequire = createRequire(path.join(repo, 'demo', demo, 'package.json'))
+  const viteRequire = createRequire(demoRequire.resolve('vite/package.json'))
+  const rollupDist = path.dirname(viteRequire.resolve('rollup'))
 
-it('deduplicates identical notifications without dropping new file states', async () => {
-  const { chokidar } = viteRequire(path.join(rollupDist, 'shared/index.js'))
-  const watcher = chokidar.watch([], { ignoreInitial: true })
-  const file = path.join(tmpdir(), 'rollup-change-probe.json')
-  const events = []
-  watcher.on('change', (_, stats) => events.push(stats))
-  const initial = { dev: 1, ino: 1, size: 10, mtimeMs: 1, ctimeMs: 1 }
-  try {
-    await watcher._emit('change', file, initial)
-    await watcher._emit('change', file, { ...initial })
-    expect(events).toEqual([initial])
-    for (const key of ['dev', 'ino', 'size', 'mtimeMs', 'ctimeMs']) {
-      const changed = { ...events.at(-1), [key]: events.at(-1)[key] + 1 }
-      await watcher._emit('change', file, changed)
-      expect(events.at(-1)).toEqual(changed)
-      const count = events.length
-      await watcher._emit('change', file, { ...changed })
-      expect(events).toHaveLength(count)
+  it('deduplicates identical notifications without dropping new file states', async () => {
+    const { chokidar } = viteRequire(path.join(rollupDist, 'shared/index.js'))
+    const watcher = chokidar.watch([], { ignoreInitial: true })
+    const file = path.join(tmpdir(), 'rollup-change-probe.json')
+    const events = []
+    watcher.on('change', (_, stats) => events.push(stats))
+    const initial = { dev: 1, ino: 1, size: 10, mtimeMs: 1, ctimeMs: 1 }
+    try {
+      await watcher._emit('change', file, initial)
+      await watcher._emit('change', file, { ...initial })
+      expect(events).toEqual([initial])
+      for (const key of ['dev', 'ino', 'size', 'mtimeMs', 'ctimeMs']) {
+        const changed = { ...events.at(-1), [key]: events.at(-1)[key] + 1 }
+        await watcher._emit('change', file, changed)
+        expect(events.at(-1)).toEqual(changed)
+        const count = events.length
+        await watcher._emit('change', file, { ...changed })
+        expect(events).toHaveLength(count)
+      }
+      expect(events).toHaveLength(6)
     }
-    expect(events).toHaveLength(6)
-  }
-  finally { await watcher.close() }
-})
+    finally { await watcher.close() }
+  })
 
-it.each(['cjs', 'esm'])('preserves transform invalidation received during an unfinished build (%s)', async (format) => {
-  const rollup = format === 'cjs'
-    ? viteRequire('rollup')
-    : await import(pathToFileURL(path.join(rollupDist, 'es/rollup.js')).href)
-  const dir = await realpath(await mkdtemp(path.join(tmpdir(), 'rollup-inflight-')))
-  const entry = path.join(dir, 'entry.js')
-  const dataDir = path.join(dir, 'data')
-  const data = path.join(dataDir, 'value.json')
-  const output = path.join(dir, 'bundle.mjs')
-  let reached = false
-  const release = Promise.withResolvers()
-  const invalidated = []
-  let watcher
-  let inspection = 0
-  try {
-    await mkdir(dataDir)
-    await replaceSourceFile(entry, 'export { default } from "virtual:derived"')
-    await replaceSourceFile(data, '{"value":0}')
-    watcher = rollup.watch({
-      input: entry,
-      output: { file: output, format: 'es' },
-      watch: { onInvalidate(id) { invalidated.push(id) } },
-      plugins: [{
-        name: 'inflight-transform-dependency',
-        resolveId(id) { return id === 'virtual:derived' ? id : null },
-        load(id) { return id === 'virtual:derived' ? 'export default null' : null },
-        async transform(_, id) {
-          if (id !== 'virtual:derived') {
-            return
-          }
-          this.addWatchFile(data)
-          const { value } = JSON.parse(await readFile(data, 'utf8'))
-          if (value === 1) {
-            reached = true
-            await release.promise
-          }
-          return `export default ${value * 2}`
-        },
-      }],
-    })
-    watcher.on('event', event => event.result?.close())
-    const inspect = value => expect.poll(async () => {
-      const module = await import(`${pathToFileURL(output).href}?inspection=${++inspection}`)
-      return module.default
-    }, { timeout: 5000, interval: 1 }).toBe(value)
-    await inspect(0)
-    await replaceSourceFile(data, '{"value":1}')
-    await expect.poll(() => reached, { timeout: 5000, interval: 1 }).toBe(true)
-    const previous = invalidated.length
-    await replaceSourceFile(data, '{"value":2}')
-    await expect.poll(() => invalidated.slice(previous), { timeout: 5000, interval: 1 }).toContain(data)
-    release.resolve()
-    await inspect(4)
-    await replaceSourceFile(data, '{"value":3}')
-    await inspect(6)
-  }
-  finally {
-    release.resolve()
-    await watcher?.close()
-    await rm(dir, { recursive: true, force: true })
-  }
-}, 15_000)
+  it.each(['cjs', 'esm'])('preserves transform invalidation received during an unfinished build (%s)', async (format) => {
+    const rollup = format === 'cjs'
+      ? viteRequire('rollup')
+      : await import(pathToFileURL(path.join(rollupDist, 'es/rollup.js')).href)
+    const dir = await realpath(await mkdtemp(path.join(tmpdir(), 'rollup-inflight-')))
+    const entry = path.join(dir, 'entry.js')
+    const dataDir = path.join(dir, 'data')
+    const data = path.join(dataDir, 'value.json')
+    const output = path.join(dir, 'bundle.mjs')
+    let reached = false
+    const release = Promise.withResolvers()
+    const invalidated = []
+    let watcher
+    let inspection = 0
+    try {
+      await mkdir(dataDir)
+      await replaceSourceFile(entry, 'export { default } from "virtual:derived"')
+      await replaceSourceFile(data, '{"value":0}')
+      watcher = rollup.watch({
+        input: entry,
+        output: { file: output, format: 'es' },
+        watch: { onInvalidate(id) { invalidated.push(id) } },
+        plugins: [{
+          name: 'inflight-transform-dependency',
+          resolveId(id) { return id === 'virtual:derived' ? id : null },
+          load(id) { return id === 'virtual:derived' ? 'export default null' : null },
+          async transform(_, id) {
+            if (id !== 'virtual:derived') {
+              return
+            }
+            this.addWatchFile(data)
+            const { value } = JSON.parse(await readFile(data, 'utf8'))
+            if (value === 1) {
+              reached = true
+              await release.promise
+            }
+            return `export default ${value * 2}`
+          },
+        }],
+      })
+      watcher.on('event', event => event.result?.close())
+      const inspect = value => expect.poll(async () => {
+        const module = await import(`${pathToFileURL(output).href}?inspection=${++inspection}`)
+        return module.default
+      }, { timeout: 5000, interval: 1 }).toBe(value)
+      await inspect(0)
+      await replaceSourceFile(data, '{"value":1}')
+      await expect.poll(() => reached, { timeout: 5000, interval: 1 }).toBe(true)
+      const previous = invalidated.length
+      await replaceSourceFile(data, '{"value":2}')
+      await expect.poll(() => invalidated.slice(previous), { timeout: 5000, interval: 1 }).toContain(data)
+      release.resolve()
+      await inspect(4)
+      await replaceSourceFile(data, '{"value":3}')
+      await inspect(6)
+    }
+    finally {
+      release.resolve()
+      await watcher?.close()
+      await rm(dir, { recursive: true, force: true })
+    }
+  }, 15_000)
+})

--- a/scripts/ci/demo-matrix/rollup-watch.test.mjs
+++ b/scripts/ci/demo-matrix/rollup-watch.test.mjs
@@ -7,8 +7,12 @@ import { expect, it } from 'vitest'
 import { repo } from './catalog.mjs'
 import { replaceSourceFile } from './source-file.mjs'
 
-it.each(['cjs', 'esm'].flatMap(format => ['file', 'directory'].map(dependency => ({ format, dependency }))))('keeps module and transform dependencies live after atomic replacement ($format, $dependency)', async ({ format, dependency }) => {
-  const demoRequire = createRequire(path.join(repo, 'demo/uni-app-vite-tailwindcss-v4/package.json'))
+const scenarios = ['uni-app-vite-tailwindcss-v4', 'issue-uview-plus-cssentries'].flatMap(demo =>
+  ['cjs', 'esm'].flatMap(format => ['file', 'directory'].map(dependency => ({ demo, format, dependency }))),
+)
+
+it.each(scenarios)('keeps module and transform dependencies live after atomic replacement ($demo, $format, $dependency)', async ({ demo, format, dependency }) => {
+  const demoRequire = createRequire(path.join(repo, 'demo', demo, 'package.json'))
   const viteRequire = createRequire(demoRequire.resolve('vite/package.json'))
   const rollup = format === 'cjs'
     ? viteRequire('rollup')

--- a/scripts/ci/demo-matrix/run.mjs
+++ b/scripts/ci/demo-matrix/run.mjs
@@ -42,7 +42,7 @@ const report = {
   expected: selected.map(item => item.id),
   results: [],
 }
-assert.equal(report.pnpm, '11.25.0')
+assert.equal(report.pnpm, '12.3.4')
 await mkdir(artifactRoot, { recursive: true })
 let interrupted = false
 let activeSession

--- a/scripts/ci/windows-utilities.mjs
+++ b/scripts/ci/windows-utilities.mjs
@@ -116,7 +116,7 @@ async function verify(label, expectRegression) {
 
 try {
   await cp(fixture, project, { recursive: true })
-  assert.equal((await runPnpm(['--version'])).trim(), '11.25.0')
+  assert.equal((await runPnpm(['--version'])).trim(), '12.3.4')
   await writeFile(path.join(reportDir, 'published-install.log'), await runPnpm(['install', '--frozen-lockfile']))
   await verify('published-5.5.1', process.platform === 'win32')
 

--- a/scripts/ci/windows-utilities.mjs
+++ b/scripts/ci/windows-utilities.mjs
@@ -116,7 +116,7 @@ async function verify(label, expectRegression) {
 
 try {
   await cp(fixture, project, { recursive: true })
-  assert.equal((await runPnpm(['--version'])).trim(), '12.3.4')
+  assert.equal((await runPnpm(['--version'])).trim(), '11.25.0')
   await writeFile(path.join(reportDir, 'published-install.log'), await runPnpm(['install', '--frozen-lockfile']))
   await verify('published-5.5.1', process.platform === 'win32')
 

--- a/scripts/pnpm-command.mjs
+++ b/scripts/pnpm-command.mjs
@@ -1,4 +1,18 @@
+import { readFileSync } from 'node:fs'
 import process from 'node:process'
+
+function isNodeScript(file) {
+  if (!file) {
+    return false
+  }
+  try {
+    const header = readFileSync(file, { encoding: 'utf8', flag: 'r' }).slice(0, 256)
+    return header.startsWith('#!') || /\.(?:c|m)?js$/i.test(file)
+  }
+  catch {
+    return /\.(?:c|m)?js$/i.test(file)
+  }
+}
 
 export function createPnpmCommand(
   args,
@@ -10,7 +24,7 @@ export function createPnpmCommand(
     ? options.npmExecPath
     : process.env.npm_execpath
 
-  if (npmExecPath) {
+  if (npmExecPath && isNodeScript(npmExecPath)) {
     return {
       command: execPath,
       args: [npmExecPath, ...args],

--- a/scripts/uni-e2e-watch.mjs
+++ b/scripts/uni-e2e-watch.mjs
@@ -2,28 +2,14 @@ import { spawn } from 'node:child_process'
 import { readdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
+import { createPnpmCommand } from './pnpm-command.mjs'
 
 const READY_RE = /Build complete|Watching for changes|ready in \d+/i
-const pnpmExecPath = process.env.npm_execpath
 const sourceDirs = ['src']
 const ignoredDirs = new Set(['dist', 'node_modules', '.git'])
 const ignoredFiles = new Set(['auto-imports.d.ts', 'components.d.ts', 'uni-pages.d.ts'])
 const useNativeWatch = process.env.UNI_E2E_WATCH_NATIVE === '1'
 const uniPlatform = process.env.UNI_E2E_WATCH_PLATFORM || 'mp-weixin'
-
-function createPnpmCommand(args) {
-  if (pnpmExecPath) {
-    return {
-      command: process.execPath,
-      args: [pnpmExecPath, ...args],
-    }
-  }
-
-  return {
-    command: process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
-    args,
-  }
-}
 
 function spawnPnpm(args, options = {}) {
   const { command, args: commandArgs } = createPnpmCommand(args)

--- a/scripts/uni-e2e-watch.mjs
+++ b/scripts/uni-e2e-watch.mjs
@@ -12,13 +12,14 @@ const useNativeWatch = process.env.UNI_E2E_WATCH_NATIVE === '1'
 const uniPlatform = process.env.UNI_E2E_WATCH_PLATFORM || 'mp-weixin'
 
 function spawnPnpm(args, options = {}) {
-  const { command, args: commandArgs } = createPnpmCommand(args)
+  const { command, args: commandArgs, shell } = createPnpmCommand(args)
   return spawn(command, commandArgs, {
     cwd: process.cwd(),
     env: {
       ...process.env,
       ...options.env,
     },
+    shell,
     stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
   })
 }

--- a/scripts/weapp-vite-e2e-watch.mjs
+++ b/scripts/weapp-vite-e2e-watch.mjs
@@ -24,10 +24,11 @@ export function resolveWatchPlatform(env = process.env) {
 }
 
 function spawnPnpm(args, options = {}) {
-  const { command, args: commandArgs } = createPnpmCommand(args)
+  const { command, args: commandArgs, shell } = createPnpmCommand(args)
   return spawn(command, commandArgs, {
     cwd: process.cwd(),
     env: process.env,
+    shell,
     stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
   })
 }

--- a/scripts/weapp-vite-e2e-watch.mjs
+++ b/scripts/weapp-vite-e2e-watch.mjs
@@ -3,9 +3,9 @@ import { readdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
+import { createPnpmCommand } from './pnpm-command.mjs'
 
 const READY_RE = /开发服务已就绪|dev(?:elopment)? server ready|ready in \d+/i
-const pnpmExecPath = process.env.npm_execpath
 const sourceDirs = ['miniprogram', 'pages', 'packageA', 'packageB', 'sub-normal', 'sub-independent']
 const ignoredDirs = new Set(['dist', 'node_modules', '.git'])
 const rootSourceFileRe = /^(?:app|tailwind\.config(?:\.[\w-]+)?)\.[cm]?[jt]s$|^app\.(?:wxss|css|s[ac]ss|less|json)$/i
@@ -21,20 +21,6 @@ export function resolveWatchPlatform(env = process.env) {
     throw new Error(`Unsupported WEAPP_VITE_E2E_WATCH_PLATFORM: ${platform}`)
   }
   return platform
-}
-
-function createPnpmCommand(args) {
-  if (pnpmExecPath) {
-    return {
-      command: process.execPath,
-      args: [pnpmExecPath, ...args],
-    }
-  }
-
-  return {
-    command: process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
-    args,
-  }
 }
 
 function spawnPnpm(args, options = {}) {


### PR DESCRIPTION
## 变更说明

修复 Core 使用外层 CSS 入口时，嵌套 CSS 中 `@source` 未参与 Tailwind CSS v4 扫描的问题。

现在会递归收集本地 CSS import，保留每个 stylesheet 的 `file/base/dependencies`，并按声明所在文件解析相对 `@source` 路径。这样直接入口和嵌套入口可以得到一致的候选集，范围外 source 仍会被排除。

## 验证

- `pnpm --filter weapp-tailwindcss exec vitest run test/compiler/core-compiler.test.ts test/tailwindcss/v4-source-options.test.ts`
- `pnpm --filter weapp-tailwindcss build`
- `git diff --check`

Related to #1174
