### PR TITLE
feat: 增加 P0 编译诊断事件与性能统计

### DIFF
--- a/benchmark/version-compare/scripts/percentiles.mjs
+++ b/benchmark/version-compare/scripts/percentiles.mjs
@@ -1,0 +1,28 @@
+export function percentile(values, percentileRank) {
+  const sorted = values.filter(value => Number.isFinite(value)).sort((a, b) => a - b)
+  if (!sorted.length) return undefined
+  const rank = Math.min(1, Math.max(0, percentileRank)) * (sorted.length - 1)
+  const lower = Math.floor(rank)
+  const upper = Math.ceil(rank)
+  if (lower === upper) return sorted[lower]
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (rank - lower)
+}
+
+export function summarizeSamples(values) {
+  const samples = values.filter(value => Number.isFinite(value))
+  return {
+    count: samples.length,
+    p50: percentile(samples, 0.5),
+    p95: percentile(samples, 0.95),
+    p99: percentile(samples, 0.99),
+  }
+}
+
+export function evaluatePercentileGuard(current, baseline, { thresholdPct = 10, minimumSamples = 3 } = {}) {
+  if (current?.count < minimumSamples || baseline?.count < minimumSamples) return { status: 'unavailable', passed: false }
+  const baselineValue = baseline.p95
+  const currentValue = current.p95
+  if (!Number.isFinite(baselineValue) || !Number.isFinite(currentValue)) return { status: 'unavailable', passed: false }
+  const deltaPct = baselineValue === 0 ? 0 : ((currentValue - baselineValue) / baselineValue) * 100
+  return { status: 'complete', passed: deltaPct <= thresholdPct, deltaPct }
+}

--- a/benchmark/version-compare/scripts/run-ci.mjs
+++ b/benchmark/version-compare/scripts/run-ci.mjs
@@ -545,6 +545,9 @@ async function main() {
   if (baselineRef) {
     let performanceGuard = evaluatePerformanceGuard(summary, {
       regressionPercent: parseNumber('--regression-percent', 5),
+      minimumTailRegressionSamples: parseNumber('--minimum-tail-samples', 2),
+      minimumTimingRegressionMs: parseNumber('--minimum-timing-ms', 10),
+      minimumMemoryRegressionMb: parseNumber('--minimum-memory-mb', 64),
     })
     if (
       performanceRelevantChanges

--- a/benchmark/version-compare/scripts/run-matrix.mjs
+++ b/benchmark/version-compare/scripts/run-matrix.mjs
@@ -98,6 +98,19 @@ function summarizeSteady(values) {
   return summarize(values.slice(1)) ?? summarize(values)
 }
 
+function summarizeTimingPhases(timings) {
+  const phases = new Map()
+  for (const timing of timings) {
+    const phase = timing?.phase
+    const durationMs = timing?.durationMs
+    if (typeof phase !== 'string' || typeof durationMs !== 'number' || !Number.isFinite(durationMs)) continue
+    const values = phases.get(phase) ?? []
+    values.push(durationMs)
+    phases.set(phase, values)
+  }
+  return Object.fromEntries([...phases].map(([phase, values]) => [phase, summarize(values)]))
+}
+
 function spawnPnpmWithEnv(cwd, args, env = {}, stdio = 'pipe') {
   return spawn(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', args, {
     cwd,
@@ -739,6 +752,7 @@ async function runCase(versionMeta, projectMeta, options) {
       hmrPluginSteady: summarizeSteady(hmrPluginMs),
       hmrPeakRssMb: summarize(hmrMemory?.count > 0 ? [hmrMemory.peakRssMb] : []),
       hmrSteadyRssMb: summarize(hmrMemory?.count > 0 ? [hmrMemory.steadyRssMb] : []),
+      phases: summarizeTimingPhases([...buildPluginTimings, ...hmrPluginTimings]),
     },
   }
 }

--- a/benchmark/version-compare/scripts/run-matrix.mjs
+++ b/benchmark/version-compare/scripts/run-matrix.mjs
@@ -81,6 +81,7 @@ function summarize(values) {
   }
   const sorted = [...values].sort((a, b) => a - b)
   const p95Index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)
+  const p99Index = Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.99) - 1)
   return {
     count: values.length,
     mean: mean(values),
@@ -88,6 +89,7 @@ function summarize(values) {
     min: sorted[0],
     max: sorted[sorted.length - 1],
     p95: sorted[p95Index],
+    p99: sorted[p99Index],
     stddev: stddev(values),
   }
 }

--- a/benchmark/version-compare/test/percentiles.test.mjs
+++ b/benchmark/version-compare/test/percentiles.test.mjs
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { evaluatePercentileGuard, summarizeSamples } from '../scripts/percentiles.mjs'
+
+describe('阶段性能统计', () => {
+  it('计算 p50/p95/p99 与样本数', () => {
+    const result = summarizeSamples([1, 2, 3, 4, 5])
+    expect(result).toMatchObject({ count: 5, p50: 3, p95: 4.8, p99: 4.96 })
+  })
+
+  it('样本不足时标记 unavailable', () => {
+    expect(evaluatePercentileGuard(summarizeSamples([1]), summarizeSamples([1]))).toMatchObject({ status: 'unavailable', passed: false })
+  })
+
+  it('超过阈值时失败', () => {
+    const baseline = summarizeSamples([10, 10, 10])
+    const current = summarizeSamples([12, 12, 12])
+    expect(evaluatePercentileGuard(current, baseline, { thresholdPct: 10 })).toMatchObject({ status: 'complete', passed: false })
+  })
+})

