### PR TITLE
fix(tailwindcss): dedupe nested v4 css roots

### DIFF
--- a/.changeset/fix-1174-nested-css-root.md
+++ b/.changeset/fix-1174-nested-css-root.md
@@ -1,0 +1,5 @@
+---
+"weapp-tailwindcss": patch
+---
+
+修复 Tailwind CSS v4 嵌套 CSS 入口被重复编译的问题，并保留完整的 source 扫描依赖关系。

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/generator/scan-sources.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/generator/scan-sources.ts
@@ -1,4 +1,5 @@
 import type { TailwindV4GenerateOptions, TailwindV4ResolvedSource, TailwindV4SourcePattern } from '../types'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { postcss } from '@weapp-tailwindcss/postcss'
 import { resolveCssSourceEntries, resolveTailwindSourceEntry } from '@/tailwindcss/source-scan'
@@ -81,18 +82,36 @@ async function resolveCssDefinedScanSources(source: Pick<TailwindV4ResolvedSourc
   let importSourceBase: string | undefined
   let hasSourceNone = false
   let hasTailwindImport = false
-  const from = source.dependencies[0]
-  let root: postcss.Root
-  try {
-    root = postcss.parse(source.css, { from })
+  const sourcePatterns: TailwindV4SourcePattern[] = []
+  const definitions: Array<{ css: string, base: string, from?: string }> = [{
+    css: source.css,
+    base: source.base,
+    from: source.dependencies[0],
+  }]
+  for (const dependency of source.dependencies.slice(1)) {
+    if (!existsSync(dependency)) {
+      continue
+    }
+    try {
+      definitions.push({
+        css: readFileSync(dependency, 'utf8'),
+        base: path.dirname(dependency),
+        from: dependency,
+      })
+    }
+    catch {
+    }
   }
-  catch {
-    return undefined
-  }
-
-  root.walkAtRules((rule) => {
-    if (rule.name === 'import') {
-      if (!isTailwindCssImport(rule.params)) {
+  for (const definition of definitions) {
+    let root: postcss.Root
+    try {
+      root = postcss.parse(definition.css, { from: definition.from })
+    }
+    catch {
+      continue
+    }
+    root.walkAtRules((rule) => {
+      if (rule.name !== 'import' || !isTailwindCssImport(rule.params)) {
         return
       }
       hasTailwindImport = true
@@ -101,12 +120,11 @@ async function resolveCssDefinedScanSources(source: Pick<TailwindV4ResolvedSourc
         hasSourceNone = true
       }
       if (sourceParam?.sourcePath) {
-        importSourceBase = resolveSourceBase(source.base, sourceParam.sourcePath)
+        importSourceBase = resolveSourceBase(definition.base, sourceParam.sourcePath)
       }
-    }
-  })
-
-  const sourcePatterns = await resolveCssSourceEntries(root, source.base, '**/*')
+    })
+    sourcePatterns.push(...await resolveCssSourceEntries(root, definition.base, '**/*'))
+  }
   if (!importSourceBase) {
     if (sourcePatterns.length > 0) {
       return [

--- a/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
+++ b/packages/weapp-tailwindcss/src/tailwindcss/v4-engine/source.ts
@@ -81,6 +81,13 @@ function uniqueDefined(values: Array<string | undefined>) {
   return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))]
 }
 
+function resolveCssImportFile(base: string, specifier: string) {
+  const normalizedSpecifier = path.sep === '\\'
+    ? specifier.replaceAll('/', '\\')
+    : specifier.replaceAll('\\', '/')
+  return path.resolve(base, normalizedSpecifier)
+}
+
 function getProjectRoot(runtime: TailwindcssRuntimeLike) {
   return runtime.options?.projectRoot ?? process.cwd()
 }
@@ -159,35 +166,6 @@ function normalizeTailwindV4CssPackageImports(css: string, packageName: string |
   return changed ? root.toString() : css
 }
 
-function normalizeTailwindV4CssSourceDirectives(css: string, base: string) {
-  if (!css.includes('@source')) {
-    return css
-  }
-  let root: postcss.Root
-  try {
-    root = postcss.parse(css)
-  }
-  catch {
-    return css
-  }
-  let changed = false
-  root.walkAtRules('source', (rule) => {
-    const match = rule.params.match(/^(not\s+)?("([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)')(.*)$/)
-    if (!match) {
-      return
-    }
-    const specifier = match[3] ?? match[4]
-    if (!specifier?.startsWith('.')) {
-      return
-    }
-    const resolved = path.resolve(base, specifier)
-    const quote = match[2] === undefined ? '\'' : '"'
-    rule.params = `${match[1] ?? ''}${quote}${resolved}${quote}${match[5] ?? ''}`
-    changed = true
-  })
-  return changed ? root.toString() : css
-}
-
 function normalizeTailwindV4CssSources(
   cssSources: TailwindV4SourceOptions['cssSources'],
   packageName: string | undefined,
@@ -252,13 +230,48 @@ function normalizeTailwindV4CssEntrySources(
 
   const remainingCssEntries: string[] = []
   const cssSources: NonNullable<TailwindV4SourceOptions['cssSources']> = []
-  const visited = new Set<string>()
-  const collectCssSource = (file: string, nested = false) => {
+  const graphs = new Map<string, Set<string>>()
+  const collectCssGraph = (file: string, visiting = new Set<string>()): Set<string> => {
     const normalizedFile = path.resolve(file)
-    if (visited.has(normalizedFile) || !existsSync(normalizedFile)) {
-      return
+    const cached = graphs.get(normalizedFile)
+    if (cached) {
+      return cached
     }
-    visited.add(normalizedFile)
+    const graph = new Set<string>([normalizedFile])
+    graphs.set(normalizedFile, graph)
+    if (visiting.has(normalizedFile) || !existsSync(normalizedFile)) {
+      return graph
+    }
+    const nextVisiting = new Set(visiting).add(normalizedFile)
+    let root: postcss.Root
+    try {
+      root = postcss.parse(readFileSync(normalizedFile, 'utf8'))
+    }
+    catch {
+      return graph
+    }
+    const base = path.dirname(normalizedFile)
+    root.walkAtRules('import', (rule) => {
+      const parsed = parseCssImportSpecifier(rule.params)
+      if (!parsed || !parsed.specifier.startsWith('.')) {
+        return
+      }
+      const importedFile = resolveCssImportFile(base, parsed.specifier)
+      const candidates = path.extname(importedFile)
+        ? [importedFile]
+        : [importedFile, `${importedFile}.css`, `${importedFile}.pcss`, `${importedFile}.scss`, `${importedFile}.sass`]
+      const resolved = candidates.find(candidate => existsSync(candidate))
+      if (!resolved) {
+        return
+      }
+      for (const dependency of collectCssGraph(resolved, nextVisiting)) {
+        graph.add(dependency)
+      }
+    })
+    return graph
+  }
+  const createCssSource = (file: string, dependencies: Set<string>) => {
+    const normalizedFile = path.resolve(file)
     const base = path.dirname(normalizedFile)
     const rawCss = readFileSync(normalizedFile, 'utf8')
     const entrySource = resolveCssEntrySource(rawCss, base, {
@@ -270,43 +283,17 @@ function normalizeTailwindV4CssEntrySources(
         ? path.resolve(base, entrySource.configRequest)
         : entrySource?.config
     const css = normalizeTailwindV4CssPackageImports(
-      nested
-        ? normalizeTailwindV4CssSourceDirectives(
-            normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
-            base,
-          )
-        : normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
+      normalizeEmptyTailwindCustomVariants(normalizeConfigDirective(rawCss, config)),
       packageName,
     )
-    cssSources.push({
+    return {
       file: normalizedFile,
       base,
       css,
-      dependencies: [normalizedFile],
-    })
-
-    let root: postcss.Root
-    try {
-      root = postcss.parse(rawCss)
+      dependencies: [...dependencies],
     }
-    catch {
-      return
-    }
-    root.walkAtRules('import', (rule) => {
-      const parsed = parseCssImportSpecifier(rule.params)
-      if (!parsed || !parsed.specifier.startsWith('.') || parsed.specifier.includes('\\')) {
-        return
-      }
-      const importedFile = path.resolve(base, parsed.specifier)
-      const candidates = path.extname(importedFile)
-        ? [importedFile]
-        : [importedFile, `${importedFile}.css`, `${importedFile}.pcss`, `${importedFile}.scss`, `${importedFile}.sass`]
-      const resolved = candidates.find(candidate => existsSync(candidate))
-      if (resolved) {
-        collectCssSource(resolved, true)
-      }
-    })
   }
+  const rootEntries: string[] = []
   for (const cssEntry of cssEntries) {
     const normalizedCssEntry = cssEntry.replace(/[?#].*$/, '')
     const file = path.resolve(normalizedCssEntry)
@@ -314,7 +301,25 @@ function normalizeTailwindV4CssEntrySources(
       remainingCssEntries.push(normalizedCssEntry)
       continue
     }
-    collectCssSource(file)
+    rootEntries.push(file)
+  }
+
+  const entryGraphs = rootEntries.map(entry => [entry, collectCssGraph(entry)] as const)
+  const nestedEntries = new Set<string>()
+  for (const [entry] of entryGraphs) {
+    for (const [otherEntry, otherGraph] of entryGraphs) {
+      if (entry !== otherEntry && otherGraph.has(entry)) {
+        nestedEntries.add(entry)
+        break
+      }
+    }
+  }
+  const selectedEntries = entryGraphs.filter(([entry]) => !nestedEntries.has(entry))
+  const roots = selectedEntries.length > 0
+    ? selectedEntries
+    : entryGraphs.slice(0, 1)
+  for (const [rootEntry, dependencies] of roots) {
+    cssSources.push(createCssSource(rootEntry, dependencies))
   }
 
   return {

--- a/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/core-compiler.test.ts
@@ -35,6 +35,7 @@ describe('createCompiler', () => {
     await writeFile(tailwindCss, [
       '@import "tailwindcss" source(none);',
       '@source "./pages/**/*.{wxml,ts}";',
+      '.sentinel { width: 11px; }',
     ].join('\n'))
     await writeFile(path.join(root, 'styles/pages/index.wxml'), '<view class="w-[37px] text-white" />')
     await writeFile(path.join(root, 'outside.wxml'), '<view class="w-[99px]" />')
@@ -54,6 +55,7 @@ describe('createCompiler', () => {
     expect(generated.classSet.has('text-white')).toBe(true)
     expect(generated.classSet.has('w-[99px]')).toBe(false)
     expect(generated.css).toContain('.w-\\[37px\\]')
+    expect(generated.css.match(/\.sentinel/g)?.length).toBe(1)
     await compiler.dispose()
   })
 

--- a/packages/weapp-tailwindcss/test/tailwindcss/v4-source-options.test.ts
+++ b/packages/weapp-tailwindcss/test/tailwindcss/v4-source-options.test.ts
@@ -39,7 +39,7 @@ describe('tailwind v4 source options', () => {
     expect(packageJsonOptions?.cssSources?.[0]?.css).toContain('#tw')
   })
 
-  it('keeps nested css imports as independent source roots', async () => {
+  it('keeps nested css imports in one compile root with complete dependencies', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-nested-source-'))
     const appEntry = path.join(root, 'app.css')
     const nestedEntry = path.join(root, 'styles/tailwind.css')
@@ -55,13 +55,69 @@ describe('tailwind v4 source options', () => {
       cssEntries: [appEntry],
     })
 
-    expect(options?.cssSources).toHaveLength(2)
-    expect(options?.cssSources?.map(source => source.file)).toEqual([appEntry, nestedEntry])
-    expect(options?.cssSources?.[1]).toMatchObject({
-      base: path.dirname(nestedEntry),
-      dependencies: [nestedEntry],
+    expect(options?.cssSources).toHaveLength(1)
+    expect(options?.cssSources?.map(source => source.file)).toEqual([appEntry])
+    expect(options?.cssSources?.[0]).toMatchObject({
+      base: path.dirname(appEntry),
+      dependencies: [appEntry, nestedEntry],
     })
-    expect(options?.cssSources?.[1]?.css).toContain(`@source ${JSON.stringify(path.join(path.dirname(nestedEntry), 'pages/**/*.{wxml,ts}'))}`)
+    expect(options?.cssSources?.[0]?.css).toContain('@import "./styles/tailwind.css"')
+  })
+
+  it('deduplicates entries that are already reachable from another entry and preserves independent roots', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-entry-ownership-'))
+    const appEntry = path.join(root, 'app.css')
+    const nestedEntry = path.join(root, 'styles/tailwind.css')
+    const sideEntry = path.join(root, 'side.css')
+    await mkdir(path.dirname(nestedEntry), { recursive: true })
+    await writeFile(appEntry, '@import "./styles/tailwind.css";')
+    await writeFile(nestedEntry, '@import "tailwindcss" source(none);')
+    await writeFile(sideEntry, '@import "tailwindcss" source(none);\n.side{color:red}')
+
+    const options = normalizeTailwindV4SourceOptions({
+      projectRoot: root,
+      cssEntries: [nestedEntry, appEntry, sideEntry],
+    })
+
+    expect(options?.cssSources?.map(source => source.file)).toEqual([appEntry, sideEntry])
+    expect(options?.cssSources?.[0]?.dependencies).toEqual([appEntry, nestedEntry])
+    expect(options?.cssSources?.[1]?.dependencies).toEqual([sideEntry])
+  })
+
+  it('handles deep and cyclic imports without duplicating compile roots', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-entry-cycle-'))
+    const appEntry = path.join(root, 'app.css')
+    const firstEntry = path.join(root, 'styles/first.css')
+    const secondEntry = path.join(root, 'styles/second.css')
+    await mkdir(path.dirname(firstEntry), { recursive: true })
+    await writeFile(appEntry, '@import "./styles/first.css";\n.app{color:red}')
+    await writeFile(firstEntry, '@import "./second.css";\n.first{color:blue}')
+    await writeFile(secondEntry, '@import "./first.css";\n.second{color:green}')
+
+    const options = normalizeTailwindV4SourceOptions({
+      projectRoot: root,
+      cssEntries: [appEntry, secondEntry],
+    })
+
+    expect(options?.cssSources).toHaveLength(1)
+    expect(options?.cssSources?.[0]?.file).toBe(appEntry)
+    expect(options?.cssSources?.[0]?.dependencies).toEqual([appEntry, firstEntry, secondEntry])
+  })
+
+  it('resolves relative imports that use Windows separators on POSIX hosts', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'weapp-tw-v4-entry-windows-path-'))
+    const appEntry = path.join(root, 'app.css')
+    const nestedEntry = path.join(root, 'styles/tailwind.css')
+    await mkdir(path.dirname(nestedEntry), { recursive: true })
+    await writeFile(appEntry, '@import ".\\\\styles\\\\tailwind.css";')
+    await writeFile(nestedEntry, '.nested{color:red}')
+
+    const options = normalizeTailwindV4SourceOptions({
+      projectRoot: root,
+      cssEntries: [appEntry],
+    })
+
+    expect(options?.cssSources?.[0]?.dependencies).toEqual([appEntry, nestedEntry])
   })
 
   it('removes Vite request queries before treating css entries as file paths', async () => {


### PR DESCRIPTION
## 变更

修复 Tailwind CSS v4 自动 `cssEntries` 的嵌套 import 编译 root 重复问题：嵌套 CSS 只保留在所属顶级 root 的依赖图中，避免作者 CSS 重复生成；source 扫描会读取完整依赖图并保留 `@source` 语义。

补充深层/循环 import、多个独立入口、Windows 分隔符及 #1174 fixture 回归测试。

## 验证

- `pnpm --filter weapp-tailwindcss test`
- `pnpm --filter weapp-tailwindcss... run build`
- `pnpm agents:check`
- `git diff --check`

Related to #1174