--- a/docs/engineering/architecture-audit-2026.md
+++ b/docs/engineering/architecture-audit-2026.md
@@ -1,0 +1,47 @@
+# weapp-tailwindcss 架构与工程增强审计
+
+> 审计基线：`c41a9076d`（main，2026-09-11）。本文是基于源码、测试、benchmark、规则和 skill 的静态审计；没有把未运行的跨平台设备链路当作已验证事实。
+
+## 1. 当前架构
+
+核心入口位于 `packages/weapp-tailwindcss`。`createContext` 管理 Tailwind runtime、classNameSet 和模板/脚本/样式转换；`createCompiler` 把快照、源码候选、CSS 生成和增量更新抽象成编译器层。`@weapp-tailwindcss/postcss` 负责 AST 处理、兼容性和结果缓存，Vite、Webpack、Rspack、Gulp 通过各自 adapter 接入。运行时能力拆分到 `packages-runtime/*`，模板与框架验证集中在 `e2e/` 和 `demo/`。
+
+主要优点：单一 Tailwind 生成链路、明确的 classNameSet 精确命中约束、较完整的 v3/v4 与多平台兼容分支、已有缓存/HMR/内存 benchmark，以及以复盘文档和 `pnpm agents:check` 约束 AI 协作。
+
+主要结构风险：adapter 对编译器内部状态的依赖仍较多；扫描、候选集合、CSS 生成和产物注入的生命周期边界分散在多个包；诊断事件缺少统一 schema；性能数据已有采集脚本但缺少稳定的历史查询面；AI skill 有规则和触发样例，但缺少端到端质量指标。
+
+## 2. 性能与可靠性发现
+
+### 已证实
+
+- PostCSS handler 已使用选项指纹、feature probe、内容哈希和 LRU 结果缓存。
+- benchmark 已覆盖版本对比、框架矩阵、构建/HMR 时间和内存，并有 `perf:guard`。
+- HMR 与多平台 E2E 已有大量回归用例和失败证据目录。
+
+### 推断风险
+
+- 缓存键和失效原因对使用者不可见，难以区分“扫描变化”“配置变化”和“生成器变化”导致的重算。
+- 当前门禁更偏整体结果；缺少 source scan、AST、Tailwind generate、注入四个阶段的 P95/P99 分解。
+- 长时间 watch 的内存生命周期、LRU 淘汰和跨项目复用缺少统一趋势报告。
+
+## 3. AI 流程发现
+
+已有 `skills/*`、触发评测集、规则索引、工程工作流和 lessons 复盘，强调先复现、找首次偏离、分层验收。这是可靠基础。
+
+待增强部分：Issue 信息尚未自动结构化为“事实/假设/证据”；AI 生成的回归建议没有统一评测；skill 触发准确率、误导率和完成率没有持续指标；Issue、fixture、测试、E2E 基线与 release note 之间缺少机器可追踪关系。
+
+## 4. 优先级与依赖
+
+建议季度顺序：
+
+1. P0：统一诊断事件模型、分层性能指标与 HMR 门禁。
+2. P1：编译器/adapter 契约、缓存可观测性、支持矩阵自动化。
+3. P1：Issue 到回归证据追踪、模板/文档/skill 影响检查。
+4. P2：AI triage/eval、运行时按需加载与体积治理、兼容性弃用周期。
+
+依赖关系：诊断事件模型是性能报告和 AI triage 的基础；追踪关系依赖统一事件与支持矩阵；运行时体积治理可独立推进。
+
+## 5. 限制
+
+本审计未执行完整 `pnpm test`、跨平台 IDE/设备 E2E 或远端 CI；因此没有给出绝对性能数值，也没有宣称 Windows、macOS、Linux、Harmony 和 HBuilderX 的当前行为完全一致。实施每个 Issue 时应按就近规则补定向测试，并记录真实环境证据。
+

--- a/docs/engineering/enhancement-issues.md
+++ b/docs/engineering/enhancement-issues.md
@@ -1,0 +1,96 @@
+# 架构与工程增强 Issue 草案
+
+以下草案默认使用普通 Issue 关联方式，不使用 `Fixes`/`Closes`。
+
+## P0：统一编译诊断事件与报告
+
+**问题**：扫描、生成、转换、注入和 HMR 的日志格式分散，失败时难以定位首次偏离。
+
+**目标**：定义版本化 `CompilationEvent` schema，覆盖 project、compiler、adapter、phase、duration、cache、module/source identity、error 和 evidence 引用；提供 JSONL 与人类可读报告。
+
+**验收**：Vite、Webpack、PostCSS 至少各产出一份事件；事件可关联一次 HMR；敏感路径可脱敏；旧日志行为兼容。
+
+**测试/依赖**：事件 schema 单测、adapter 集成测试；作为性能和 AI Issue 的前置依赖。
+
+## P0：增加分阶段性能基准与 HMR P95/P99 门禁
+
+**问题**：已有整体 benchmark，缺少扫描、生成、AST、注入和 HMR 各阶段指标。
+
+**目标**：输出阶段耗时、缓存命中率、峰值 RSS、增量文件规模，并按框架/平台保存历史基线。
+
+**验收**：CI 能比较基线并报告回归；P95/P99 和内存阈值可配置；冷启动与稳态 watch 分开统计。
+
+**测试/依赖**：复用现有 `benchmark/version-compare`；依赖诊断事件模型。
+
+## P1：统一编译器与 bundler adapter 能力契约
+
+**问题**：adapter 共享内部状态的方式不一致，新增平台容易复制生命周期逻辑。
+
+**目标**：定义 compiler host、source candidate、asset emission、watch update、diagnostic capability 接口；adapter 只实现能力声明和桥接。
+
+**验收**：Vite/Webpack/Rspack/Gulp 通过同一契约测试；缺少能力时给出明确诊断；不新增硬编码目录或后置读文件。
+
+## P1：建立分层缓存可观测性与失效策略
+
+**问题**：缓存命中/淘汰/失效原因不可见，复杂项目难以调优。
+
+**目标**：拆分 source scan、candidate set、Tailwind CSS、PostCSS result 缓存，统一 key fingerprint 和统计接口。
+
+**验收**：报告命中率、淘汰数、失效原因和内存占用；配置变化不会复用错误结果；跨平台路径身份有回归用例。
+
+## P1：自动生成跨框架与多平台支持矩阵
+
+**问题**：支持矩阵、demo、E2E 与文档存在手工同步成本。
+
+**目标**：从 manifest、demo 配置和 E2E 元数据生成矩阵，标注 verified/partial/blocked 与失败归因。
+
+**验收**：新增或移除框架会触发差异检查；矩阵链接到测试和报告；不把跳过误报为通过。
+
+## P1：建立 Issue 到回归证据的追踪链
+
+**问题**：Issue、fixture、单测、E2E 快照和 release note 之间缺少统一 ID。
+
+**目标**：定义轻量 frontmatter/metadata 约定，自动检查 Issue URL、回归路径、基线和发布说明的一致性。
+
+**验收**：缺少回归入口或断链时 CI 失败；支持 partial/superseded；不改变现有关闭型关键词政策。
+
+## P1：模板、demo、文档与公开 skill 影响检查
+
+**问题**：源码能力变化可能漏同步模板、网站和 skill 元数据。
+
+**目标**：根据变更路径生成影响清单，并提供只读检查和明确豁免说明。
+
+**验收**：核心 API、配置、平台支持变化能提示对应同步项；纯文档变更不触发无关构建。
+
+## P2：AI Issue triage 与根因假设助手
+
+**问题**：AI 可以读取规则，但 Issue 信息整理和证据缺口识别仍依赖人工。
+
+**目标**：生成事实/假设/待验证项、最小复现建议、首次偏离探针和回归测试候选；禁止自动修改源码或创建后台任务。
+
+**验收**：在脱敏 fixture 上输出结构化结果；每条假设带证据或明确标记未验证；与现有 workflow/lessons 格式兼容。
+
+## P2：Skill 与 eval 的版本化质量指标
+
+**问题**：已有触发样例，但没有持续衡量触发准确率和误导率。
+
+**目标**：建立按 skill、场景、版本统计的 precision/recall、误导建议率、用户修正率和完成率。
+
+**验收**：`pnpm skills:validate` 检查数据格式；变更 skill 时生成差异报告；失败样例可回放。
+
+## P2：运行时按需加载与体积预算
+
+**问题**：runtime、merge、variants 等包虽有子入口，但缺少统一体积预算和 tree-shaking 验证。
+
+**目标**：为主入口和子入口建立压缩体积、依赖图和重复代码报告。
+
+**验收**：CI 对关键入口设预算；导入子入口不会带入无关模块；跨 ESM/CJS 构建验证通过。
+
+## P2：兼容性策略与弃用周期
+
+**问题**：Tailwind v3/v4、多平台和框架兼容分支持续增长，用户难以判断支持边界。
+
+**目标**：维护 capability matrix、弃用周期、迁移说明和 breaking-change 模板。
+
+**验收**：每个兼容分支有 owner、测试入口和移除条件；发布前检查文档与矩阵一致。
+

--- a/docs/engineering/p0-diagnostics-performance.md
+++ b/docs/engineering/p0-diagnostics-performance.md
@@ -1,0 +1,17 @@
+# P0 诊断事件与性能门禁实现说明
+
+## 事件口径
+
+编译诊断事件使用 schema version 1，阶段限定为 `scan`、`candidate`、`generate`、`postcss`、`emit` 和 `hmr`。事件可携带 revision、operationId、耗时、缓存结果、模块/源码身份、错误和证据引用。旧的 source/bundle/hot-update 事件仍可通过同一个事件总线发送。
+
+`redactCompilationPath` 只保留项目根目录下的相对路径；根目录外只保留 basename，并统一处理 Windows 反斜杠，避免把本机绝对路径写入诊断产物。JSONL 使用逐事件 JSON 序列化，摘要用于 CI 和本地日志首屏展示。
+
+## 性能口径
+
+`summarizeSamples` 对有限数值计算样本数、P50、P95、P99；`evaluatePercentileGuard` 在任一侧样本不足或缺少有限 P95 时返回 `unavailable`，否则按可配置相对阈值判断是否通过。冷启动、预热和稳态样本应由调用方分别收集，避免混合统计。
+
+本次先提供稳定的统计原语和回归测试，后续接入现有 `benchmark/version-compare` 采样器时应复用这些函数，并将阶段数据写入既有 JSON/Markdown artifact。P95/P99 门禁不改变现有 HMR 内存反向复测规则。
+
+## 兼容边界
+
+本次没有修改 bundler 输出路径、源码扫描边界或 Tailwind 生成方式，也没有增加官方 Tailwind 插件。完整的 Vite/Webpack/PostCSS 生命周期事件接入和 CI 阶段 artifact 聚合应在后续提交中沿用上述 schema 与统计口径。

--- a/packages/postcss/src/handler.ts
+++ b/packages/postcss/src/handler.ts
@@ -2,6 +2,7 @@
 import type { Result as PostcssResult, Root } from 'postcss'
 import type { FeatureSignal } from './content-probe'
 import type { IStyleHandlerOptions, StyleHandler } from './types'
+import { performance } from 'node:perf_hooks'
 import { defuOverrideArray } from '@weapp-tailwindcss/shared'
 import { LRUCache } from 'lru-cache'
 import postcss from 'postcss'
@@ -129,16 +130,18 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
 
     const cachedResult = resultCache.get(cacheKey)
     if (cachedResult) {
+      void resolvedOptions.onDiagnostic?.({ phase: 'postcss', durationMs: 0, cache: { hit: true, key: cacheKey } })
       return Promise.resolve(cloneOutput ? cloneResult(cachedResult) : cachedResult)
     }
 
     const processor = processorCache.getProcessor(resolvedOptions, signal)
     const processOptions = processorCache.getProcessOptions(resolvedOptions)
 
+    const startedAt = performance.now()
     return processor.process(
       processInput,
       processOptions,
-    ).async().then((result) => {
+    ).async().then(async (result) => {
       const styleBranch = resolvePostcssFrameworkProfile(resolvedOptions)
       let finalResult = styleBranch.postprocess(result, resolvedOptions)
       if (resolvedOptions.isMainChunk !== false && finalResult.root) {
@@ -176,7 +179,11 @@ export function createStyleHandler(options?: Partial<IStyleHandlerOptions>): Sty
       }
       // 缓存最终结果
       resultCache.set(cacheKey, finalResult)
+      await resolvedOptions.onDiagnostic?.({ phase: 'postcss', durationMs: performance.now() - startedAt, cache: { hit: false, key: cacheKey } })
       return cloneOutput ? cloneResult(finalResult) : finalResult
+    }).catch(async (error) => {
+      await resolvedOptions.onDiagnostic?.({ phase: 'postcss', durationMs: performance.now() - startedAt, cache: { hit: false, key: cacheKey }, error: { name: error instanceof Error ? error.name : undefined, message: error instanceof Error ? error.message : String(error) } })
+      throw error
     })
   }
 

--- a/packages/postcss/src/types.ts
+++ b/packages/postcss/src/types.ts
@@ -186,6 +186,13 @@ export interface CssOptions {
 }
 
 export type IStyleHandlerOptions = {
+  /** 编译诊断回调；由上层 bundler 注入，保持 PostCSS 包与 compiler 解耦。 */
+  onDiagnostic?: (event: {
+    phase: 'postcss'
+    durationMs: number
+    cache?: { hit: boolean, key?: string }
+    error?: { name?: string, message: string }
+  }) => void | Promise<void>
   appType?: PostcssAppType | undefined
   ctx?: PostcssContext | undefined
   /**

--- a/packages/weapp-tailwindcss/src/bundlers/gulp/shared/create-native-framework-plugins.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/gulp/shared/create-native-framework-plugins.ts
@@ -8,6 +8,7 @@ import { hasTailwindRootDirectives, normalizeTailwindConfigDirectives, normalize
 import { createSourceCandidateCollector } from '@/bundlers/shared/source-candidates'
 import { resolveSourceScanEntries } from '@/bundlers/shared/source-scan'
 import { beginCompilerShadowRun as beginShadowRun, createCompilationDependencyChanges, createRuntimeCompilationBuildState, disposeCompilerOwner, finalizeCompilerShadowRun, getCompilationScopeDependencyRevision, getCompilerShadowRunSnapshot, invalidateCompilationScope, recordCompilationDependencyChanges, removeRuntimeCompilationBuildStateFiles, updateRuntimeCompilationBuildState } from '@/compiler'
+import { COMPILATION_EVENT_SCHEMA_VERSION } from '@/compiler/events'
 import { createCompilerRuntimeState } from '@/compiler/runtime-state'
 import { getCompilerContext } from '@/context'
 import { normalizeStyleHandlerMajorVersion } from '@/context/style-options'
@@ -53,6 +54,7 @@ export function createNativeGulpPlugins(options: UserDefinedOptions = {}) {
     readyPromise,
     refreshTailwindcssRuntime,
   })
+  void runtimeState.events.emit({ schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION, type: 'diagnostic', timestamp: new Date().toISOString(), adapter: 'gulp', phase: 'emit', revision: runtimeState.revision, operationId: `gulp-init-${Date.now()}`, evidence: ['createNativeGulpPlugins'] })
   const defaultStyleHandlerOptionsCache = new Map<number | 'unknown', Partial<IStyleHandlerOptions>>()
   let cachedDefaultTemplateHandlerOptions: Partial<ITemplateHandlerOptions> | undefined
   let cachedDefaultTemplateRuntimeSet: Set<string> | undefined

--- a/packages/weapp-tailwindcss/src/bundlers/vite/runtime-class-set.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/runtime-class-set.ts
@@ -130,6 +130,8 @@ export function createViteRuntimeClassSet(options: CreateViteRuntimeClassSetOpti
       transformOnly?: boolean | undefined
     } = {},
   ) {
+    const startedAt = performance.now()
+    const operationId = `vite-bundle-${Date.now()}-${runtimeState.revision}`
     const forceRuntimeRefresh = forceRefresh || process.env['WEAPP_TW_VITE_FORCE_RUNTIME_REFRESH'] === '1'
     const invalidation = resolveRuntimeRefreshOptions()
     const shouldRefreshRuntime = forceRuntimeRefresh || invalidation.changed
@@ -159,6 +161,7 @@ export function createViteRuntimeClassSet(options: CreateViteRuntimeClassSetOpti
           skipInitialFullScanWithBase: options.allowBaselineOnlyInitialSync,
         })
         runtimeSet = nextRuntimeSet
+        await runtimeState.events.emit({ schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION, type: 'diagnostic', timestamp: new Date().toISOString(), adapter: 'vite', phase: 'candidate', revision: runtimeState.revision, operationId, durationMs: performance.now() - startedAt, cache: { hit: !shouldRefreshRuntime }, evidence: ['bundle-runtime-sync'] })
         return nextRuntimeSet
       }
       catch (error) {
@@ -180,6 +183,7 @@ export function createViteRuntimeClassSet(options: CreateViteRuntimeClassSetOpti
 
     try {
       runtimeSet = await task
+      await runtimeState.events.emit({ schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION, type: 'diagnostic', timestamp: new Date().toISOString(), adapter: 'vite', phase: 'candidate', revision: runtimeState.revision, operationId, durationMs: performance.now() - startedAt, cache: { hit: false }, evidence: ['runtime-class-scan'] })
       return runtimeSet
     }
     finally {

--- a/packages/weapp-tailwindcss/src/bundlers/vite/runtime-class-set.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/vite/runtime-class-set.ts
@@ -1,6 +1,7 @@
 import type { BundleSnapshot } from './bundle-state'
 import type { InternalUserDefinedOptions } from '@/types'
 import process from 'node:process'
+import { COMPILATION_EVENT_SCHEMA_VERSION } from '@/compiler/events'
 import { createCompilerRuntimeState } from '@/compiler/runtime-state'
 import {
   collectRuntimeClassSet,
@@ -87,6 +88,8 @@ export function createViteRuntimeClassSet(options: CreateViteRuntimeClassSetOpti
   }
 
   async function ensureRuntimeClassSet(force = false): Promise<Set<string>> {
+    const startedAt = performance.now()
+    const operationId = `vite-runtime-${Date.now()}-${runtimeState.revision}`
     const forceRuntimeRefresh = force || process.env['WEAPP_TW_VITE_FORCE_RUNTIME_REFRESH'] === '1'
     await refreshRuntimeState(force)
     await runtimeState.readyPromise
@@ -94,8 +97,8 @@ export function createViteRuntimeClassSet(options: CreateViteRuntimeClassSetOpti
       return runtimeSet
     }
 
+    const invalidation = resolveRuntimeRefreshOptions()
     if (forceRuntimeRefresh || !runtimeSetPromise) {
-      const invalidation = resolveRuntimeRefreshOptions()
       const task = collectRuntimeClassSet(runtimeState.tailwindRuntime, {
         force: forceRuntimeRefresh || invalidation.changed,
         skipRefresh: forceRuntimeRefresh,
@@ -107,6 +110,7 @@ export function createViteRuntimeClassSet(options: CreateViteRuntimeClassSetOpti
     const task = runtimeSetPromise!
     try {
       runtimeSet = await task
+      await runtimeState.events.emit({ schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION, type: 'diagnostic', timestamp: new Date().toISOString(), adapter: 'vite', phase: 'candidate', revision: runtimeState.revision, operationId, durationMs: performance.now() - startedAt, cache: { hit: !forceRuntimeRefresh && !invalidation.changed } })
       return runtimeSet
     }
     finally {

--- a/packages/weapp-tailwindcss/src/bundlers/webpack/shared/create-framework-plugin/plugin.ts
+++ b/packages/weapp-tailwindcss/src/bundlers/webpack/shared/create-framework-plugin/plugin.ts
@@ -7,6 +7,7 @@ import type { WebpackStyleInjectorDelegateFactory } from '@/style-injector/inter
 import type { AppType, IBaseWebpackPlugin, InternalUserDefinedOptions, UserDefinedOptions } from '@/types'
 import path from 'node:path'
 import process from 'node:process'
+import { COMPILATION_EVENT_SCHEMA_VERSION } from '@/compiler/events'
 import { createCompilerRuntimeState } from '@/compiler/runtime-state'
 import { pluginName } from '@/constants'
 import { getCompilerContext } from '@/context'
@@ -101,6 +102,7 @@ export class WebpackFrameworkPlugin implements IBaseWebpackPlugin {
       readyPromise,
       refreshTailwindcssRuntime: refreshTailwindRuntime,
     })
+    void runtimeState.events.emit({ schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION, type: 'diagnostic', timestamp: new Date().toISOString(), adapter: 'webpack', phase: 'hmr', revision: runtimeState.revision, operationId: `webpack-init-${Date.now()}`, evidence: ['compiler.apply'] })
 
     let runtimeSetPrepared = false
     let runtimeSetSignature: string | undefined

--- a/packages/weapp-tailwindcss/src/compiler/events.ts
+++ b/packages/weapp-tailwindcss/src/compiler/events.ts
@@ -44,6 +44,26 @@ export interface CompilationEventBus {
   clear: () => void
 }
 
+export interface CompilationEventReporter {
+  readonly events: readonly CompilationEvent[]
+  collect: CompilationEventListener
+  toJSONL: () => string
+  summarize: () => string
+  clear: () => void
+}
+
+/** 创建轻量事件收集器，可同时用于本地诊断和 CI JSONL 输出。 */
+export function createCompilationEventReporter(): CompilationEventReporter {
+  const events: CompilationEvent[] = []
+  return {
+    get events() { return events },
+    collect(event) { events.push(event) },
+    toJSONL() { return events.map(serializeCompilationEvent).join('\n') },
+    summarize() { return summarizeCompilationEvents(events) },
+    clear() { events.length = 0 },
+  }
+}
+
 export function redactCompilationPath(value: string, root = process.cwd()): string {
   const normalized = value.replaceAll('\\', path.sep)
   const relative = path.relative(root, normalized)

--- a/packages/weapp-tailwindcss/src/compiler/events.ts
+++ b/packages/weapp-tailwindcss/src/compiler/events.ts
@@ -1,15 +1,39 @@
+import path from 'node:path'
+import process from 'node:process'
+
+export const COMPILATION_EVENT_SCHEMA_VERSION = 1
+
+export interface CompilationDiagnosticEvent {
+  schemaVersion: typeof COMPILATION_EVENT_SCHEMA_VERSION
+  type: 'diagnostic'
+  timestamp: string
+  projectId?: string
+  compilerId?: string
+  adapter?: string
+  phase: 'scan' | 'candidate' | 'generate' | 'postcss' | 'emit' | 'hmr'
+  revision?: number
+  operationId?: string
+  durationMs?: number
+  cache?: { hit: boolean, key?: string, reason?: string }
+  moduleId?: string
+  sourceId?: string
+  error?: { name?: string, message: string, stack?: string }
+  evidence?: string[]
+}
+
 export type CompilationEvent
-  = | {
-    type: 'source-updated'
-    id: string
-    source: string
-    sourceKind?: 'css' | 'template' | 'script' | 'config' | 'asset'
-  }
-  | { type: 'source-removed', id: string }
-  | { type: 'css-entry', id: string, source: string }
-  | { type: 'bundle-emitted', file: string, artifact?: unknown }
-  | { type: 'hot-update', id: string, mutation: 'template' | 'script' | 'style' | 'content' | 'subpackage' | 'root-style' }
-  | { type: 'config-changed', id?: string }
+  = | CompilationDiagnosticEvent
+    | {
+      type: 'source-updated'
+      id: string
+      source: string
+      sourceKind?: 'css' | 'template' | 'script' | 'config' | 'asset'
+    }
+    | { type: 'source-removed', id: string }
+    | { type: 'css-entry', id: string, source: string }
+    | { type: 'bundle-emitted', file: string, artifact?: unknown }
+    | { type: 'hot-update', id: string, mutation: 'template' | 'script' | 'style' | 'content' | 'subpackage' | 'root-style' }
+    | { type: 'config-changed', id?: string }
 
 export type CompilationEventListener = (event: CompilationEvent) => void | Promise<void>
 
@@ -18,6 +42,27 @@ export interface CompilationEventBus {
   emit: (event: CompilationEvent) => Promise<number>
   subscribe: (listener: CompilationEventListener) => () => void
   clear: () => void
+}
+
+export function redactCompilationPath(value: string, root = process.cwd()): string {
+  const normalized = value.replaceAll('\\', path.sep)
+  const relative = path.relative(root, normalized)
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+    return relative
+  }
+  return path.basename(normalized)
+}
+
+export function serializeCompilationEvent(event: CompilationEvent): string {
+  return JSON.stringify(event)
+}
+
+export function summarizeCompilationEvents(events: readonly CompilationEvent[]): string {
+  const diagnostics = events.filter((event): event is CompilationDiagnosticEvent => event.type === 'diagnostic')
+  const failures = diagnostics.filter(event => event.error)
+  const duration = diagnostics.reduce((sum, event) => sum + (event.durationMs ?? 0), 0)
+  const cacheHits = diagnostics.filter(event => event.cache?.hit).length
+  return `事件 ${events.length} 条，诊断 ${diagnostics.length} 条，失败 ${failures.length} 条，总耗时 ${duration.toFixed(2)}ms，缓存命中 ${cacheHits} 条`
 }
 
 /** 创建跨 bundler 共用的生命周期事件总线。 */

--- a/packages/weapp-tailwindcss/src/compiler/runtime-state.ts
+++ b/packages/weapp-tailwindcss/src/compiler/runtime-state.ts
@@ -1,4 +1,4 @@
-import type { CompilationEventBus } from './events'
+import type { CompilationEventBus, CompilationEventListener } from './events'
 import type { RefreshTailwindcssRuntimeOptions, TailwindcssRuntimeLike } from '@/types'
 import { createCompilationEventBus } from './events'
 
@@ -17,11 +17,15 @@ export interface CreateCompilerRuntimeStateOptions {
   readyPromise?: Promise<void>
   refreshTailwindcssRuntime: (options?: RefreshTailwindcssRuntimeOptions) => Promise<TailwindcssRuntimeLike>
   events?: CompilationEventBus
+  reporter?: CompilationEventListener
 }
 
 /** 创建构建器无关的 runtime state，并保留旧字段供现有插件继续使用。 */
 export function createCompilerRuntimeState(options: CreateCompilerRuntimeStateOptions): CompilerRuntimeState {
   const events = options.events ?? createCompilationEventBus()
+  if (options.reporter) {
+    events.subscribe(options.reporter)
+  }
   return {
     tailwindRuntime: options.tailwindRuntime,
     readyPromise: options.readyPromise ?? Promise.resolve(),

--- a/packages/weapp-tailwindcss/src/core.ts
+++ b/packages/weapp-tailwindcss/src/core.ts
@@ -1,8 +1,11 @@
+import type { CompilationDiagnosticEvent } from './compiler/events'
 import type { CreateJsHandlerOptions, IStyleHandlerOptions, ITemplateHandlerOptions, UserDefinedOptions } from './types'
+import { performance } from 'node:perf_hooks'
 import { defuOverrideArray } from '@weapp-tailwindcss/shared'
 import { getCompilerContext } from '@/context'
 import { shouldSkipJsTransform } from '@/js/precheck'
 import { createTailwindRuntimeReadyPromise, ensureRuntimeClassSet } from '@/tailwindcss/runtime'
+import { COMPILATION_EVENT_SCHEMA_VERSION } from './compiler/events'
 import { createCompilerRuntimeState } from './compiler/runtime-state'
 
 export { createCompilationEventBus, createCompilerRuntimeState } from './compiler'
@@ -79,6 +82,26 @@ export function createContext(options: UserDefinedOptions = {}) {
     refreshTailwindcssRuntime,
   })
   const defaultJsHandlerOptionsCache = new Map<number, CreateJsHandlerOptions>()
+  const diagnosticEvents: CompilationDiagnosticEvent[] = []
+  runtimeState.events.subscribe((event) => {
+    if (event.type === 'diagnostic') {
+      diagnosticEvents.push(event)
+    }
+  })
+
+  async function emitDiagnostic(phase: CompilationDiagnosticEvent['phase'], startedAt: number, operationId: string, error?: unknown) {
+    await runtimeState.events.emit({
+      schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION,
+      type: 'diagnostic',
+      timestamp: new Date().toISOString(),
+      compilerId: 'weapp-tailwindcss',
+      phase,
+      revision: runtimeState.revision,
+      operationId,
+      durationMs: performance.now() - startedAt,
+      error: error ? { name: error instanceof Error ? error.name : undefined, message: error instanceof Error ? error.message : String(error) } : undefined,
+    })
+  }
 
   function getDefaultJsHandlerOptions(majorVersion = runtimeState.tailwindRuntime.majorVersion) {
     if (typeof majorVersion !== 'number') {
@@ -207,9 +230,18 @@ export function createContext(options: UserDefinedOptions = {}) {
 
   async function transformWxss(rawCss: string, options?: Partial<IStyleHandlerOptions>) {
     await runtimeState.readyPromise
-    const result = await styleHandler(rawCss, resolveTransformWxssOptions(options))
-    runtimeSet = await ensureRuntimeClassSet(runtimeState)
-    return result
+    const startedAt = performance.now()
+    const operationId = `css-${Date.now()}-${runtimeState.revision}`
+    try {
+      const result = await styleHandler(rawCss, resolveTransformWxssOptions(options))
+      runtimeSet = await ensureRuntimeClassSet(runtimeState)
+      await emitDiagnostic('postcss', startedAt, operationId)
+      return result
+    }
+    catch (error) {
+      await emitDiagnostic('postcss', startedAt, operationId, error)
+      throw error
+    }
   }
 
   async function getRuntimeSet(options?: GetRuntimeSetOptions) {
@@ -232,7 +264,17 @@ export function createContext(options: UserDefinedOptions = {}) {
     if (shouldSkipJsTransform(rawJs, resolvedOptions)) {
       return { code: rawJs }
     }
-    return await jsHandler(rawJs, runtimeSet, resolvedOptions)
+    const startedAt = performance.now()
+    const operationId = `js-${Date.now()}-${runtimeState.revision}`
+    try {
+      const result = await jsHandler(rawJs, runtimeSet, resolvedOptions)
+      await emitDiagnostic('candidate', startedAt, operationId)
+      return result
+    }
+    catch (error) {
+      await emitDiagnostic('candidate', startedAt, operationId, error)
+      throw error
+    }
   }
 
   async function transformWxml(rawWxml: string, options?: ITemplateHandlerOptions) {
@@ -242,7 +284,17 @@ export function createContext(options: UserDefinedOptions = {}) {
         forceCollect: true,
       })
     }
-    return templateHandler(rawWxml, resolveTransformWxmlOptions(options))
+    const startedAt = performance.now()
+    const operationId = `template-${Date.now()}-${runtimeState.revision}`
+    try {
+      const result = templateHandler(rawWxml, resolveTransformWxmlOptions(options))
+      await emitDiagnostic('scan', startedAt, operationId)
+      return result
+    }
+    catch (error) {
+      await emitDiagnostic('scan', startedAt, operationId, error)
+      throw error
+    }
   }
 
   return {
@@ -250,5 +302,7 @@ export function createContext(options: UserDefinedOptions = {}) {
     transformWxss,
     transformWxml,
     transformJs,
+    events: runtimeState.events,
+    getDiagnosticEvents: () => diagnosticEvents.slice(),
   }
 }

--- a/packages/weapp-tailwindcss/test/compiler/events-diagnostic.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/events-diagnostic.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPILATION_EVENT_SCHEMA_VERSION,
+  createCompilationEventBus,
+  redactCompilationPath,
+  serializeCompilationEvent,
+  summarizeCompilationEvents,
+} from '../../src/compiler/events'
+
+describe('编译诊断事件', () => {
+  it('保留旧事件总线并按顺序递增 revision', async () => {
+    const bus = createCompilationEventBus()
+    const revisions: number[] = []
+    bus.subscribe(async (event) => {
+      if (event.type === 'diagnostic') revisions.push(bus.revision)
+    })
+    await bus.emit({ schemaVersion: COMPILATION_EVENT_SCHEMA_VERSION, type: 'diagnostic', timestamp: new Date(0).toISOString(), phase: 'scan', durationMs: 2, cache: { hit: true } })
+    expect(revisions).toEqual([1])
+    expect(bus.revision).toBe(1)
+  })
+
+  it('序列化并生成摘要', () => {
+    const event = { schemaVersion: 1 as const, type: 'diagnostic' as const, timestamp: new Date(0).toISOString(), phase: 'generate' as const, durationMs: 4, cache: { hit: false }, error: { message: 'failed' } }
+    expect(JSON.parse(serializeCompilationEvent(event))).toMatchObject({ phase: 'generate' })
+    expect(summarizeCompilationEvents([event])).toContain('失败 1 条')
+  })
+
+  it('脱敏绝对路径并支持 Windows 分隔符', () => {
+    expect(redactCompilationPath('/workspace/project/src/app.ts', '/workspace/project')).toBe('src/app.ts')
+    expect(redactCompilationPath('C:\\work\\project\\src\\app.ts', 'C:\\work\\project')).toContain('app.ts')
+  })
+})

--- a/packages/weapp-tailwindcss/test/compiler/events-diagnostic.test.ts
+++ b/packages/weapp-tailwindcss/test/compiler/events-diagnostic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   COMPILATION_EVENT_SCHEMA_VERSION,
   createCompilationEventBus,
+  createCompilationEventReporter,
   redactCompilationPath,
   serializeCompilationEvent,
   summarizeCompilationEvents,
@@ -23,6 +24,16 @@ describe('编译诊断事件', () => {
     const event = { schemaVersion: 1 as const, type: 'diagnostic' as const, timestamp: new Date(0).toISOString(), phase: 'generate' as const, durationMs: 4, cache: { hit: false }, error: { message: 'failed' } }
     expect(JSON.parse(serializeCompilationEvent(event))).toMatchObject({ phase: 'generate' })
     expect(summarizeCompilationEvents([event])).toContain('失败 1 条')
+  })
+
+  it('收集器输出 JSONL 与摘要', async () => {
+    const reporter = createCompilationEventReporter()
+    await reporter.collect({ schemaVersion: 1, type: 'diagnostic', timestamp: new Date(0).toISOString(), phase: 'emit', durationMs: 1, cache: { hit: true } })
+    expect(reporter.events).toHaveLength(1)
+    expect(reporter.toJSONL().split('\n')).toHaveLength(1)
+    expect(reporter.summarize()).toContain('缓存命中 1 条')
+    reporter.clear()
+    expect(reporter.events).toHaveLength(0)
   })
 
   it('脱敏绝对路径并支持 Windows 分隔符', () => {


### PR DESCRIPTION
## 背景

P0 需求需要统一编译诊断事件，并为性能基准提供可靠的 P95/P99 统计与门禁基础。

## 本次变更

- 新增版本化 `CompilationDiagnosticEvent`，覆盖扫描、候选、生成、PostCSS、产物和 HMR 阶段。
- 保留现有 `CompilationEventBus` 兼容行为。
- 增加跨平台路径脱敏、JSONL 序列化和人类可读摘要。
- 增加 P50/P95/P99 样本统计与可配置阈值判断，明确样本不足时的 `unavailable` 状态。
- 补充 compiler、benchmark 回归测试和中文实现说明。

## 验证

- `pnpm --filter weapp-tailwindcss exec vitest run test/compiler/events-diagnostic.test.ts test/compiler/protocol.test.ts --update=none`
- `pnpm exec vitest run benchmark/version-compare/test/percentiles.test.mjs --update=none`
- `pnpm --filter weapp-tailwindcss build`
- `pnpm agents:check`
- `git diff --check`

## 后续工作

完整的 Vite/Webpack/PostCSS 生命周期事件接入、CI 阶段 artifact 聚合和现有 benchmark 采样器改造将在后续提交中沿用本 PR 的 schema 与统计口径。

Related to #1178
Related to #1179
